### PR TITLE
Add PWA app badge for unread notification count

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -21,18 +21,36 @@ self.addEventListener("push", (event) => {
   const { title = "down to", body = "", type, relatedId } = data;
 
   event.waitUntil(
-    self.registration.showNotification(title, {
-      body,
-      icon: "/icons/icon-192.png",
-      badge: "/icons/icon-192.png",
-      tag: type ? `${type}-${relatedId || "default"}` : undefined,
-      data: { type, relatedId },
-    })
+    Promise.all([
+      self.registration.showNotification(title, {
+        body,
+        icon: "/icons/icon-192.png",
+        badge: "/icons/icon-192.png",
+        tag: type ? `${type}-${relatedId || "default"}` : undefined,
+        data: { type, relatedId },
+      }),
+      // Increment PWA app icon badge
+      self.registration.getNotifications().then((notifs) => {
+        // Count visible notifications as a proxy for unread count
+        if (navigator.setAppBadge) {
+          navigator.setAppBadge(notifs.length + 1);
+        }
+      }),
+    ])
   );
 });
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
+
+  // Update app badge: decrement or clear
+  self.registration.getNotifications().then((notifs) => {
+    if (navigator.setAppBadge && notifs.length > 0) {
+      navigator.setAppBadge(notifs.length);
+    } else if (navigator.clearAppBadge) {
+      navigator.clearAppBadge();
+    }
+  });
 
   const { type, relatedId } = event.notification.data || {};
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -60,6 +60,16 @@ export function useNotifications({ userId, isDemoMode, onUnreadSquadIds }: UseNo
     loadNotificationsRef.current();
   }, [isDemoMode, userId]);
 
+  // Sync unread count to PWA app badge
+  useEffect(() => {
+    if (!("setAppBadge" in navigator)) return;
+    if (unreadCount > 0) {
+      navigator.setAppBadge(unreadCount).catch(() => {});
+    } else {
+      navigator.clearAppBadge().catch(() => {});
+    }
+  }, [unreadCount]);
+
   // Reload notifications on app focus
   useEffect(() => {
     if (isDemoMode || !userId) return;


### PR DESCRIPTION
Syncs unread count to navigator.setAppBadge so installed PWAs show a badge on the app icon. Also updates the badge from the service worker on push/click events when the app is backgrounded.