### PR TITLE
Add version pings to track build adoption on admin dashboard

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,10 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  env: {
+    NEXT_PUBLIC_BUILD_ID:
+      process.env.VERCEL_GIT_COMMIT_SHA ?? new Date().toISOString(),
+  },
   async headers() {
     return [
       {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -31,6 +31,9 @@ interface Metrics {
     stale24h: number;
     recentFailures: PushFailure[];
   };
+  versions: {
+    distribution: { build_id: string; users: number; pings24h: number }[];
+  };
 }
 
 export default function AdminPage() {
@@ -249,6 +252,49 @@ export default function AdminPage() {
             </table>
           </div>
         </>
+      )}
+
+      {/* Version distribution */}
+      <h2 style={{ ...sectionHeader, marginTop: 40 }}>Versions (7d)</h2>
+
+      {metrics.versions.distribution.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontFamily: font.mono, fontSize: 12 }}>
+            <thead>
+              <tr>
+                {["Build ID", "Users", "Pings (24h)"].map((h) => (
+                  <th
+                    key={h}
+                    style={{
+                      textAlign: "left",
+                      padding: "8px 12px",
+                      color: color.dim,
+                      borderBottom: `1px solid ${color.borderLight}`,
+                      fontWeight: 400,
+                    }}
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {metrics.versions.distribution.map((v) => (
+                <tr key={v.build_id}>
+                  <td style={{ ...cellStyle, maxWidth: 200, overflow: "hidden", textOverflow: "ellipsis" }}>
+                    {v.build_id || "—"}
+                  </td>
+                  <td style={cellStyle}>
+                    <span style={{ color: color.accent, fontWeight: 700 }}>{v.users}</span>
+                  </td>
+                  <td style={cellStyle}>
+                    <span style={{ color: color.muted }}>{v.pings24h}</span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
     </div>
   );

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -30,9 +30,10 @@ export async function GET(request: NextRequest) {
   const admin = getServiceClient();
 
   const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const since7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
 
   // Run queries in parallel
-  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures] = await Promise.all([
+  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes] = await Promise.all([
     admin.from('profiles').select('*', { count: 'exact', head: true }),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', true),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', false),
@@ -52,6 +53,10 @@ export async function GET(request: NextRequest) {
       .neq('status', 'sent')
       .order('created_at', { ascending: false })
       .limit(20),
+    admin.from('version_pings')
+      .select('user_id, build_id, created_at')
+      .gte('created_at', since7d)
+      .order('created_at', { ascending: false }),
   ]);
 
   // Group signups by date
@@ -62,6 +67,27 @@ export async function GET(request: NextRequest) {
       signupsByDate[date] = (signupsByDate[date] || 0) + 1;
     }
   }
+
+  // Version distribution: latest ping per user + pings per build in last 24h
+  const latestByUser = new Map<string, string>(); // user_id → build_id
+  const pingsPerBuild = new Map<string, number>(); // build_id → 24h ping count
+  if (versionPingsRes.data) {
+    for (const row of versionPingsRes.data) {
+      if (!latestByUser.has(row.user_id)) {
+        latestByUser.set(row.user_id, row.build_id);
+      }
+      if (row.created_at >= since24h) {
+        pingsPerBuild.set(row.build_id, (pingsPerBuild.get(row.build_id) || 0) + 1);
+      }
+    }
+  }
+  const buildCounts = new Map<string, number>();
+  for (const buildId of latestByUser.values()) {
+    buildCounts.set(buildId, (buildCounts.get(buildId) || 0) + 1);
+  }
+  const versionDistribution = Array.from(buildCounts.entries())
+    .map(([build_id, users]) => ({ build_id, users, pings24h: pingsPerBuild.get(build_id) || 0 }))
+    .sort((a, b) => b.users - a.users);
 
   return NextResponse.json({
     totalUsers: totalRes.count ?? 0,
@@ -74,6 +100,9 @@ export async function GET(request: NextRequest) {
       failed24h: pushFailedRes.count ?? 0,
       stale24h: pushStaleRes.count ?? 0,
       recentFailures: pushRecentFailures.data ?? [],
+    },
+    versions: {
+      distribution: versionDistribution,
     },
   });
 }

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+  return Response.json({ buildId: process.env.NEXT_PUBLIC_BUILD_ID });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Instrument_Serif, Space_Mono } from "next/font/google";
 import DevProdBanner from "@/components/DevProdBanner";
+import UpdateBanner from "@/components/UpdateBanner";
 import Grain from "@/components/Grain";
 
 import "./global.css";
@@ -67,6 +68,7 @@ export default function RootLayout({
       <body>
         <Grain />
         <DevProdBanner />
+        <UpdateBanner />
         <div className="container">{children}</div>
       </body>
     </html>

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { font, color } from "@/lib/styles";
+import { logVersionPing } from "@/lib/db";
+
+const CLIENT_BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? "";
+const MIN_BACKGROUND_MS = 5 * 60 * 1000; // 5 minutes
+
+export default function UpdateBanner() {
+  const [show, setShow] = useState(false);
+  const backgroundSince = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (CLIENT_BUILD_ID) logVersionPing(CLIENT_BUILD_ID);
+  }, []);
+
+  useEffect(() => {
+    function onVisibilityChange() {
+      if (document.hidden) {
+        backgroundSince.current = Date.now();
+        return;
+      }
+
+      // Returning to foreground
+      const since = backgroundSince.current;
+      backgroundSince.current = null;
+      if (!since || Date.now() - since < MIN_BACKGROUND_MS) return;
+
+      fetch("/api/version")
+        .then((r) => r.json())
+        .then(({ buildId }) => {
+          if (buildId && buildId !== CLIENT_BUILD_ID) setShow(true);
+        })
+        .catch(() => {});
+    }
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 70,
+        left: 0,
+        right: 0,
+        zIndex: 9998,
+        display: "flex",
+        justifyContent: "center",
+        pointerEvents: "none",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          background: color.surface,
+          border: `1px solid ${color.borderMid}`,
+          borderRadius: 12,
+          padding: "10px 14px",
+          pointerEvents: "auto",
+        }}
+      >
+        <span
+          onClick={() => window.location.reload()}
+          style={{
+            fontFamily: font.mono,
+            fontSize: 12,
+            color: color.accent,
+            cursor: "pointer",
+          }}
+        >
+          Update available &middot; tap to refresh
+        </span>
+        <span
+          onClick={() => setShow(false)}
+          style={{
+            fontFamily: font.mono,
+            fontSize: 14,
+            color: color.dim,
+            cursor: "pointer",
+            padding: "0 2px",
+          }}
+        >
+          &times;
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -81,6 +81,14 @@ export async function getFriendshipWith(userId: string): Promise<{ id: string; s
   return { id: data.id, status: data.status, isRequester: data.requester_id === user.id };
 }
 
+export async function logVersionPing(buildId: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return;
+  await supabase
+    .from("version_pings")
+    .insert({ user_id: user.id, build_id: buildId });
+}
+
 // ============================================================================
 // EVENTS
 // ============================================================================

--- a/supabase/migrations/20260302000002_version_pings.sql
+++ b/supabase/migrations/20260302000002_version_pings.sql
@@ -1,0 +1,20 @@
+-- Version pings: track which build each user is running
+CREATE TABLE IF NOT EXISTS public.version_pings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  build_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_version_pings_user ON public.version_pings(user_id);
+CREATE INDEX idx_version_pings_build ON public.version_pings(build_id);
+
+ALTER TABLE public.version_pings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can insert own pings"
+  ON public.version_pings FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can read own pings"
+  ON public.version_pings FOR SELECT
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
Logs a version ping on every app load via UpdateBanner. New version_pings table with RLS. Admin dashboard shows per-build user count and 24h ping volume.