### PR TITLE
ci: fix npm run build step of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: http://placeholder.invalid
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
was getting this error here: https://github.com/xylene-p/downto/actions/runs/22829675848/job/66215715701?pr=69

> downto@1.0.0 build                                                                                                                  
> next build                                                                                                                          
                                                                                                                                      
fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.                                                 
Use '--' to separate paths from revisions, like this:                                                                                 
'git <command> [<revision>...] -- [<file>...]'                                                                                        
⚠ No build cache found. Please configure build caching for faster rebuilds. Read more: https://nextjs.org/docs/messages/no-cache      
Attention: Next.js now collects completely anonymous telemetry regarding usage.                                                       
This information is used to shape Next.js' roadmap and prioritize features.                                                           
You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following    
URL:                                                                                                                                  
https://nextjs.org/telemetry                                                                                                          
                                                                                                                                      
▲ Next.js 16.1.6 (Turbopack)                                                                                                          
- Experiments (use with caution):                                                                                                     
  · clientTraceMetadata                                                                                                               
                                                                                                                                      
  Creating an optimized production build ...                                                                                          
fatal: ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.                                                 
Use '--' to separate paths from revisions, like this:                                                                                 
'git <command> [<revision>...] -- [<file>...]'                                                                                        
✓ Compiled successfully in 6.1s                                                                                                       
  Running next.config.js provided runAfterProductionCompile ...                                                                       
✓ Completed runAfterProductionCompile in 289ms                                                                                        
  Skipping validation of types                                                                                                        
  Collecting page data using 3 workers ...                                                                                            
  Generating static pages using 3 workers (0/21) ...                                                                                  
Error occurred prerendering page "/auth/verify-otp". Read more: https://nextjs.org/docs/messages/prerender-error                      
Error: supabaseUrl is required.                                                                                                       
    at <unknown> (.next/server/chunks/ssr/src_lib_supabase_ts_187e04b9._.js:37:43440)                                                 
    at new cd (.next/server/chunks/ssr/src_lib_supabase_ts_187e04b9._.js:37:43691)                                                    
    at module evaluation (.next/server/chunks/ssr/src_lib_supabase_ts_187e04b9._.js:37:48029)                                         
    at instantiateModule (.next/server/chunks/ssr/[turbopack]_runtime.js:740:9)                                                       
    at getOrInstantiateModuleFromParent (.next/server/chunks/ssr/[turbopack]_runtime.js:763:12)                                       
    at Context.esmImport [as i] (.next/server/chunks/ssr/[turbopack]_runtime.js:228:20)                                               
    at module evaluation (.next/server/chunks/ssr/src_35f2da70._.js:1:54)                                                             
    at instantiateModule (.next/server/chunks/ssr/[turbopack]_runtime.js:740:9)                                                       
    at getOrInstantiateModuleFromParent (.next/server/chunks/ssr/[turbopack]_runtime.js:763:12)                                       
    at Context.esmImport [as i] (.next/server/chunks/ssr/[turbopack]_runtime.js:228:20) {                                             
  digest: '1194331917'                                                                                                                
}                                                                                                                                     
Export encountered an error on /(public)/auth/verify-otp/page: /auth/verify-otp, exiting the build.                                   
⨯ Next.js build worker exited with code: 1 and signal: null                                                                           
Error: Process completed with exit code 1.