### PR TITLE
Add check archive/delete via gear icon bottom sheet

### DIFF
--- a/src/components/events/CheckActionsSheet.tsx
+++ b/src/components/events/CheckActionsSheet.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { font, color } from "@/lib/styles";
+
+export default function CheckActionsSheet({
+  open,
+  onClose,
+  onEdit,
+  onArchive,
+  onDelete,
+  hasSquad,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  onArchive: () => void;
+  onDelete: () => void;
+  hasSquad: boolean;
+}) {
+  const touchStartY = useRef(0);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [closing, setClosing] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const isDragging = useRef(false);
+
+  useEffect(() => {
+    if (!open) {
+      setConfirmDelete(false);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  const dismiss = () => {
+    setClosing(true);
+    setTimeout(() => { setClosing(false); setDragOffset(0); onClose(); }, 250);
+  };
+
+  const finishSwipe = () => {
+    if (dragOffset > 60) {
+      dismiss();
+    } else {
+      setDragOffset(0);
+    }
+    isDragging.current = false;
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+    isDragging.current = false;
+  };
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
+  };
+  const handleTouchEnd = () => { if (isDragging.current) finishSwipe(); };
+
+  if (!open) return null;
+
+  const actionRow = (label: string, icon: string, onClick: () => void, destructive?: boolean) => (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        width: "100%",
+        padding: "14px 0",
+        background: "transparent",
+        border: "none",
+        borderBottom: `1px solid ${color.border}`,
+        fontFamily: font.mono,
+        fontSize: 13,
+        color: destructive ? "#ff4444" : color.text,
+        cursor: "pointer",
+        textAlign: "left",
+      }}
+    >
+      <span style={{ fontSize: 16, width: 24, textAlign: "center" }}>{icon}</span>
+      {label}
+    </button>
+  );
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={dismiss}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,0.7)",
+          backdropFilter: "blur(8px)",
+          WebkitBackdropFilter: "blur(8px)",
+          zIndex: 100,
+        }}
+      />
+
+      {/* Panel */}
+      <div
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: color.surface,
+          borderRadius: "24px 24px 0 0",
+          maxWidth: 420,
+          margin: "0 auto",
+          zIndex: 101,
+          animation: closing ? undefined : "slideUp 0.3s ease-out",
+          transform: closing ? "translateY(100%)" : dragOffset > 0 ? `translateY(${dragOffset}px)` : undefined,
+          transition: closing ? "transform 0.25s ease-in" : dragOffset > 0 ? undefined : "transform 0.25s ease-out",
+          paddingBottom: "env(safe-area-inset-bottom, 20px)",
+        }}
+      >
+        {/* Drag handle */}
+        <div style={{ display: "flex", justifyContent: "center", padding: "12px 0 8px" }}>
+          <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2 }} />
+        </div>
+
+        <div style={{ padding: "0 20px 20px" }}>
+          <p style={{
+            fontFamily: font.serif,
+            fontSize: 18,
+            color: color.text,
+            margin: "0 0 8px",
+            fontWeight: 400,
+          }}>
+            Check actions
+          </p>
+
+          {actionRow("Edit", "✎", () => { onClose(); onEdit(); })}
+          {actionRow("Archive", "📦", () => { onClose(); onArchive(); })}
+          {!hasSquad && actionRow("Delete", "🗑", () => setConfirmDelete(true), true)}
+        </div>
+      </div>
+
+      {/* Delete confirm dialog */}
+      {confirmDelete && (
+        <div
+          onClick={() => setConfirmDelete(false)}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.7)",
+            zIndex: 9999,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: color.deep,
+              border: `1px solid ${color.border}`,
+              borderRadius: 16,
+              maxWidth: 300,
+              padding: "24px 20px",
+            }}
+          >
+            <p style={{
+              fontFamily: font.serif,
+              fontSize: 18,
+              color: color.text,
+              margin: "0 0 8px",
+              fontWeight: 400,
+            }}>
+              Delete check?
+            </p>
+            <p style={{
+              fontFamily: font.mono,
+              fontSize: 11,
+              color: color.dim,
+              margin: "0 0 16px",
+              lineHeight: 1.5,
+            }}>
+              This will permanently remove the check and all responses. This can&apos;t be undone.
+            </p>
+            <div style={{ display: "flex", gap: 10 }}>
+              <button
+                onClick={() => setConfirmDelete(false)}
+                style={{
+                  flex: 1,
+                  padding: 12,
+                  background: "transparent",
+                  border: `1px solid ${color.borderMid}`,
+                  borderRadius: 12,
+                  color: color.text,
+                  fontFamily: font.mono,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  setConfirmDelete(false);
+                  onClose();
+                  onDelete();
+                }}
+                style={{
+                  flex: 1,
+                  padding: 12,
+                  background: "#ff4444",
+                  border: "none",
+                  borderRadius: 10,
+                  color: "#fff",
+                  fontFamily: font.mono,
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/events/FeedView.tsx
+++ b/src/components/events/FeedView.tsx
@@ -7,6 +7,7 @@ import { font, color } from "@/lib/styles";
 import type { Event, InterestCheck, Friend } from "@/lib/ui-types";
 import EventCard from "@/components/events/EventCard";
 import EditCheckModal from "@/components/events/EditCheckModal";
+import CheckActionsSheet from "@/components/events/CheckActionsSheet";
 import { logError } from "@/lib/logger";
 
 /** Render @mentions highlighted + inline URLs as clickable links */
@@ -147,6 +148,7 @@ export default function FeedView({
   const [showHidden, setShowHidden] = useState(false);
   const [expandedCheckId, setExpandedCheckId] = useState<string | null>(null);
   const [editModalCheck, setEditModalCheck] = useState<InterestCheck | null>(null);
+  const [actionsSheetCheck, setActionsSheetCheck] = useState<InterestCheck | null>(null);
 
   const visibleChecks = checks
     .filter((c) => !hiddenCheckIds.has(c.id) && c.expiresIn !== "expired")
@@ -491,56 +493,27 @@ export default function FeedView({
                                   <Linkify coAuthors={check.coAuthors}>{check.text}</Linkify>
                                 </p>
                                 {(check.isYours || check.isCoAuthor) && (
-                                  <div style={{ display: "flex", gap: 4, flexShrink: 0, marginTop: 2 }}>
-                                    <button
-                                      onClick={(e) => {
-                                        e.stopPropagation();
-                                        setEditModalCheck(check);
-                                      }}
-                                      style={{
-                                        background: "transparent",
-                                        border: `1px solid ${color.border}`,
-                                        borderRadius: 8,
-                                        color: color.dim,
-                                        padding: "6px 10px",
-                                        fontFamily: font.mono,
-                                        fontSize: 13,
-                                        cursor: "pointer",
-                                        lineHeight: 1,
-                                      }}
-                                    >
-                                      &#9998;
-                                    </button>
-                                    {!check.squadId && (
-                                      <button
-                                        onClick={async (e) => {
-                                          e.stopPropagation();
-                                          setChecks((prev) => prev.filter((c) => c.id !== check.id));
-                                          if (!isDemoMode) {
-                                            try {
-                                              await db.deleteInterestCheck(check.id);
-                                            } catch (err) {
-                                              logError("deleteCheck", err, { checkId: check.id });
-                                            }
-                                          }
-                                          showToast("Check removed");
-                                        }}
-                                        style={{
-                                          background: "transparent",
-                                          border: `1px solid ${color.border}`,
-                                          borderRadius: 8,
-                                          color: color.dim,
-                                          padding: "6px 10px",
-                                          fontFamily: font.mono,
-                                          fontSize: 13,
-                                          cursor: "pointer",
-                                          lineHeight: 1,
-                                        }}
-                                      >
-                                        &#10005;
-                                      </button>
-                                    )}
-                                  </div>
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      setActionsSheetCheck(check);
+                                    }}
+                                    style={{
+                                      background: "transparent",
+                                      border: `1px solid ${color.border}`,
+                                      borderRadius: 8,
+                                      color: color.dim,
+                                      padding: "6px 10px",
+                                      fontFamily: font.mono,
+                                      fontSize: 13,
+                                      cursor: "pointer",
+                                      lineHeight: 1,
+                                      flexShrink: 0,
+                                      marginTop: 2,
+                                    }}
+                                  >
+                                    ⚙
+                                  </button>
                                 )}
                               </div>
                               {(check.eventDateLabel || check.eventTime) && (
@@ -1518,6 +1491,44 @@ export default function FeedView({
               </>
             )}
           </div>
+
+      <CheckActionsSheet
+        open={!!actionsSheetCheck}
+        onClose={() => setActionsSheetCheck(null)}
+        hasSquad={!!actionsSheetCheck?.squadId}
+        onEdit={() => {
+          if (actionsSheetCheck) setEditModalCheck(actionsSheetCheck);
+          setActionsSheetCheck(null);
+        }}
+        onArchive={async () => {
+          if (!actionsSheetCheck) return;
+          const checkId = actionsSheetCheck.id;
+          setActionsSheetCheck(null);
+          setChecks((prev) => prev.filter((c) => c.id !== checkId));
+          if (!isDemoMode) {
+            try {
+              await db.archiveInterestCheck(checkId);
+            } catch (err) {
+              logError("archiveCheck", err, { checkId });
+            }
+          }
+          showToast("Check archived");
+        }}
+        onDelete={async () => {
+          if (!actionsSheetCheck) return;
+          const checkId = actionsSheetCheck.id;
+          setActionsSheetCheck(null);
+          setChecks((prev) => prev.filter((c) => c.id !== checkId));
+          if (!isDemoMode) {
+            try {
+              await db.deleteInterestCheck(checkId);
+            } catch (err) {
+              logError("deleteCheck", err, { checkId });
+            }
+          }
+          showToast("Check removed");
+        }}
+      />
 
       <EditCheckModal
         check={editModalCheck}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -584,6 +584,7 @@ export async function getActiveChecks(): Promise<(InterestCheck & { author: Prof
     `)
     .or(`expires_at.gt.${new Date().toISOString()},expires_at.is.null,event_date.gte.${new Date().toISOString().slice(0, 10)}`)
     .or(`event_date.gte.${new Date().toISOString().slice(0, 10)},event_date.is.null`)
+    .is('archived_at', null)
     .order('created_at', { ascending: false });
 
   if (error) throw error;
@@ -648,6 +649,15 @@ export async function deleteInterestCheck(checkId: string): Promise<void> {
     .delete()
     .eq('id', checkId);
   // RLS policy allows author and accepted co-authors
+
+  if (error) throw error;
+}
+
+export async function archiveInterestCheck(checkId: string): Promise<void> {
+  const { error } = await supabase
+    .from('interest_checks')
+    .update({ archived_at: new Date().toISOString() })
+    .eq('id', checkId);
 
   if (error) throw error;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,6 +83,7 @@ export interface InterestCheck {
     thumbnail?: string;
     vibes?: string[];
   } | null;
+  archived_at: string | null;
   created_at: string;
   // Joined data
   author?: Profile;

--- a/supabase/migrations/20260310000001_check_archived_at.sql
+++ b/supabase/migrations/20260310000001_check_archived_at.sql
@@ -1,0 +1,2 @@
+-- Add archived_at column to interest_checks for soft-delete (archive)
+ALTER TABLE interest_checks ADD COLUMN archived_at TIMESTAMPTZ DEFAULT NULL;


### PR DESCRIPTION
Replace pencil+X buttons on checks with a gear icon that opens a bottom sheet with Edit, Archive, and Delete actions. Archive soft-deletes via new archived_at column; archived checks are filtered from the feed.