### PR TITLE
Fix admin page: responsive layout and DAU data

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -159,7 +159,7 @@ export default function AdminPage() {
       {/* Users tab */}
       {tab === "users" && (
         <>
-          <div style={{ display: "flex", gap: 12, marginBottom: 32 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 32 }}>
             <SummaryCard label="DAU Today" value={dauToday} />
             <SummaryCard label="Total Users" value={metrics.totalUsers} />
             <SummaryCard label="Onboarded" value={metrics.onboarded} />
@@ -266,7 +266,7 @@ export default function AdminPage() {
       {tab === "push" && (
         <>
           <h2 style={sectionHeader}>Delivery (24h)</h2>
-          <div style={{ display: "flex", gap: 12, marginBottom: 24 }}>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 24 }}>
             <SummaryCard label="Sent" value={metrics.push.sent24h} />
             <SummaryCard label="Failed" value={metrics.push.failed24h} accent="#ff4444" />
             <SummaryCard label="Stale" value={metrics.push.stale24h} accent={color.muted} />
@@ -435,7 +435,7 @@ function SummaryCard({ label, value, accent: accentOverride }: { label: string; 
   return (
     <div
       style={{
-        flex: 1,
+        flex: "1 1 120px",
         backgroundColor: color.card,
         border: `1px solid ${color.borderLight}`,
         borderRadius: 8,
@@ -453,12 +453,13 @@ function SummaryCard({ label, value, accent: accentOverride }: { label: string; 
 }
 
 const containerStyle: React.CSSProperties = {
-  minHeight: "100dvh",
+  flex: 1,
   backgroundColor: color.bg,
   padding: "24px 16px",
   display: "flex",
   flexDirection: "column",
   maxWidth: 640,
+  width: "100%",
   margin: "0 auto",
   overflowY: "auto",
 };

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -42,10 +42,12 @@ export async function GET(request: NextRequest) {
     admin.from('version_pings')
       .select('user_id, build_id, created_at')
       .gte('created_at', since7d)
-      .order('created_at', { ascending: false }),
+      .order('created_at', { ascending: false })
+      .limit(10000),
     admin.from('version_pings')
       .select('user_id, created_at')
-      .gte('created_at', since30d),
+      .gte('created_at', since30d)
+      .limit(50000),
   ]);
 
   // Compute DAU from version_pings (30 days)


### PR DESCRIPTION
## Summary
- Fix page not scrolling by using `flex: 1` + `overflowY: auto` instead of `minHeight: 100dvh` (works within root layout's `h-dvh` wrapper)
- Add `flexWrap` to summary card rows so they stack on narrow screens
- Bump `version_pings` query limits from default 1000 to 50k — the default was silently truncating DAU data, causing 0s

## Test plan
- [ ] Admin page scrolls on mobile
- [ ] DAU chart shows data
- [ ] Recent signups table is visible below the charts
- [ ] Summary cards wrap on narrow screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)