### PR TITLE
fix: prevent pinch-to-zoom in squad chat

### DIFF
--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -134,6 +134,15 @@ const SquadChat = ({
     return () => { onChatOpen?.(false); };
   }, [onChatOpen]);
 
+  // Prevent pinch-to-zoom in PWA
+  useEffect(() => {
+    const prevent = (e: TouchEvent) => {
+      if (e.touches.length > 1) e.preventDefault();
+    };
+    document.addEventListener("touchstart", prevent, { passive: false });
+    return () => document.removeEventListener("touchstart", prevent);
+  }, []);
+
   // Slide in from right on mount
   useEffect(() => {
     requestAnimationFrame(() => {


### PR DESCRIPTION
## Summary
- Prevents multi-touch pinch-to-zoom gesture in squad chat on iOS PWA
- Uses `touchstart` event listener that calls `preventDefault()` when more than 1 touch is detected

## Test plan
- [ ] Open squad chat in iOS PWA
- [ ] Try pinch-to-zoom — should be blocked
- [ ] Verify single-finger scroll and swipe-to-dismiss still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)