### PR TITLE
refactor: decompose SquadChat further and migrate squad components to Tailwind

### DIFF
--- a/src/features/squads/components/ChatHeader.tsx
+++ b/src/features/squads/components/ChatHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import type { Squad } from "@/lib/ui-types";
 
 const formatExpiryShort = (expiresAt?: string): string | null => {
@@ -63,76 +63,33 @@ export default function ChatHeader({
     (squad.expiresAt && new Date(squad.expiresAt).getTime() - Date.now() < 24 * 60 * 60 * 1000);
 
   return (
-    <div
-      style={{
-        padding: "0 20px 12px",
-        borderBottom: `1px solid ${color.border}`,
-        position: "relative",
-        zIndex: hasOpenModal ? 10000 : "auto",
-        background: color.bg,
-        flexShrink: 0,
-      }}
-    >
-      <div
-        style={{ display: "flex", alignItems: "center", justifyContent: "space-between", cursor: "pointer" }}
-      >
+    <div className={`px-5 pb-3 border-b border-neutral-900 relative bg-neutral-950 shrink-0 ${hasOpenModal ? "z-10000" : "z-auto"}`}>
+      <div className="flex items-center justify-between cursor-pointer">
         <button
           onClick={(e) => { e.stopPropagation(); onBack(); }}
-          style={{
-            background: "none",
-            border: "none",
-            color: color.accent,
-            fontSize: 18,
-            cursor: "pointer",
-            padding: 0,
-            marginRight: 8,
-            flexShrink: 0,
-            alignSelf: hasDetails ? "flex-start" : "center",
-          }}
+          className={`bg-transparent border-none text-dt text-lg cursor-pointer p-0 mr-2 shrink-0 ${hasDetails ? "self-start" : "self-center"}`}
         >
           ‹
         </button>
         <div
           onClick={onOpenSettings}
-          style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flex: 1, minWidth: 0 }}
+          className="flex items-center justify-between flex-1 min-w-0"
         >
-          <div style={{ minWidth: 0, flex: 1 }}>
-            <h2
-              style={{
-                fontFamily: font.serif,
-                fontSize: 18,
-                color: color.text,
-                fontWeight: 400,
-                margin: 0,
-                display: "-webkit-box",
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: "vertical" as const,
-                overflow: "hidden",
-              }}
-            >
+          <div className="min-w-0 flex-1">
+            <h2 className="font-serif text-lg text-white font-normal m-0 line-clamp-2">
               {squad.name}
             </h2>
             {hasDetails && (
-              <p
-                style={{
-                  fontFamily: font.mono,
-                  fontSize: 10,
-                  color: color.dim,
-                  margin: "2px 0 0",
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                }}
-              >
+              <p className="font-mono text-tiny text-neutral-500 m-0 mt-0.5 truncate">
                 {detailParts.length > 0 ? detailParts.join(" · ") : squad.event}
               </p>
             )}
           </div>
           <div
             onClick={onOpenSettings}
-            style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", justifyContent: "center", marginLeft: 12, flexShrink: 0, cursor: "pointer", paddingTop: 4 }}
+            className="flex flex-col items-end justify-center ml-3 shrink-0 cursor-pointer pt-1"
           >
-            <div style={{ display: "flex", alignItems: "center" }}>
+            <div className="flex items-center">
               {squad.members.slice(0, 4).map((m, idx) => {
                 const isLocked = squad.dateStatus === "locked";
                 const isProposed = squad.dateStatus === "proposed";
@@ -152,40 +109,21 @@ export default function ChatHeader({
                 return (
                   <div
                     key={m.name}
-                    style={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: "50%",
-                      background: avatarBg,
-                      color: avatarColor,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      fontFamily: font.mono,
-                      fontSize: 10,
-                      fontWeight: 700,
-                      marginLeft: idx === 0 ? 0 : -6,
-                      border: `2px solid ${color.card}`,
-                      position: "relative",
-                      zIndex: 4 - idx,
-                    }}
+                    className={`size-6 rounded-full flex items-center justify-center font-mono text-tiny font-bold border-2 border-neutral-925 ${idx === 0 ? "" : "-ml-1.5"}`}
+                    style={{ background: avatarBg, color: avatarColor, zIndex: 4 - idx, position: "relative" }}
                   >
                     {m.avatar}
                   </div>
                 );
               })}
               {squad.members.length > 4 && (
-                <span style={{ fontFamily: font.mono, fontSize: 8, fontWeight: 700, color: color.dim, marginLeft: 4 }}>
+                <span className="font-mono text-tiny font-bold text-neutral-500 ml-1">
                   +{squad.members.length - 4}
                 </span>
               )}
             </div>
             {expiryLabel && (
-              <span style={{
-                fontFamily: font.mono, fontSize: 9,
-                color: expiryUrgent ? color.accent : color.faint,
-                marginTop: 2,
-              }}>
+              <span className={`font-mono text-tiny mt-0.5 ${expiryUrgent ? "text-dt" : "text-neutral-700"}`}>
                 {expiryLabel}
               </span>
             )}

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { font, color } from "@/lib/styles";
+import cn from "@/lib/tailwindMerge";
 import PollMessage from "./PollMessage";
 
 const URL_RE = /(https?:\/\/[^\s<]+)/;
@@ -16,12 +16,7 @@ const linkify = (text: string, isDark: boolean): React.ReactNode => {
         href={part}
         target="_blank"
         rel="noopener noreferrer"
-        style={{
-          color: isDark ? "#000" : color.accent,
-          textDecoration: "underline",
-          textUnderlineOffset: 2,
-          wordBreak: "break-all",
-        }}
+        className={cn("underline underline-offset-2 break-all", { "text-black": isDark, "text-dt": !isDark })}
       >
         {part.replace(/^https?:\/\/(www\.)?/, "").replace(/\/$/, "")}
       </a>
@@ -77,18 +72,18 @@ export default function ChatMessage({
   if (msg.sender === "system") {
     if (msg.messageType === 'date_confirm' && isLastConfirm) {
       return (
-        <div style={{ textAlign: "center", padding: "8px 0" }}>
-          <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>{msg.text}</span>
+        <div className="text-center py-2">
+          <span className="font-mono text-tiny text-neutral-500">{msg.text}</span>
           {confirmLoading && (
-            <div style={{ fontFamily: font.mono, fontSize: 10, color: color.faint, marginTop: 6 }}>...</div>
+            <div className="font-mono text-tiny text-neutral-700 mt-1.5">...</div>
           )}
           {dateConfirmStatus === 'yes' && !confirmLoading && (
-            <div style={{ fontFamily: font.mono, fontSize: 10, color: color.accent, marginTop: 6 }}>
+            <div className="font-mono text-tiny text-dt mt-1.5">
               you&apos;re in
             </div>
           )}
           {dateConfirmStatus === 'none' && !confirmLoading && (
-            <div style={{ fontFamily: font.mono, fontSize: 10, color: color.faint, marginTop: 6 }}>
+            <div className="font-mono text-tiny text-neutral-700 mt-1.5">
               waiting for responses
             </div>
           )}
@@ -110,45 +105,40 @@ export default function ChatMessage({
     }
 
     return (
-      <div style={{ textAlign: "center", padding: "4px 0" }}>
-        <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>{msg.text}</span>
+      <div className="text-center py-1">
+        <span className="font-mono text-tiny text-neutral-500">{msg.text}</span>
       </div>
     );
   }
 
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: msg.isYou ? "flex-end" : "flex-start",
-        marginTop: isFirstInGroup ? 8 : 0,
-      }}
-    >
+    <div className={cn("flex flex-col", { "items-end": msg.isYou, "items-start": !msg.isYou, "mt-2": isFirstInGroup, "mt-0": !isFirstInGroup })}>
       {isFirstInGroup && !msg.isYou && (
-        <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim, marginBottom: 3 }}>
+        <span className="font-mono text-tiny text-neutral-500 mb-1">
           {msg.sender}
         </span>
       )}
       <div
-        className="select-text"
-        style={{
-          background: msg.isYou ? color.accent : color.card,
-          color: msg.isYou ? "#000" : color.text,
-          padding: "8px 12px",
-          borderRadius: msg.isYou
-            ? `${isFirstInGroup ? 16 : 8}px 16px ${isLastInGroup ? 4 : 8}px 16px`
-            : `16px ${isFirstInGroup ? 16 : 8}px ${isLastInGroup ? 8 : 8}px ${isLastInGroup ? 4 : 8}px`,
-          fontFamily: font.mono,
-          fontSize: 13,
-          maxWidth: "80%",
-          lineHeight: 1.4,
-        }}
+        className={cn("select-text py-2 px-3 font-mono text-sm max-w-[80%] leading-snug",
+          msg.isYou
+            ? cn("bg-dt text-black rounded-tr-2xl rounded-bl-2xl", {
+                "rounded-tl-2xl": isFirstInGroup,
+                "rounded-tl-lg": !isFirstInGroup,
+                "rounded-br": isLastInGroup,
+                "rounded-br-lg": !isLastInGroup,
+              })
+            : cn("bg-neutral-925 text-white rounded-tl-2xl rounded-br-lg", {
+                "rounded-tr-2xl": isFirstInGroup,
+                "rounded-tr-lg": !isFirstInGroup,
+                "rounded-bl": isLastInGroup,
+                "rounded-bl-lg": !isLastInGroup,
+              })
+        )}
       >
         {linkify(msg.text, !!msg.isYou)}
       </div>
       {isLastInGroup && (
-        <span style={{ fontFamily: font.mono, fontSize: 9, color: color.faint, marginTop: 2 }}>
+        <span className="font-mono text-tiny text-neutral-700 mt-0.5">
           {msg.time}
         </span>
       )}

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -9,6 +9,7 @@ import { parseNaturalDate, parseNaturalTime, parseDateToISO, formatTimeAgo } fro
 import ChatHeader from "./ChatHeader";
 import MessageComposer from "./MessageComposer";
 import ChatMessage from "./ChatMessage";
+import SquadSettingsModal from "./SquadSettingsModal";
 
 
 interface SquadChatProps {
@@ -66,9 +67,7 @@ const SquadChat = ({
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [showImOutConfirm, setShowImOutConfirm] = useState(false);
   const [kickTarget, setKickTarget] = useState<{ name: string; userId: string } | null>(null);
-  const [memberMenu, setMemberMenu] = useState<{ name: string; userId: string } | null>(null);
   const [showSquadPopup, setShowSquadPopup] = useState(false);
-  const [squadPopupView, setSquadPopupView] = useState<'menu' | 'members'>('menu');
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [datePickerValue, setDatePickerValue] = useState("");
   const [settingDate, setSettingDate] = useState(false);
@@ -1119,443 +1118,34 @@ const SquadChat = ({
       )}
       </div>{/* end blur wrapper */}
 
+
       {/* Squad popup modal */}
       {showSquadPopup && (
-        <div
-          onClick={() => { setShowSquadPopup(false); setSquadPopupView('menu'); }}
-          style={{
-            position: "fixed",
-            top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.3)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 9999,
-          }}
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            style={{
-              background: color.deep,
-              border: `1px solid ${color.border}`,
-              borderRadius: 16,
-              padding: "24px 20px",
-              maxWidth: 300,
-              width: "90%",
-              maxHeight: "70vh",
-              overflowY: "auto",
-            }}
-          >
-            {squadPopupView === 'menu' ? (
-              <>
-                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", marginBottom: 20 }}>
-                  <div style={{ display: "flex", alignItems: "center", marginBottom: 6 }}>
-                    {localSquad.members.slice(0, 4).map((m, idx) => {
-                      const isLocked = localSquad.dateStatus === 'locked';
-                      const isProposed = localSquad.dateStatus === 'proposed';
-                      const confirmResponse = m.userId ? dateConfirms.get(m.userId) : undefined;
-                      const isConfirmed = isLocked || (isProposed && dateConfirms.size > 0 && confirmResponse === 'yes');
-                      const isPending = isProposed && dateConfirms.size > 0 && confirmResponse !== 'yes';
-                      const avatarBg = isConfirmed ? color.accent : isPending ? color.borderLight : m.name === "You" ? color.accent : color.borderLight;
-                      const avatarColor = isConfirmed ? "#000" : isPending ? color.dim : m.name === "You" ? "#000" : color.dim;
-                      return (
-                        <div key={m.name} style={{
-                          width: 24, height: 24, borderRadius: "50%",
-                          background: avatarBg, color: avatarColor,
-                          display: "flex", alignItems: "center", justifyContent: "center",
-                          fontFamily: font.mono, fontSize: 10, fontWeight: 700,
-                          marginLeft: idx === 0 ? 0 : -6,
-                          border: `2px solid ${color.deep}`,
-                          position: "relative", zIndex: 4 - idx,
-                        }}>
-                          {m.avatar}
-                        </div>
-                      );
-                    })}
-                    {localSquad.members.length > 4 && (
-                      <span style={{ fontFamily: font.mono, fontSize: 8, fontWeight: 700, color: color.dim, marginLeft: 4 }}>
-                        +{localSquad.members.length - 4}
-                      </span>
-                    )}
-                  </div>
-                  <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>
-                    {localSquad.members.length}{localSquad.maxSquadSize != null ? `/${localSquad.maxSquadSize}` : ''} member{localSquad.members.length !== 1 ? 's' : ''}
-                  </span>
-                </div>
-
-                <div style={{ display: "flex", flexDirection: "column", gap: 0 }}>
-                  <button
-                    onClick={() => setSquadPopupView('members')}
-                    style={{
-                      background: "none", border: "none",
-                      borderBottom: `1px solid ${color.border}`,
-                      color: color.text, fontFamily: font.mono, fontSize: 12,
-                      padding: "12px 0", cursor: "pointer", textAlign: "center",
-                    }}
-                  >
-                    See members
-                  </button>
-                  {localSquad.checkId && onUpdateSquadSize && (
-                    <div style={{
-                      display: "flex", alignItems: "center", justifyContent: "center",
-                      gap: 12, padding: "12px 0",
-                      borderBottom: `1px solid ${color.border}`,
-                    }}>
-                      <span style={{ fontFamily: font.mono, fontSize: 12, color: color.text }}>Squad size</span>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        <button
-                          onClick={() => {
-                            const newSize = (localSquad.maxSquadSize ?? 5) - 1;
-                            if (newSize >= localSquad.members.length) {
-                              onUpdateSquadSize(localSquad.checkId!, newSize);
-                              setLocalSquad((prev) => ({ ...prev, maxSquadSize: newSize }));
-                              onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === localSquad.id ? { ...s, maxSquadSize: newSize } : s));
-                            }
-                          }}
-                          disabled={(localSquad.maxSquadSize ?? 5) <= localSquad.members.length}
-                          style={{
-                            width: 24, height: 24, borderRadius: 6,
-                            border: `1px solid ${color.borderMid}`, background: "none",
-                            color: (localSquad.maxSquadSize ?? 5) <= localSquad.members.length ? color.faint : color.text,
-                            fontFamily: font.mono, fontSize: 14,
-                            cursor: (localSquad.maxSquadSize ?? 5) <= localSquad.members.length ? "default" : "pointer",
-                            display: "flex", alignItems: "center", justifyContent: "center", padding: 0,
-                          }}
-                        >
-                          −
-                        </button>
-                        <span style={{ fontFamily: font.mono, fontSize: 13, color: color.accent, fontWeight: 700, minWidth: 20, textAlign: "center" }}>
-                          {localSquad.maxSquadSize ?? 5}
-                        </span>
-                        <button
-                          onClick={() => {
-                            const newSize = (localSquad.maxSquadSize ?? 5) + 1;
-                            if (newSize <= 20) {
-                              onUpdateSquadSize(localSquad.checkId!, newSize);
-                              setLocalSquad((prev) => ({ ...prev, maxSquadSize: newSize }));
-                              onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === localSquad.id ? { ...s, maxSquadSize: newSize } : s));
-                            }
-                          }}
-                          disabled={(localSquad.maxSquadSize ?? 5) >= 20}
-                          style={{
-                            width: 24, height: 24, borderRadius: 6,
-                            border: `1px solid ${color.borderMid}`, background: "none",
-                            color: (localSquad.maxSquadSize ?? 5) >= 20 ? color.faint : color.text,
-                            fontFamily: font.mono, fontSize: 14,
-                            cursor: (localSquad.maxSquadSize ?? 5) >= 20 ? "default" : "pointer",
-                            display: "flex", alignItems: "center", justifyContent: "center", padding: 0,
-                          }}
-                        >
-                          +
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                  {onSetSquadDate && (
-                    <button
-                      onClick={() => {
-                        setShowSquadPopup(false);
-                        setSquadPopupView('menu');
-                        setShowDatePicker(true);
-                        const dateLabel = localSquad.eventIsoDate
-                          ? new Date(localSquad.eventIsoDate + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })
-                          : "";
-                        setDatePickerValue(dateLabel);
-                        setDateLocked(false);
-                        setTimeLocked(false);
-                        setDateDismissed(false);
-                        setTimeDismissed(false);
-                      }}
-                      style={{
-                        background: "none", border: "none",
-                        borderBottom: `1px solid ${color.border}`,
-                        color: color.text, fontFamily: font.mono, fontSize: 12,
-                        padding: "12px 0", cursor: "pointer", textAlign: "center",
-                      }}
-                    >
-                      Set plans
-                    </button>
-                  )}
-                  <button
-                    onClick={async () => {
-                      try {
-                        const newExpiry = await db.extendSquad(localSquad.id);
-                        onSquadUpdate((prev) => prev.map((s) =>
-                          s.id === localSquad.id ? { ...s, expiresAt: newExpiry } : s
-                        ));
-                        setLocalSquad((prev) => ({ ...prev, expiresAt: newExpiry }));
-                      } catch {}
-                      setShowSquadPopup(false);
-                      setSquadPopupView('menu');
-                    }}
-                    style={{
-                      background: "none", border: "none",
-                      borderBottom: `1px solid ${color.border}`,
-                      color: color.text, fontFamily: font.mono, fontSize: 12,
-                      padding: "12px 0", cursor: "pointer", textAlign: "center",
-                    }}
-                  >
-                    Extend +7 days
-                  </button>
-                  <button
-                    onClick={() => {
-                      setShowSquadPopup(false);
-                      setSquadPopupView('menu');
-                      setShowLeaveConfirm(true);
-                    }}
-                    style={{
-                      background: "none", border: "none", color: "#ff4444",
-                      fontFamily: font.mono, fontSize: 12,
-                      padding: "12px 0", cursor: "pointer", textAlign: "center",
-                    }}
-                  >
-                    Leave
-                  </button>
-                </div>
-              </>
-            ) : (
-              <>
-                <button
-                  onClick={() => setSquadPopupView('menu')}
-                  style={{
-                    background: "none", border: "none", color: color.accent,
-                    fontFamily: font.mono, fontSize: 12, cursor: "pointer",
-                    padding: 0, marginBottom: 16,
-                  }}
-                >
-                  ← Back
-                </button>
-
-                <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-                  {localSquad.members.map((m) => {
-                    const isLocked = localSquad.dateStatus === 'locked';
-                    const isProposed = localSquad.dateStatus === 'proposed';
-                    const confirmResponse = m.userId ? dateConfirms.get(m.userId) : undefined;
-                    const isConfirmed = isLocked || (isProposed && dateConfirms.size > 0 && confirmResponse === 'yes');
-                    const isGrayed = isProposed && dateConfirms.size > 0 && !isConfirmed;
-                    return (
-                    <React.Fragment key={m.name}>
-                    <div
-                      onClick={() => {
-                        if (m.name !== "You" && m.userId) {
-                          setShowSquadPopup(false);
-                          setSquadPopupView('menu');
-                          onViewProfile?.(m.userId);
-                        }
-                      }}
-                      style={{
-                        display: "flex", alignItems: "center", gap: 10,
-                        cursor: m.name !== "You" && m.userId ? "pointer" : "default",
-                        opacity: isGrayed ? 0.35 : 1,
-                      }}
-                    >
-                      <div style={{
-                        width: 28, height: 28, borderRadius: "50%",
-                        background: isConfirmed ? color.accent : (m.name === "You" && !isGrayed) ? color.accent : color.borderLight,
-                        color: isConfirmed || (m.name === "You" && !isGrayed) ? "#000" : color.dim,
-                        display: "flex", alignItems: "center", justifyContent: "center",
-                        fontFamily: font.mono, fontSize: 11, fontWeight: 700, flexShrink: 0,
-                      }}>
-                        {m.avatar}
-                      </div>
-                      <span style={{ fontFamily: font.mono, fontSize: 12, color: isGrayed ? color.faint : color.text }}>
-                        {m.name}
-                      </span>
-                      {m.name === "You" && (
-                        <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>you</span>
-                      )}
-                      {(m.name === "You" || !(onSetMemberRole || onKickMember)) && (isLocked || (isProposed && dateConfirms.size > 0)) && (
-                        <span style={{ fontFamily: font.mono, fontSize: 10, color: isConfirmed ? color.accent : color.faint, marginLeft: "auto" }}>
-                          {isConfirmed ? "down" : confirmResponse === 'no' ? "out" : "pending"}
-                        </span>
-                      )}
-                      {m.name !== "You" && m.userId && (onSetMemberRole || onKickMember) && (
-                        <div style={{ display: "flex", gap: 8, marginLeft: "auto", alignItems: "center" }}>
-                          {(isLocked || (isProposed && dateConfirms.size > 0)) && (
-                            <span style={{ fontFamily: font.mono, fontSize: 10, color: isConfirmed ? color.accent : color.faint }}>
-                              {isConfirmed ? "down" : confirmResponse === 'no' ? "out" : "pending"}
-                            </span>
-                          )}
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setMemberMenu(memberMenu?.userId === m.userId ? null : { name: m.name, userId: m.userId! });
-                            }}
-                            style={{
-                              background: "none", border: "none", color: color.faint,
-                              fontFamily: font.mono, fontSize: 14, cursor: "pointer",
-                              padding: "2px 4px", letterSpacing: "0.1em",
-                            }}
-                          >
-                            •••
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                    {memberMenu?.userId === m.userId && (
-                      <div style={{
-                        background: color.deep, border: `1px solid ${color.border}`,
-                        borderRadius: 10, padding: "4px 0", marginTop: 4, marginLeft: 38,
-                      }}>
-                        {onSetMemberRole && (
-                          <button
-                            onClick={async () => {
-                              setMemberMenu(null);
-                              setShowSquadPopup(false);
-                              setSquadPopupView('menu');
-                              await onSetMemberRole(localSquad.id, m.userId!, 'waitlist');
-                              const updated = {
-                                ...localSquad,
-                                members: localSquad.members.filter((x) => x.userId !== m.userId),
-                                waitlistedMembers: [...(localSquad.waitlistedMembers ?? []), { name: m.name, avatar: m.avatar, userId: m.userId! }],
-                              };
-                              setLocalSquad(updated);
-                              onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === localSquad.id ? updated : s));
-                            }}
-                            style={{
-                              display: "block", width: "100%", background: "none", border: "none",
-                              color: color.muted, fontFamily: font.mono, fontSize: 11,
-                              padding: "8px 14px", cursor: "pointer", textAlign: "left",
-                            }}
-                          >
-                            Move to waitlist
-                          </button>
-                        )}
-                        {onKickMember && (
-                          <button
-                            onClick={() => {
-                              setMemberMenu(null);
-                              setShowSquadPopup(false);
-                              setSquadPopupView('menu');
-                              setKickTarget({ name: m.name, userId: m.userId! });
-                            }}
-                            style={{
-                              display: "block", width: "100%", background: "none", border: "none",
-                              color: "#ff4444", fontFamily: font.mono, fontSize: 11,
-                              padding: "8px 14px", cursor: "pointer", textAlign: "left",
-                            }}
-                          >
-                            Kick from squad
-                          </button>
-                        )}
-                      </div>
-                    )}
-                    </React.Fragment>
-                    );
-                  })}
-                </div>
-
-                {localSquad.waitlistedMembers && localSquad.waitlistedMembers.length > 0 && (
-                  <div style={{ marginTop: 16 }}>
-                    <span style={{ fontFamily: font.mono, fontSize: 10, textTransform: "uppercase", letterSpacing: "0.15em", color: color.dim }}>
-                      Waitlist
-                    </span>
-                    <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 10 }}>
-                      {localSquad.waitlistedMembers.map((m) => (
-                        <div
-                          key={m.userId}
-                          onClick={() => {
-                            if (m.userId) {
-                              setShowSquadPopup(false);
-                              setSquadPopupView('menu');
-                              onViewProfile?.(m.userId);
-                            }
-                          }}
-                          style={{ display: "flex", alignItems: "center", gap: 10, cursor: m.userId ? "pointer" : "default" }}
-                        >
-                          <div style={{
-                            width: 28, height: 28, borderRadius: "50%",
-                            background: color.borderLight, color: color.dim,
-                            display: "flex", alignItems: "center", justifyContent: "center",
-                            fontFamily: font.mono, fontSize: 11, fontWeight: 700, flexShrink: 0,
-                          }}>
-                            {m.avatar}
-                          </div>
-                          <span style={{ fontFamily: font.mono, fontSize: 12, color: color.muted, flex: 1 }}>{m.name}</span>
-                          {onSetMemberRole && (
-                            <button
-                              onClick={async (e) => {
-                                e.stopPropagation();
-                                const isFull = localSquad.members.length >= (localSquad.maxSquadSize ?? Infinity);
-                                if (isFull) return;
-                                await onSetMemberRole(localSquad.id, m.userId, 'member');
-                                const updated = {
-                                  ...localSquad,
-                                  members: [...localSquad.members, { name: m.name, avatar: m.avatar, userId: m.userId }],
-                                  waitlistedMembers: (localSquad.waitlistedMembers ?? []).filter((x) => x.userId !== m.userId),
-                                };
-                                setLocalSquad(updated);
-                                onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === localSquad.id ? updated : s));
-                              }}
-                              disabled={localSquad.members.length >= (localSquad.maxSquadSize ?? Infinity)}
-                              style={{
-                                background: "none", border: `1px solid ${color.borderMid}`,
-                                borderRadius: 8,
-                                color: localSquad.members.length >= (localSquad.maxSquadSize ?? Infinity) ? color.faint : color.accent,
-                                fontFamily: font.mono, fontSize: 11, fontWeight: 700,
-                                padding: "4px 10px",
-                                cursor: localSquad.members.length >= (localSquad.maxSquadSize ?? Infinity) ? "default" : "pointer",
-                              }}
-                            >
-                              Promote
-                            </button>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {localSquad.downResponders && localSquad.downResponders.length > 0 &&
-                  localSquad.members.length < (localSquad.maxSquadSize ?? Infinity) && (
-                  <div style={{ marginTop: 16 }}>
-                    <span style={{ fontFamily: font.mono, fontSize: 10, textTransform: "uppercase", letterSpacing: "0.15em", color: color.dim }}>
-                      Down on check
-                    </span>
-                    <div style={{ display: "flex", flexDirection: "column", gap: 12, marginTop: 10 }}>
-                      {localSquad.downResponders.map((p) => (
-                        <div key={p.userId} style={{ display: "flex", alignItems: "center", gap: 10 }}>
-                          <div style={{
-                            width: 28, height: 28, borderRadius: "50%",
-                            background: color.borderLight, color: color.dim,
-                            display: "flex", alignItems: "center", justifyContent: "center",
-                            fontFamily: font.mono, fontSize: 11, fontWeight: 700, flexShrink: 0,
-                          }}>
-                            {p.avatar}
-                          </div>
-                          <span style={{ fontFamily: font.mono, fontSize: 12, color: color.text, flex: 1 }}>{p.name}</span>
-                          {onAddMember && (
-                            <button
-                              onClick={async () => {
-                                await onAddMember(localSquad.id, p.userId);
-                                const newMember = { name: p.name, avatar: p.avatar, userId: p.userId };
-                                const updated = {
-                                  ...localSquad,
-                                  members: [...localSquad.members, newMember],
-                                  downResponders: localSquad.downResponders?.filter((d) => d.userId !== p.userId),
-                                };
-                                setLocalSquad(updated);
-                                onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === localSquad.id ? updated : s));
-                              }}
-                              style={{
-                                background: "none", border: `1px solid ${color.borderMid}`,
-                                borderRadius: 8, color: color.accent,
-                                fontFamily: font.mono, fontSize: 11, fontWeight: 700,
-                                padding: "4px 10px", cursor: "pointer",
-                              }}
-                            >
-                              Add
-                            </button>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
-        </div>
+        <SquadSettingsModal
+          squad={localSquad}
+          dateConfirms={dateConfirms}
+          onClose={() => setShowSquadPopup(false)}
+          onRequestLeave={() => setShowLeaveConfirm(true)}
+          onRequestKick={(target) => setKickTarget(target)}
+          onOpenDatePicker={onSetSquadDate ? () => {
+            setShowSquadPopup(false);
+            const dateLabel = localSquad.eventIsoDate
+              ? new Date(localSquad.eventIsoDate + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })
+              : "";
+            setDatePickerValue(dateLabel);
+            setDateLocked(false);
+            setTimeLocked(false);
+            setDateDismissed(false);
+            setTimeDismissed(false);
+            setShowDatePicker(true);
+          } : undefined}
+          onViewProfile={onViewProfile}
+          onUpdateSquadSize={onUpdateSquadSize}
+          onSetMemberRole={onSetMemberRole}
+          onAddMember={onAddMember}
+          onSquadUpdate={onSquadUpdate}
+          onLocalSquadUpdate={setLocalSquad}
+        />
       )}
 
       {/* Poll creation modal */}

--- a/src/features/squads/components/SquadMembersView.tsx
+++ b/src/features/squads/components/SquadMembersView.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import React, { useState } from "react";
+import cn from "@/lib/tailwindMerge";
+import { color } from "@/lib/styles";
+import type { Squad } from "@/lib/ui-types";
+
+interface SquadMembersViewProps {
+  squad: Squad;
+  dateConfirms: Map<string, "yes" | "no" | null>;
+  onBack: () => void;
+  onClose: () => void;
+  onViewProfile?: (userId: string) => void;
+  onRequestKick: (target: { name: string; userId: string }) => void;
+  onSetMemberRole?: (squadId: string, userId: string, role: "member" | "waitlist") => Promise<void>;
+  onAddMember?: (squadId: string, userId: string) => Promise<void>;
+  onSquadUpdate: (updater: Squad[] | ((prev: Squad[]) => Squad[])) => void;
+  onLocalSquadUpdate: React.Dispatch<React.SetStateAction<Squad>>;
+}
+
+export default function SquadMembersView({
+  squad,
+  dateConfirms,
+  onBack,
+  onClose,
+  onViewProfile,
+  onRequestKick,
+  onSetMemberRole,
+  onAddMember,
+  onSquadUpdate,
+  onLocalSquadUpdate,
+}: SquadMembersViewProps) {
+  const [memberMenu, setMemberMenu] = useState<{ name: string; userId: string } | null>(null);
+
+  return (
+    <>
+      <button
+        onClick={onBack}
+        className="bg-transparent border-none text-dt font-mono text-xs cursor-pointer p-0 mb-4"
+      >
+        ← Back
+      </button>
+
+      <div className="flex flex-col gap-3">
+        {squad.members.map((m) => {
+          const isLocked = squad.dateStatus === "locked";
+          const isProposed = squad.dateStatus === "proposed";
+          const confirmResponse = m.userId ? dateConfirms.get(m.userId) : undefined;
+          const isConfirmed = isLocked || (isProposed && dateConfirms.size > 0 && confirmResponse === "yes");
+          const isGrayed = isProposed && dateConfirms.size > 0 && !isConfirmed;
+          const showDateStatus = isLocked || (isProposed && dateConfirms.size > 0);
+          return (
+            <React.Fragment key={m.name}>
+              <div
+                onClick={() => {
+                  if (m.name !== "You" && m.userId) {
+                    onClose();
+                    onViewProfile?.(m.userId);
+                  }
+                }}
+                className={cn("flex items-center gap-2.5", {
+                  "cursor-pointer": m.name !== "You" && !!m.userId,
+                  "cursor-default": m.name === "You" || !m.userId,
+                  "opacity-35": isGrayed,
+                })}
+              >
+                <div
+                  className="size-7 rounded-full flex items-center justify-center font-mono text-xs font-bold shrink-0"
+                  style={{
+                    background: isConfirmed ? color.accent : (m.name === "You" && !isGrayed) ? color.accent : color.borderLight,
+                    color: isConfirmed || (m.name === "You" && !isGrayed) ? "#000" : color.dim,
+                  }}
+                >
+                  {m.avatar}
+                </div>
+                <span className={cn("font-mono text-xs", { "text-neutral-700": isGrayed, "text-white": !isGrayed })}>
+                  {m.name}
+                </span>
+                {m.name === "You" && (
+                  <span className="font-mono text-tiny text-neutral-500">you</span>
+                )}
+                {m.name === "You" && showDateStatus && (
+                  <span className={cn("font-mono text-tiny ml-auto", { "text-dt": isConfirmed, "text-neutral-700": !isConfirmed })}>
+                    {isConfirmed ? "down" : confirmResponse === "no" ? "out" : "pending"}
+                  </span>
+                )}
+                {m.name !== "You" && m.userId && (
+                  <div className="flex gap-2 ml-auto items-center">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setMemberMenu(memberMenu?.userId === m.userId ? null : { name: m.name, userId: m.userId! });
+                      }}
+                      className="bg-transparent border-none text-neutral-700 font-mono text-sm cursor-pointer px-1 py-0.5 tracking-widest"
+                    >
+                      •••
+                    </button>
+                    {showDateStatus && (
+                      <span className={cn("font-mono text-tiny", { "text-dt": isConfirmed, "text-neutral-700": !isConfirmed })}>
+                        {isConfirmed ? "down" : confirmResponse === "no" ? "out" : "pending"}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+              {memberMenu?.userId === m.userId && (
+                <div className="bg-neutral-950 border border-neutral-900 rounded-lg py-1 mt-1 ml-10">
+                  {onSetMemberRole && (
+                    <button
+                      onClick={async () => {
+                        setMemberMenu(null);
+                        onClose();
+                        await onSetMemberRole(squad.id, m.userId!, "waitlist");
+                        const updated = {
+                          ...squad,
+                          members: squad.members.filter((x) => x.userId !== m.userId),
+                          waitlistedMembers: [...(squad.waitlistedMembers ?? []), { name: m.name, avatar: m.avatar, userId: m.userId! }],
+                        };
+                        onLocalSquadUpdate(updated);
+                        onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === squad.id ? updated : s));
+                      }}
+                      className="block w-full bg-transparent border-none text-neutral-500 font-mono text-xs px-3.5 py-2 cursor-pointer text-left"
+                    >
+                      Move to waitlist
+                    </button>
+                  )}
+                  <button
+                    onClick={() => {
+                      setMemberMenu(null);
+                      onClose();
+                      onRequestKick({ name: m.name, userId: m.userId! });
+                    }}
+                    className="block w-full bg-transparent border-none text-red-500 font-mono text-xs px-3.5 py-2 cursor-pointer text-left"
+                  >
+                    Kick from squad
+                  </button>
+                </div>
+              )}
+            </React.Fragment>
+          );
+        })}
+      </div>
+
+      {squad.waitlistedMembers && squad.waitlistedMembers.length > 0 && (
+        <div className="mt-4">
+          <span className="font-mono text-tiny uppercase tracking-widest text-neutral-500">
+            Waitlist
+          </span>
+          <div className="flex flex-col gap-3 mt-2.5">
+            {squad.waitlistedMembers.map((m) => (
+              <div
+                key={m.userId}
+                onClick={() => {
+                  if (m.userId) {
+                    onClose();
+                    onViewProfile?.(m.userId);
+                  }
+                }}
+                className={cn("flex items-center gap-2.5", m.userId ? "cursor-pointer" : "cursor-default")}
+              >
+                <div className="size-7 rounded-full flex items-center justify-center font-mono text-xs font-bold shrink-0 bg-neutral-800 text-neutral-500">
+                  {m.avatar}
+                </div>
+                <span className="font-mono text-xs text-neutral-500 flex-1">{m.name}</span>
+                {onSetMemberRole && (
+                  <button
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      const isFull = squad.members.length >= (squad.maxSquadSize ?? Infinity);
+                      if (isFull) return;
+                      await onSetMemberRole(squad.id, m.userId, "member");
+                      const updated = {
+                        ...squad,
+                        members: [...squad.members, { name: m.name, avatar: m.avatar, userId: m.userId }],
+                        waitlistedMembers: (squad.waitlistedMembers ?? []).filter((x) => x.userId !== m.userId),
+                      };
+                      onLocalSquadUpdate(updated);
+                      onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === squad.id ? updated : s));
+                    }}
+                    disabled={squad.members.length >= (squad.maxSquadSize ?? Infinity)}
+                    className={cn("bg-transparent border border-neutral-800 rounded-lg font-mono text-xs font-bold px-2.5 py-1", {
+                      "text-neutral-700 cursor-default": squad.members.length >= (squad.maxSquadSize ?? Infinity),
+                      "text-dt cursor-pointer": squad.members.length < (squad.maxSquadSize ?? Infinity),
+                    })}
+                  >
+                    Promote
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {squad.downResponders && squad.downResponders.length > 0 &&
+        squad.members.length < (squad.maxSquadSize ?? Infinity) && (
+        <div className="mt-4">
+          <span className="font-mono text-tiny uppercase tracking-widest text-neutral-500">
+            Down on check
+          </span>
+          <div className="flex flex-col gap-3 mt-2.5">
+            {squad.downResponders.map((p) => (
+              <div key={p.userId} className="flex items-center gap-2.5">
+                <div className="size-7 rounded-full flex items-center justify-center font-mono text-xs font-bold shrink-0 bg-neutral-800 text-neutral-500">
+                  {p.avatar}
+                </div>
+                <span className="font-mono text-xs text-white flex-1">{p.name}</span>
+                {onAddMember && (
+                  <button
+                    onClick={async () => {
+                      await onAddMember(squad.id, p.userId);
+                      const newMember = { name: p.name, avatar: p.avatar, userId: p.userId };
+                      const updated = {
+                        ...squad,
+                        members: [...squad.members, newMember],
+                        downResponders: squad.downResponders?.filter((d) => d.userId !== p.userId),
+                      };
+                      onLocalSquadUpdate(updated);
+                      onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === squad.id ? updated : s));
+                    }}
+                    className="bg-transparent border border-neutral-800 rounded-lg text-dt font-mono text-xs font-bold px-2.5 py-1 cursor-pointer"
+                  >
+                    Add
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/features/squads/components/SquadSettingsModal.tsx
+++ b/src/features/squads/components/SquadSettingsModal.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import React, { useState } from "react";
+import * as db from "@/lib/db";
+import cn from "@/lib/tailwindMerge";
+import { color } from "@/lib/styles";
+import type { Squad } from "@/lib/ui-types";
+import SquadMembersView from "./SquadMembersView";
+
+interface SquadSettingsModalProps {
+  squad: Squad;
+  dateConfirms: Map<string, "yes" | "no" | null>;
+  onClose: () => void;
+  onRequestLeave: () => void;
+  onRequestKick: (target: { name: string; userId: string }) => void;
+  onOpenDatePicker?: () => void;
+  onViewProfile?: (userId: string) => void;
+  onUpdateSquadSize?: (checkId: string, newSize: number) => Promise<void>;
+  onSetMemberRole?: (squadId: string, userId: string, role: "member" | "waitlist") => Promise<void>;
+  onAddMember?: (squadId: string, userId: string) => Promise<void>;
+  onSquadUpdate: (updater: Squad[] | ((prev: Squad[]) => Squad[])) => void;
+  onLocalSquadUpdate: React.Dispatch<React.SetStateAction<Squad>>;
+}
+
+export default function SquadSettingsModal({
+  squad,
+  dateConfirms,
+  onClose,
+  onRequestLeave,
+  onRequestKick,
+  onOpenDatePicker,
+  onViewProfile,
+  onUpdateSquadSize,
+  onSetMemberRole,
+  onAddMember,
+  onSquadUpdate,
+  onLocalSquadUpdate,
+}: SquadSettingsModalProps) {
+  const [view, setView] = useState<"menu" | "members">("menu");
+
+  return (
+    <div
+      onClick={onClose}
+      className="fixed inset-0 bg-black/30 flex items-center justify-center z-9999"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="bg-neutral-950 border border-neutral-900 rounded-2xl px-5 py-6 max-w-75 w-11/12 max-h-[70vh] overflow-y-auto"
+      >
+        {view === "menu" ? (
+          <>
+            <div className="flex flex-col items-center mb-5">
+              <div className="flex items-center mb-1.5">
+                {squad.members.slice(0, 4).map((m, idx) => {
+                  const isLocked = squad.dateStatus === "locked";
+                  const isProposed = squad.dateStatus === "proposed";
+                  const confirmResponse = m.userId ? dateConfirms.get(m.userId) : undefined;
+                  const isConfirmed = isLocked || (isProposed && dateConfirms.size > 0 && confirmResponse === "yes");
+                  const isPending = isProposed && dateConfirms.size > 0 && confirmResponse !== "yes";
+                  const avatarBg = isConfirmed ? color.accent : isPending ? color.borderLight : m.name === "You" ? color.accent : color.borderLight;
+                  const avatarColor = isConfirmed ? "#000" : isPending ? color.dim : m.name === "You" ? "#000" : color.dim;
+                  return (
+                    <div
+                      key={m.name}
+                      className="size-6 rounded-full flex items-center justify-center font-mono text-tiny font-bold border-2 border-neutral-950 relative"
+                      style={{ background: avatarBg, color: avatarColor, marginLeft: idx === 0 ? 0 : -6, zIndex: 4 - idx }}
+                    >
+                      {m.avatar}
+                    </div>
+                  );
+                })}
+                {squad.members.length > 4 && (
+                  <span className="font-mono text-tiny font-bold text-neutral-500 ml-1">
+                    +{squad.members.length - 4}
+                  </span>
+                )}
+              </div>
+              <span className="font-mono text-tiny text-neutral-500">
+                {squad.members.length}{squad.maxSquadSize != null ? `/${squad.maxSquadSize}` : ""} member{squad.members.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+
+            <div className="flex flex-col">
+              <button
+                onClick={() => setView("members")}
+                className="bg-transparent border-none border-b border-neutral-900 text-white font-mono text-xs py-3 cursor-pointer text-center w-full"
+              >
+                See members
+              </button>
+              {squad.checkId && onUpdateSquadSize && (
+                <div className="flex items-center justify-center gap-3 py-3 border-b border-neutral-900">
+                  <span className="font-mono text-xs text-white">Squad size</span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => {
+                        const newSize = (squad.maxSquadSize ?? 5) - 1;
+                        if (newSize >= squad.members.length) {
+                          onUpdateSquadSize(squad.checkId!, newSize);
+                          onLocalSquadUpdate((prev) => ({ ...prev, maxSquadSize: newSize }));
+                          onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === squad.id ? { ...s, maxSquadSize: newSize } : s));
+                        }
+                      }}
+                      disabled={(squad.maxSquadSize ?? 5) <= squad.members.length}
+                      className={cn("size-6 rounded-md border border-neutral-800 bg-transparent font-mono text-sm flex items-center justify-center p-0", {
+                        "text-neutral-700 cursor-default": (squad.maxSquadSize ?? 5) <= squad.members.length,
+                        "text-white cursor-pointer": (squad.maxSquadSize ?? 5) > squad.members.length,
+                      })}
+                    >
+                      −
+                    </button>
+                    <span className="font-mono text-sm text-dt font-bold min-w-5 text-center">
+                      {squad.maxSquadSize ?? 5}
+                    </span>
+                    <button
+                      onClick={() => {
+                        const newSize = (squad.maxSquadSize ?? 5) + 1;
+                        if (newSize <= 20) {
+                          onUpdateSquadSize(squad.checkId!, newSize);
+                          onLocalSquadUpdate((prev) => ({ ...prev, maxSquadSize: newSize }));
+                          onSquadUpdate((prev: Squad[]) => prev.map((s) => s.id === squad.id ? { ...s, maxSquadSize: newSize } : s));
+                        }
+                      }}
+                      disabled={(squad.maxSquadSize ?? 5) >= 20}
+                      className={cn("size-6 rounded-md border border-neutral-800 bg-transparent font-mono text-sm flex items-center justify-center p-0", {
+                        "text-neutral-700 cursor-default": (squad.maxSquadSize ?? 5) >= 20,
+                        "text-white cursor-pointer": (squad.maxSquadSize ?? 5) < 20,
+                      })}
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+              )}
+              {onOpenDatePicker && (
+                <button
+                  onClick={onOpenDatePicker}
+                  className="bg-transparent border-none border-b border-neutral-900 text-white font-mono text-xs py-3 cursor-pointer text-center w-full"
+                >
+                  Set plans
+                </button>
+              )}
+              <button
+                onClick={async () => {
+                  try {
+                    const newExpiry = await db.extendSquad(squad.id);
+                    onSquadUpdate((prev) => prev.map((s) =>
+                      s.id === squad.id ? { ...s, expiresAt: newExpiry } : s
+                    ));
+                    onLocalSquadUpdate((prev) => ({ ...prev, expiresAt: newExpiry }));
+                  } catch {}
+                  onClose();
+                }}
+                className="bg-transparent border-none border-b border-neutral-900 text-white font-mono text-xs py-3 cursor-pointer text-center w-full"
+              >
+                Extend +7 days
+              </button>
+              <button
+                onClick={() => { onClose(); onRequestLeave(); }}
+                className="bg-transparent border-none text-red-500 font-mono text-xs py-3 cursor-pointer text-center w-full"
+              >
+                Leave
+              </button>
+            </div>
+          </>
+        ) : (
+          <SquadMembersView
+            squad={squad}
+            dateConfirms={dateConfirms}
+            onBack={() => setView("menu")}
+            onClose={onClose}
+            onViewProfile={onViewProfile}
+            onRequestKick={onRequestKick}
+            onSetMemberRole={onSetMemberRole}
+            onAddMember={onAddMember}
+            onSquadUpdate={onSquadUpdate}
+            onLocalSquadUpdate={onLocalSquadUpdate}
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract `SquadSettingsModal` from `SquadChat` — settings popup is now its own component with internal `view` and `memberMenu` state
- Extract `SquadMembersView` from `SquadSettingsModal` — members list (active, waitlist, down-on-check) is isolated further
- Migrate `ChatHeader`, `ChatMessage`, `SquadSettingsModal`, `SquadMembersView` to Tailwind CSS, replacing inline styles
- Use `cn()` with object syntax for conditional classes in `ChatMessage` bubble corners

## Test plan

- [ ] Open a squad chat — header renders correctly with back button, squad name, avatars, expiry
- [ ] Tap header to open settings modal — menu view shows members preview, squad size stepper, set plans, extend, leave
- [ ] Navigate to members view — active members, waitlist, down-on-check sections render; ••• menu opens inline
- [ ] Chat messages render with correct bubble shapes for first/last in group, your vs others
- [ ] System messages (date confirm, poll) render correctly
- [ ] Kick, waitlist, promote, add member actions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)