### PR TITLE
fix: prevent unread badges from re-appearing after clearing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,6 +104,7 @@ export default function Home() {
   const [selectedSquad, setSelectedSquad] = useState<Squad | null>(null);
   const selectedSquadIdRef = useRef<string | null>(null);
   selectedSquadIdRef.current = selectedSquad?.id ?? null;
+  const readSquadIdsRef = useRef<Set<string>>(new Set());
   const [viewingUserId, setViewingUserId] = useState<string | null>(null);
   const [onboardingFriendGate, setOnboardingFriendGate] = useState(false);
   const friendGateInitRef = useRef(false);
@@ -169,6 +170,7 @@ export default function Home() {
     profile,
     setChecks: checksHook.setChecks,
     showToast,
+    openSquadIdRef: selectedSquadIdRef,
     onSquadCreated: (squadId: string) => {
       setSquadChatOrigin(tab);
       squadsHook.setAutoSelectSquadId(squadId);
@@ -188,8 +190,13 @@ export default function Home() {
     isDemoMode,
     onUnreadSquadIds: (ids) => {
       const openId = selectedSquadIdRef.current;
+      const recentlyRead = readSquadIdsRef.current;
+      // Remove confirmed-read squads from the suppression set
+      for (const id of recentlyRead) {
+        if (!ids.includes(id)) recentlyRead.delete(id);
+      }
       squadsHook.setSquads((prev) => prev.map((s) =>
-        ids.includes(s.id) && s.id !== openId ? { ...s, hasUnread: true } : s
+        ids.includes(s.id) && s.id !== openId && !recentlyRead.has(s.id) ? { ...s, hasUnread: true } : s
       ));
     },
   });
@@ -508,8 +515,15 @@ export default function Home() {
           ));
         }
       } else {
-        notificationsHook.setNotifications((prev) => [newNotif, ...prev]);
-        notificationsHook.setUnreadCount((prev) => prev + 1);
+        // Auto-mark read if this notification is for the currently-open squad
+        const isOpenSquad = newNotif.related_squad_id && newNotif.related_squad_id === selectedSquadIdRef.current;
+        if (isOpenSquad) {
+          db.markNotificationRead(newNotif.id).catch(() => {});
+          notificationsHook.setNotifications((prev) => [{ ...newNotif, is_read: true }, ...prev]);
+        } else {
+          notificationsHook.setNotifications((prev) => [newNotif, ...prev]);
+          notificationsHook.setUnreadCount((prev) => prev + 1);
+        }
       }
 
       if (newNotif.type === "friend_request" && newNotif.related_user_id) {
@@ -629,6 +643,17 @@ export default function Home() {
     if (squad) {
       setSelectedSquad({ ...squad, hasUnread: false });
       squadsHook.setAutoSelectSquadId(null);
+      readSquadIdsRef.current.add(squad.id);
+      db.markSquadNotificationsRead(squad.id).catch(() => {});
+      if (squad.hasUnread) {
+        squadsHook.setSquads((prev) => prev.map((s) => s.id === squad.id ? { ...s, hasUnread: false } : s));
+        notificationsHook.setUnreadSquadCount((prev) => Math.max(0, prev - 1));
+      }
+      const updatedNotifs = notificationsHook.notifications.map((n) =>
+        n.related_squad_id === squad.id ? { ...n, is_read: true } : n
+      );
+      notificationsHook.setNotifications(updatedNotifs);
+      notificationsHook.setUnreadCount(updatedNotifs.filter((n) => !n.is_read).length);
     }
   }, [squadsHook.autoSelectSquadId, squadsHook.squads]);
 
@@ -1203,11 +1228,19 @@ export default function Home() {
             onSelectSquad={(squad) => {
               setSelectedSquad(squad);
               setSquadChatOrigin("groups");
+              readSquadIdsRef.current.add(squad.id);
+              // Clear all notification state for this squad
+              db.markSquadNotificationsRead(squad.id).catch(() => {});
               if (squad.hasUnread) {
                 squadsHook.setSquads((prev) => prev.map((s) => s.id === squad.id ? { ...s, hasUnread: false } : s));
-                db.markSquadNotificationsRead(squad.id).catch(() => {});
                 notificationsHook.setUnreadSquadCount((prev) => Math.max(0, prev - 1));
               }
+              // Clear bell badge: mark squad notifications read locally and recompute count
+              const updatedNotifs = notificationsHook.notifications.map((n) =>
+                n.related_squad_id === squad.id ? { ...n, is_read: true } : n
+              );
+              notificationsHook.setNotifications(updatedNotifs);
+              notificationsHook.setUnreadCount(updatedNotifs.filter((n) => !n.is_read).length);
               if ("serviceWorker" in navigator) {
                 navigator.serviceWorker.getRegistration().then((reg) => {
                   reg?.getNotifications({ tag: `squad_message-${squad.id}` }).then((notifs) => {

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, type Dispatch, type SetStateAction } from "react";
+import { useState, useCallback, useEffect, type Dispatch, type SetStateAction, type MutableRefObject } from "react";
 import * as db from "@/lib/db";
 import type { Profile } from "@/lib/types";
 import type { Person, Event, InterestCheck, Squad } from "@/lib/ui-types";
@@ -100,9 +100,10 @@ interface UseSquadsParams {
   showToast: (msg: string) => void;
   onSquadCreated?: (squadId: string) => void;
   onAutoDown?: (eventId: string) => Promise<void>;
+  openSquadIdRef?: MutableRefObject<string | null>;
 }
 
-export function useSquads({ userId, isDemoMode, profile, setChecks, showToast, onSquadCreated, onAutoDown }: UseSquadsParams) {
+export function useSquads({ userId, isDemoMode, profile, setChecks, showToast, onSquadCreated, onAutoDown, openSquadIdRef }: UseSquadsParams) {
   const [squads, setSquads] = useState<Squad[]>([]);
   const [socialEvent, setSocialEvent] = useState<Event | null>(null);
   const [squadPoolMembers, setSquadPoolMembers] = useState<Person[]>([]);
@@ -194,9 +195,10 @@ export function useSquads({ userId, isDemoMode, profile, setChecks, showToast, o
     transformedSquads.sort((a, b) =>
       new Date(b.lastActivityAt!).getTime() - new Date(a.lastActivityAt!).getTime()
     );
-    // Preserve hasUnread flags from previous state
+    // Preserve hasUnread flags from previous state (skip currently-open squad)
     setSquads((prev) => {
       const unreadMap = new Map(prev.filter((s) => s.hasUnread).map((s) => [s.id, true]));
+      if (openSquadIdRef?.current) unreadMap.delete(openSquadIdRef.current);
       if (unreadMap.size === 0) return transformedSquads;
       return transformedSquads.map((s) => unreadMap.has(s.id) ? { ...s, hasUnread: true } : s);
     });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1295,7 +1295,8 @@ export async function getUnreadSquadIds(): Promise<string[]> {
     .eq('user_id', user.id)
     .eq('is_read', false)
     .in('type', ['squad_message', 'squad_mention'])
-    .not('related_squad_id', 'is', null);
+    .not('related_squad_id', 'is', null)
+    .neq('related_user_id', user.id);  // exclude self-notifications
 
   if (error) return [];
   const ids = new Set(data.map((n) => n.related_squad_id as string));


### PR DESCRIPTION
## Summary
- Track read squad IDs so unread dots don't re-appear when data reloads (e.g. tab switch, visibility change)
- Auto-mark squad notifications as read when opening a squad chat from either feed or groups tab
- Clear bell badge count alongside squad dot when opening squad chats
- Skip currently-open squad when preserving `hasUnread` flags during squad list refresh
- Exclude self-notifications from unread squad ID count in `db.ts`

## Test plan
- [ ] Open a squad chat → unread dot clears and stays cleared after switching tabs
- [ ] Receive a squad message while viewing that squad → no badge appears
- [ ] Open notifications panel → bell badge clears to 0
- [ ] Send a message yourself → no self-notification unread dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)