### PR TITLE
refactor: init FeedContext

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,6 +20,7 @@ import EventLobby from "@/features/events/components/EventLobby";
 import AddModal from "@/features/events/components/CreateModal";
 import UserProfileOverlay from "@/features/friends/components/UserProfileOverlay";
 import FeedView from "@/features/feed/components/FeedView";
+import { FeedContext } from "@/features/checks/context/FeedContext";
 import FriendsModal from "@/features/friends/components/FriendsModal";
 import OnboardingFriendsPopup from "@/features/friends/components/OnboardingFriendsPopup";
 import CalendarView from "@/features/calendar/components/CalendarView";
@@ -1064,6 +1065,24 @@ export default function Home() {
 
 
   return (
+    <FeedContext.Provider value={{
+      checks: checksHook.checks,
+      myCheckResponses: checksHook.myCheckResponses,
+      hiddenCheckIds: checksHook.hiddenCheckIds,
+      pendingDownCheckIds: checksHook.pendingDownCheckIds,
+      newlyAddedCheckId: checksHook.newlyAddedCheckId,
+      leftChecks: checksHook.leftChecks,
+      respondToCheck: checksHook.respondToCheck,
+      acceptCoAuthorTag: checksHook.acceptCoAuthorTag,
+      declineCoAuthorTag: checksHook.declineCoAuthorTag,
+      hideCheck: checksHook.hideCheck,
+      unhideCheck: checksHook.unhideCheck,
+      redownFromLeft: checksHook.redownFromLeft,
+      events: eventsHook.events,
+      newlyAddedEventId: eventsHook.newlyAddedId,
+      toggleSave: eventsHook.toggleSave,
+      toggleDown: eventsHook.toggleDown,
+    }}>
     <div style={{ display: "flex", flexDirection: "column", height: "100dvh" }}>
       <div>
         <Header
@@ -1165,21 +1184,11 @@ export default function Home() {
         )}
         {feedLoaded && tab === "feed" && (
           <FeedView
-            checks={checksHook.checks}
-            setChecks={checksHook.setChecks}
-            myCheckResponses={checksHook.myCheckResponses}
-            setMyCheckResponses={checksHook.setMyCheckResponses}
-            events={events}
-            newlyAddedId={newlyAddedId}
-            newlyAddedCheckId={checksHook.newlyAddedCheckId}
             sharedCheckId={sharedCheckGlowId}
             friends={friendsHook.friends}
             userId={userId}
             isDemoMode={isDemoMode}
             profile={profile}
-            toggleSave={toggleSave}
-            toggleDown={toggleDown}
-            respondToCheck={checksHook.respondToCheck}
             startSquadFromCheck={squadsHook.startSquadFromCheck}
             loadRealData={loadRealData}
             showToast={showToast}
@@ -1198,12 +1207,6 @@ export default function Home() {
                 setTab("groups");
               }
             }}
-            hiddenCheckIds={checksHook.hiddenCheckIds}
-            pendingDownCheckIds={checksHook.pendingDownCheckIds}
-            onHideCheck={checksHook.hideCheck}
-            onUnhideCheck={checksHook.unhideCheck}
-            acceptCoAuthorTag={checksHook.acceptCoAuthorTag}
-            declineCoAuthorTag={checksHook.declineCoAuthorTag}
             onViewProfile={(uid) => setViewingUserId(uid)}
           />
         )}
@@ -1498,5 +1501,6 @@ export default function Home() {
         />
       )}
     </div>
+    </FeedContext.Provider>
   );
 }

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -9,6 +9,7 @@ import { useCheckComments } from "@/features/checks/hooks/useCheckComments";
 import CheckCommentsSection from "./CheckCommentsSection";
 import EditCheckModal from "./EditCheckModal";
 import CheckActionsSheet from "./CheckActionsSheet";
+import { useFeedContext } from "@/features/checks/context/FeedContext";
 
 function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: boolean; coAuthors?: { name: string }[] }) {
   const tokenRe = /(https?:\/\/[^\s),]+|@\S+)/g;
@@ -52,18 +53,9 @@ export interface CheckCardProps {
   isDemoMode: boolean;
   profile: Profile | null;
   friends: Friend[];
-  myCheckResponses: Record<string, "down" | "waitlist">;
-  setMyCheckResponses: React.Dispatch<React.SetStateAction<Record<string, "down" | "waitlist">>>;
-  setChecks: React.Dispatch<React.SetStateAction<InterestCheck[]>>;
-  pendingDownCheckIds: Set<string>;
-  newlyAddedCheckId: string | null;
   sharedCheckId?: string | null;
   initialCommentCount: number;
-  respondToCheck: (checkId: string) => void;
   startSquadFromCheck: (check: InterestCheck) => Promise<void>;
-  acceptCoAuthorTag: (checkId: string) => Promise<void>;
-  declineCoAuthorTag: (checkId: string) => Promise<void>;
-  onHideCheck: (checkId: string) => void;
   onNavigateToGroups: (squadId?: string) => void;
   onViewProfile?: (userId: string) => void;
   showToast: (msg: string) => void;
@@ -76,23 +68,23 @@ export default function CheckCard({
   isDemoMode,
   profile,
   friends,
-  myCheckResponses,
-  setMyCheckResponses,
-  setChecks,
-  pendingDownCheckIds,
-  newlyAddedCheckId,
   sharedCheckId,
   initialCommentCount,
-  respondToCheck,
   startSquadFromCheck,
-  acceptCoAuthorTag,
-  declineCoAuthorTag,
-  onHideCheck,
   onNavigateToGroups,
   onViewProfile,
   showToast,
   loadRealData,
 }: CheckCardProps) {
+  const {
+    myCheckResponses,
+    pendingDownCheckIds,
+    newlyAddedCheckId,
+    respondToCheck,
+    acceptCoAuthorTag,
+    declineCoAuthorTag,
+    hideCheck,
+  } = useFeedContext();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
@@ -206,7 +198,7 @@ export default function CheckCard({
               </span>
               {!check.isYours && !check.isCoAuthor && (
                 <button
-                  onClick={(e) => { e.stopPropagation(); onHideCheck(check.id); }}
+                  onClick={(e) => { e.stopPropagation(); hideCheck(check.id); }}
                   className="bg-transparent border-none text-neutral-700 py-0.5 px-1 font-mono text-xs cursor-pointer leading-none"
                   title="Hide this check"
                 >✕</button>
@@ -298,8 +290,6 @@ export default function CheckCard({
                   <button
                     onClick={() => {
                       if (myCheckResponses[check.id] === "down" || myCheckResponses[check.id] === "waitlist") {
-                        setMyCheckResponses(prev => { const next = { ...prev }; delete next[check.id]; return next; });
-                        setChecks(prev => prev.map(c => c.id === check.id ? { ...c, responses: c.responses.filter(r => r.name !== "You"), inSquad: undefined } : c));
                         if (!isDemoMode && check.id) {
                           db.removeCheckResponse(check.id)
                             .then(() => loadRealData())
@@ -429,19 +419,19 @@ export default function CheckCard({
         onEdit={() => { setActionsSheetOpen(false); setEditModalOpen(true); }}
         onArchive={async () => {
           setActionsSheetOpen(false);
-          setChecks(prev => prev.filter(c => c.id !== check.id));
           if (!isDemoMode) {
             try { await db.archiveInterestCheck(check.id); } catch (err) { logError("archiveCheck", err, { checkId: check.id }); }
           }
           showToast("Check archived");
+          await loadRealData();
         }}
         onDelete={async () => {
           setActionsSheetOpen(false);
-          setChecks(prev => prev.filter(c => c.id !== check.id));
           if (!isDemoMode) {
             try { await db.deleteInterestCheck(check.id); } catch (err) { logError("deleteCheck", err, { checkId: check.id }); }
           }
           showToast("Check removed");
+          await loadRealData();
         }}
       />
 
@@ -451,10 +441,6 @@ export default function CheckCard({
         onClose={() => setEditModalOpen(false)}
         friends={friendsList}
         onSave={async (updates) => {
-          setChecks(prev => prev.map(c => c.id === check.id
-            ? { ...c, text: updates.text, eventDate: updates.eventDate ?? undefined, eventDateLabel: updates.eventDateLabel ?? undefined, eventTime: updates.eventTime ?? undefined, dateFlexible: updates.dateFlexible, timeFlexible: updates.timeFlexible }
-            : c
-          ));
           setEditModalOpen(false);
           if (!isDemoMode) {
             try {
@@ -464,6 +450,7 @@ export default function CheckCard({
             } catch (err) { logError("updateCheck", err, { checkId: check.id }); showToast("Failed to save changes"); return; }
           }
           showToast("Check updated");
+          await loadRealData();
         }}
       />
     </>

--- a/src/features/checks/context/FeedContext.tsx
+++ b/src/features/checks/context/FeedContext.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { Event, InterestCheck } from "@/lib/ui-types";
+
+export interface FeedContextValue {
+  // — Check data —
+  checks: InterestCheck[];
+  myCheckResponses: Record<string, "down" | "waitlist">;
+  hiddenCheckIds: Set<string>;
+  pendingDownCheckIds: Set<string>;
+  newlyAddedCheckId: string | null;
+  leftChecks: InterestCheck[];
+
+  // — Event data —
+  events: Event[];
+  newlyAddedEventId: string | null;
+
+  // — Check actions —
+  respondToCheck: (checkId: string) => void;
+  acceptCoAuthorTag: (checkId: string) => Promise<void>;
+  declineCoAuthorTag: (checkId: string) => Promise<void>;
+  hideCheck: (checkId: string) => void;
+  unhideCheck: (checkId: string) => void;
+  redownFromLeft: (checkId: string) => void;
+
+  // — Event actions —
+  toggleSave: (eventId: string) => void;
+  toggleDown: (eventId: string) => Promise<void>;
+}
+
+export const FeedContext = createContext<FeedContextValue | null>(null);
+
+export function useFeedContext(): FeedContextValue {
+  const ctx = useContext(FeedContext);
+  if (!ctx) throw new Error("useFeedContext must be used inside FeedContext.Provider");
+  return ctx;
+}

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -7,6 +7,7 @@ import type { Event, InterestCheck, Friend } from "@/lib/ui-types";
 import EventCard from "@/features/events/components/EventCard";
 import CheckCard from "@/features/checks/components/CheckCard";
 import FeedEmptyState from "./FeedEmptyState";
+import { useFeedContext } from "@/features/checks/context/FeedContext";
 
 function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: boolean; coAuthors?: { name: string }[] }) {
   const tokenRe = /(https?:\/\/[^\s),]+|@\S+)/g;
@@ -43,21 +44,11 @@ function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: b
 }
 
 export interface FeedViewProps {
-  checks: InterestCheck[];
-  setChecks: React.Dispatch<React.SetStateAction<InterestCheck[]>>;
-  myCheckResponses: Record<string, "down" | "waitlist">;
-  setMyCheckResponses: React.Dispatch<React.SetStateAction<Record<string, "down" | "waitlist">>>;
-  events: Event[];
-  newlyAddedId: string | null;
-  newlyAddedCheckId: string | null;
   sharedCheckId?: string | null;
   friends: Friend[];
   userId: string | null;
   isDemoMode: boolean;
   profile: Profile | null;
-  toggleSave: (id: string) => void;
-  toggleDown: (id: string) => void;
-  respondToCheck: (checkId: string) => void;
   startSquadFromCheck: (check: InterestCheck) => Promise<void>;
   loadRealData: () => Promise<void>;
   showToast: (msg: string) => void;
@@ -66,31 +57,15 @@ export interface FeedViewProps {
   onOpenAdd: () => void;
   onOpenFriends: (tab?: "friends" | "add") => void;
   onNavigateToGroups: (squadId?: string) => void;
-  hiddenCheckIds: Set<string>;
-  pendingDownCheckIds: Set<string>;
-  onHideCheck: (checkId: string) => void;
-  onUnhideCheck: (checkId: string) => void;
-  acceptCoAuthorTag: (checkId: string) => Promise<void>;
-  declineCoAuthorTag: (checkId: string) => Promise<void>;
   onViewProfile?: (userId: string) => void;
 }
 
 export default function FeedView({
-  checks,
-  setChecks,
-  myCheckResponses,
-  setMyCheckResponses,
-  events,
-  newlyAddedId,
-  newlyAddedCheckId,
   sharedCheckId,
   friends,
   userId,
   isDemoMode,
   profile,
-  toggleSave,
-  toggleDown,
-  respondToCheck,
   startSquadFromCheck,
   loadRealData,
   showToast,
@@ -99,14 +74,18 @@ export default function FeedView({
   onOpenAdd,
   onOpenFriends,
   onNavigateToGroups,
-  hiddenCheckIds,
-  pendingDownCheckIds,
-  onHideCheck,
-  onUnhideCheck,
-  acceptCoAuthorTag,
-  declineCoAuthorTag,
   onViewProfile,
 }: FeedViewProps) {
+  const {
+    checks,
+    hiddenCheckIds,
+    events,
+    newlyAddedEventId,
+    unhideCheck,
+    toggleSave,
+    toggleDown,
+  } = useFeedContext();
+
   const [showHidden, setShowHidden] = useState(false);
   const [commentCounts, setCommentCounts] = useState<Record<string, number>>({});
 
@@ -147,18 +126,9 @@ export default function FeedView({
                 isDemoMode={isDemoMode}
                 profile={profile}
                 friends={friends}
-                myCheckResponses={myCheckResponses}
-                setMyCheckResponses={setMyCheckResponses}
-                setChecks={setChecks}
-                pendingDownCheckIds={pendingDownCheckIds}
-                newlyAddedCheckId={newlyAddedCheckId}
                 sharedCheckId={sharedCheckId}
                 initialCommentCount={commentCounts[check.id] ?? 0}
-                respondToCheck={respondToCheck}
                 startSquadFromCheck={startSquadFromCheck}
-                acceptCoAuthorTag={acceptCoAuthorTag}
-                declineCoAuthorTag={declineCoAuthorTag}
-                onHideCheck={onHideCheck}
                 onNavigateToGroups={onNavigateToGroups}
                 onViewProfile={onViewProfile}
                 showToast={showToast}
@@ -196,7 +166,7 @@ export default function FeedView({
                         </p>
                       </div>
                       <button
-                        onClick={() => onUnhideCheck(check.id)}
+                        onClick={() => unhideCheck(check.id)}
                         className="bg-transparent border border-neutral-800 rounded-lg py-1.5 px-2.5 font-mono text-tiny text-neutral-500 cursor-pointer shrink-0 ml-3"
                       >Unhide</button>
                     </div>
@@ -220,7 +190,7 @@ export default function FeedView({
                 onToggleDown={() => toggleDown(e.id)}
                 onOpenSocial={() => onOpenSocial(e)}
                 onLongPress={(e.createdBy === userId || !e.createdBy || isDemoMode) ? () => onEditEvent(e) : undefined}
-                isNew={e.id === newlyAddedId}
+                isNew={e.id === newlyAddedEventId}
               />
             ))}
           </>


### PR DESCRIPTION
First part of porting checks/events state to FeedContext

Ideally, should be using `useReducer` to manage state and surface dispatcher. Coming in another PR