### PR TITLE
Simplify shared check onboarding (4 screens instead of 7)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -927,6 +927,13 @@ export default function Home() {
               }
             }}
             onViewProfile={(uid) => setViewingUserId(uid)}
+            showInstallBanner={
+              !onboarding.installDismissed
+              || (onboarding.installDismissed && pushSupported && !pushEnabled && !onboarding.notifBannerDismissed)
+            }
+            installBannerVariant={!onboarding.installDismissed ? "install" : "notifications"}
+            onDismissInstallBanner={!onboarding.installDismissed ? onboarding.dismissInstall : onboarding.dismissNotifBanner}
+            onEnableNotifications={handleTogglePush}
           />
         )}
         {feedLoaded && tab === "calendar" && (

--- a/src/features/auth/hooks/useOnboarding.tsx
+++ b/src/features/auth/hooks/useOnboarding.tsx
@@ -105,6 +105,14 @@ interface UseOnboardingReturn {
     checkAuthorId: string | null;
     onDone: () => Promise<void>;
   };
+  /** Whether the install banner should show in feed */
+  installDismissed: boolean;
+  /** Dismiss the install banner */
+  dismissInstall: () => void;
+  /** Whether the notifications banner has been dismissed */
+  notifBannerDismissed: boolean;
+  /** Dismiss the notifications banner */
+  dismissNotifBanner: () => void;
 }
 
 // ─── Hook ────────────────────────────────────────────────────────────────────
@@ -135,6 +143,12 @@ export function useOnboarding({
       !isIOSNotStandalone() || localStorage.getItem("pwa-install-dismissed") === "1"
     );
   }, []);
+
+  // ─── Notifications banner ────────────────────────────────────────────
+  const [notifBannerDismissed, setNotifBannerDismissed] = useState(() => {
+    if (typeof window !== "undefined") return localStorage.getItem("notif-banner-dismissed") === "1";
+    return true;
+  });
 
   // ─── Onboarding state ─────────────────────────────────────────────────
   const [profileSetupDone, setProfileSetupDone] = useState(false);
@@ -167,12 +181,24 @@ export function useOnboarding({
   useEffect(() => {
     if (!isLoggedIn || !userId || !profile?.onboarded) return;
     const checkId = localStorage.getItem("pendingCheckId");
-    if (!checkId) return;
-    localStorage.removeItem("pendingCheckId");
-    setPendingSharedCheckId(checkId);
-    setTab("feed");
-    setNewlyAddedCheckId(checkId);
-    setTimeout(() => setNewlyAddedCheckId(null), 3000);
+    if (checkId) {
+      localStorage.removeItem("pendingCheckId");
+      setPendingSharedCheckId(checkId);
+      setTab("feed");
+      setNewlyAddedCheckId(checkId);
+      setTimeout(() => setNewlyAddedCheckId(null), 3000);
+      return;
+    }
+    // PWA recovery: no localStorage, check DB for referred_by_check_id
+    if (!activeSharedCheckId) {
+      (async () => {
+        const referralId = await db.getReferralCheckId();
+        if (referralId) {
+          setPendingSharedCheckId(referralId);
+          setTab("feed");
+        }
+      })();
+    }
   }, [isLoggedIn, userId, profile?.onboarded]);
 
   // Inject shared check into feed once feedLoaded
@@ -253,9 +279,10 @@ export function useOnboarding({
     }
     setOnboardingFriendGate(false);
     setOnboardingCheckAuthorId(null);
-    if (!localStorage.getItem("pendingCheckId") && !activeSharedCheckId && checks.length === 0) {
+    const hasSharedCheck = !!localStorage.getItem("pendingCheckId") || !!activeSharedCheckId || !!pendingSharedCheckId;
+    if (!hasSharedCheck && checks.length === 0) {
       setShowFirstCheck(true);
-    } else {
+    } else if (!hasSharedCheck) {
       setShowAddGlow(true);
       localStorage.setItem("showAddGlow", "true");
     }
@@ -268,17 +295,27 @@ export function useOnboarding({
     setInstallDismissed(true);
   };
 
+  const dismissNotifBanner = () => {
+    localStorage.setItem("notif-banner-dismissed", "1");
+    setNotifBannerDismissed(true);
+  };
+
   const computeOnboardingScreen = (): ReactNode | null => {
     if (isLoading) {
       return <div style={{ minHeight: "100vh", background: "#111" }} />;
     }
 
+    // Eagerly persist pendingCheck from URL to localStorage (before any gate checks)
+    if (typeof window !== "undefined") {
+      const urlCheckId = new URLSearchParams(window.location.search).get("pendingCheck");
+      if (urlCheckId && !localStorage.getItem("pendingCheckId")) {
+        localStorage.setItem("pendingCheckId", urlCheckId);
+      }
+    }
+
     // Normal visit (no shared check): show install prompt before auth
-    const hasPendingCheck = typeof window !== "undefined" && (
-      !!localStorage.getItem("pendingCheckId") ||
-      new URLSearchParams(window.location.search).has("pendingCheck")
-    );
-    if (!installDismissed && !hasPendingCheck) {
+    const hasPendingCheck = typeof window !== "undefined" && !!localStorage.getItem("pendingCheckId");
+    if (!isLoggedIn && !installDismissed && !hasPendingCheck) {
       return <IOSInstallScreen onComplete={dismissInstall} />;
     }
 
@@ -301,13 +338,13 @@ export function useOnboarding({
     // After profile setup: onboarding gates
     if (profile && !profile.onboarded && (profileSetupDone || !!profile.display_name) && !onboardingFriendGate) {
       const pendingCheckId = localStorage.getItem("pendingCheckId");
+      const isSharedCheckFlow = !!pendingCheckId;
       const isInPWA = typeof window !== "undefined" && (
         (window.navigator as unknown as { standalone?: boolean }).standalone === true ||
         window.matchMedia("(display-mode: standalone)").matches
       );
-
-      // Shared check in browser: persist referral then show install prompt
-      if (pendingCheckId && !isInPWA && !installDismissed) {
+      // Shared check flow: fire-and-forget referral persist, skip install/notifications
+      if (isSharedCheckFlow) {
         if (!referralPersistedRef.current) {
           referralPersistedRef.current = true;
           (async () => {
@@ -321,19 +358,23 @@ export function useOnboarding({
             }
           })();
         }
-        return <IOSInstallScreen onComplete={dismissInstall} />;
-      }
+        // Fall through to feed wait → friend gate (no install/notifications screens)
+      } else {
+        // Normal flow: show install prompt and notifications screen
+        if (!isInPWA && !installDismissed) {
+          return <IOSInstallScreen onComplete={dismissInstall} />;
+        }
 
-      // Show notifications screen (PWA or after dismissing install prompt)
-      if (!notificationsDone && (isInPWA || (pendingCheckId && installDismissed))) {
-        return (
-          <EnableNotificationsScreen
-            onComplete={async () => {
-              localStorage.setItem("pushAutoPrompted", "1");
-              setNotificationsDone(true);
-            }}
-          />
-        );
+        if (!notificationsDone && isInPWA) {
+          return (
+            <EnableNotificationsScreen
+              onComplete={async () => {
+                localStorage.setItem("pushAutoPrompted", "1");
+                setNotificationsDone(true);
+              }}
+            />
+          );
+        }
       }
 
       // Wait for feed data before setting up friend gate
@@ -404,5 +445,9 @@ export function useOnboarding({
       checkAuthorId: onboardingCheckAuthorId,
       onDone: handleFriendGateDone,
     },
+    installDismissed,
+    dismissInstall,
+    notifBannerDismissed,
+    dismissNotifBanner,
   };
 }

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -7,6 +7,7 @@ import type { Event, InterestCheck, Friend } from "@/lib/ui-types";
 import EventCard from "@/features/events/components/EventCard";
 import CheckCard from "@/features/checks/components/CheckCard";
 import FeedEmptyState from "./FeedEmptyState";
+import InstallBanner from "./InstallBanner";
 import { useFeedContext } from "@/features/checks/context/FeedContext";
 
 function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: boolean; coAuthors?: { name: string }[] }) {
@@ -58,6 +59,10 @@ export interface FeedViewProps {
   onOpenFriends: (tab?: "friends" | "add") => void;
   onNavigateToGroups: (squadId?: string) => void;
   onViewProfile?: (userId: string) => void;
+  showInstallBanner?: boolean;
+  installBannerVariant?: "install" | "notifications";
+  onDismissInstallBanner?: () => void;
+  onEnableNotifications?: () => void;
 }
 
 export default function FeedView({
@@ -75,6 +80,10 @@ export default function FeedView({
   onOpenFriends,
   onNavigateToGroups,
   onViewProfile,
+  showInstallBanner,
+  installBannerVariant = "install",
+  onDismissInstallBanner,
+  onEnableNotifications,
 }: FeedViewProps) {
   const {
     checks,
@@ -112,6 +121,13 @@ export default function FeedView({
 
   return (
     <>
+      {showInstallBanner && onDismissInstallBanner && (
+        <InstallBanner
+          variant={installBannerVariant}
+          onDismiss={onDismissInstallBanner}
+          onEnableNotifications={onEnableNotifications}
+        />
+      )}
       <div className="pt-2 px-4">
         {checks.length > 0 && (
           <div className="mb-6">

--- a/src/features/feed/components/InstallBanner.tsx
+++ b/src/features/feed/components/InstallBanner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+interface InstallBannerProps {
+  variant: "install" | "notifications";
+  onDismiss: () => void;
+  onEnableNotifications?: () => void;
+}
+
+export default function InstallBanner({ variant, onDismiss, onEnableNotifications }: InstallBannerProps) {
+  return (
+    <div className="mx-4 mb-4 rounded-2xl border border-dt/20 bg-dt/[0.08] px-4 py-3 flex items-start justify-between gap-3">
+      <div className="min-w-0">
+        {variant === "install" ? (
+          <>
+            <p className="font-mono text-xs text-dt m-0 mb-1 font-bold uppercase tracking-[0.08em]">
+              Add to Home Screen
+            </p>
+            <p className="font-mono text-[11px] text-neutral-400 m-0 leading-relaxed">
+              Get notifications — tap{" "}
+              <span className="inline-block align-middle text-sm">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-dt inline-block">
+                  <path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8" /><polyline points="16 6 12 2 8 6" /><line x1="12" y1="2" x2="12" y2="15" />
+                </svg>
+              </span>{" "}
+              then &ldquo;Add to Home Screen&rdquo;
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="font-mono text-xs text-dt m-0 mb-1 font-bold uppercase tracking-[0.08em]">
+              Enable Notifications
+            </p>
+            <p className="font-mono text-[11px] text-neutral-400 m-0 leading-relaxed">
+              Get notified when friends respond to your checks
+            </p>
+            {onEnableNotifications && (
+              <button
+                onClick={onEnableNotifications}
+                className="mt-2 bg-dt text-black font-mono text-[11px] font-bold uppercase tracking-[0.08em] border-none rounded-lg py-1.5 px-3 cursor-pointer"
+              >
+                Turn on
+              </button>
+            )}
+          </>
+        )}
+      </div>
+      <button
+        onClick={onDismiss}
+        className="shrink-0 bg-transparent border-none text-neutral-500 font-mono text-xs cursor-pointer p-1"
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Shared check users now skip IOSInstallScreen and EnableNotificationsScreen, going Auth → Profile → FriendGate → Feed instead of 7 blocking screens
- Install/notification prompts deferred to dismissable banners in the feed (install variant for Safari, notifications variant for PWA)
- PWA recovery: shared check loaded from `referred_by_check_id` in DB when localStorage is empty
- Eagerly persists `pendingCheck` URL param to localStorage during render to avoid race conditions
- Suppresses add-glow and FirstCheckScreen for shared check users

## Test plan
- [ ] **Shared check onboarding**: Open check link → auth → profile → friend gate (check author shown) → feed with check + install banner. No install/notifications screens.
- [ ] **Banner dismiss**: Tap dismiss → gone, doesn't reappear on refresh
- [ ] **Normal onboarding**: Open app directly (no check link) → IOSInstall → auth → profile → notifications → friend gate → FirstCheck (unchanged)
- [ ] **Already logged in**: Open check link → check appears in feed with glow
- [ ] **Browser→PWA**: Complete shared check onboarding in Safari → install PWA → open PWA → shared check persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)