### PR TITLE
fix: prevent social preview flicker on event cards

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -217,8 +217,8 @@ const EventCard = ({
           )}
         </div>
 
-        {/* Social preview */}
-        {(event.peopleDown.length > 0 || event.isDown) && (
+        {/* Social preview — only show once social data is hydrated (peopleDown populated or user in pool) */}
+        {(event.peopleDown.length > 0 || event.userInPool) && (
           <div
             onClick={onOpenSocial}
             style={{


### PR DESCRIPTION
## Summary
The social preview section on event cards was showing immediately when `isDown` was true (before `peopleDown` data loaded), causing a flicker from "Looking for a squad?" to the actual people list.

Now only renders when social data is actually available (`peopleDown.length > 0` or `userInPool`).

## Test plan
- [ ] Mark yourself as down on an event, reload — verify no flicker
- [ ] Verify social preview still appears once people data loads
- [ ] Verify crew pool state still shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)