### PR TITLE
fix: prevent scroll-up black space in squad chat on older iOS

### DIFF
--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -146,9 +146,18 @@ const SquadChat = ({
       if (inputFocused) {
         chatContainerRef.current.style.transition = "none";
         chatContainerRef.current.style.height = `${vv.height}px`;
+        // Pin body to prevent older iOS from scrolling behind the fixed container
+        document.body.style.position = "fixed";
+        document.body.style.width = "100%";
+        document.body.style.top = "0";
+        document.body.style.overflow = "hidden";
         window.scrollTo(0, 0);
         { const p = messagesEndRef.current?.parentElement; if (p) p.scrollTop = p.scrollHeight; }
       } else {
+        document.body.style.position = "";
+        document.body.style.width = "";
+        document.body.style.top = "";
+        document.body.style.overflow = "";
         chatContainerRef.current.style.transition = "height 0.15s ease-out";
         chatContainerRef.current.style.height = "100dvh";
       }
@@ -184,6 +193,11 @@ const SquadChat = ({
       document.removeEventListener("focusout", onFocusOut);
       vv.removeEventListener("resize", onResize);
       clearTimeout(timeoutId);
+      // Restore body scroll in case unmounted while input focused
+      document.body.style.position = "";
+      document.body.style.width = "";
+      document.body.style.top = "";
+      document.body.style.overflow = "";
     };
   }, []);
 
@@ -413,6 +427,7 @@ const SquadChat = ({
         zIndex: 50,
         background: color.bg,
         overflow: "hidden",
+        overscrollBehavior: "none",
         transform: (closing || entering) ? "translateX(100%)" : `translateX(${dragX}px)`,
         transition: closing ? "transform 0.25s ease-in" : (entering || dragX === 0) ? "transform 0.3s ease-out" : "none",
       }}


### PR DESCRIPTION
## Summary
On older iOS versions, focusing the message input in squad chat allowed the user to scroll up and reveal empty black space above the chat. This happened because the iOS keyboard pushed the body scroll position while the chat container was position:fixed.

Fix:
- Pin `document.body` with `position: fixed; overflow: hidden` when the input is focused, preventing the body from scrolling
- Restore body styles on blur and component unmount
- Add `overscroll-behavior: none` to the chat container to prevent rubber-band scrolling

## Test plan
- [ ] Open squad chat on older iOS (< 18), focus message input, try scrolling up — should not reveal black space
- [ ] Verify messages still scroll normally while input is focused
- [ ] Verify keyboard dismiss works and chat returns to full height
- [ ] Verify no scroll issues on latest iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)