### PR TITLE
fix: DAU showing 0 — use server-side RPC instead of truncated row fetch

### DIFF
--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
   // Run queries in parallel
-  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes, dauPingsRes, pushSubscribersRes] = await Promise.all([
+  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes, dauRpcRes, pushSubscribersRes] = await Promise.all([
     admin.from('profiles').select('*', { count: 'exact', head: true }),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', true),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', false),
@@ -55,26 +55,17 @@ export async function GET(request: NextRequest) {
       .gte('created_at', since7d)
       .order('created_at', { ascending: false })
       .limit(10000),
-    admin.from('version_pings')
-      .select('user_id, created_at')
-      .gte('created_at', since30d)
-      .limit(50000),
+    admin.rpc('get_dau', { p_since: since30d, p_tz: tz }),
     admin.from('push_subscriptions')
       .select('user_id'),
   ]);
 
-  // Compute DAU from version_pings (30 days), grouped by local date
-  const dauSets: Record<string, Set<string>> = {};
-  if (dauPingsRes.data) {
-    for (const row of dauPingsRes.data) {
-      const date = toLocalDate(row.created_at, tz);
-      if (!dauSets[date]) dauSets[date] = new Set();
-      dauSets[date].add(row.user_id);
-    }
-  }
+  // DAU from RPC — already grouped by date
   const dauByDate: Record<string, number> = {};
-  for (const [date, users] of Object.entries(dauSets)) {
-    dauByDate[date] = users.size;
+  if (dauRpcRes.data) {
+    for (const row of dauRpcRes.data as { date: string; unique_users: number }[]) {
+      dauByDate[row.date] = row.unique_users;
+    }
   }
 
   // Group signups by local date

--- a/supabase/migrations/20260324000002_dau_rpc.sql
+++ b/supabase/migrations/20260324000002_dau_rpc.sql
@@ -1,0 +1,15 @@
+-- RPC to compute DAU from version_pings, grouped by date in a given timezone
+-- Returns rows of (date TEXT, unique_users BIGINT)
+CREATE OR REPLACE FUNCTION public.get_dau(p_since TIMESTAMPTZ, p_tz TEXT DEFAULT 'America/New_York')
+RETURNS TABLE(date TEXT, unique_users BIGINT) AS $$
+BEGIN
+  RETURN QUERY
+    SELECT
+      (created_at AT TIME ZONE p_tz)::date::text AS date,
+      COUNT(DISTINCT user_id) AS unique_users
+    FROM public.version_pings
+    WHERE created_at >= p_since
+    GROUP BY 1
+    ORDER BY 1;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
DAU was showing 0 because the version_pings query used `.limit(50000)` but Supabase's API row limit (default 1000) silently truncated results. With 8500+ pings in 30 days, only the most recent 1000 were returned, leaving most days empty.

Fix: new `get_dau` RPC function that computes `COUNT(DISTINCT user_id) GROUP BY date` directly in Postgres, returning only aggregated rows (~30 max). No row limit issues.

## Test plan
- [ ] Run migration on prod Supabase
- [ ] Check admin dashboard — DAU should now show actual numbers
- [ ] Verify timezone handling (dates should match local time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)