### PR TITLE
fix: prevent social preview flicker on event cards (v2)

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -217,8 +217,8 @@ const EventCard = ({
           )}
         </div>
 
-        {/* Social preview — only show once social data is hydrated (peopleDown populated or user in pool) */}
-        {(event.peopleDown.length > 0 || event.userInPool) && (
+        {/* Social preview */}
+        {(event.peopleDown.length > 0 || event.userInPool || event.isDown) && (
           <div
             onClick={onOpenSocial}
             style={{
@@ -265,8 +265,8 @@ const EventCard = ({
                 )}
                 <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
                   {event.peopleDown.length === 0 && !event.userInPool ? (
-                    <span style={{ fontFamily: font.mono, fontSize: 11, color: color.pool }}>
-                      Looking for a squad?
+                    <span style={{ fontFamily: font.mono, fontSize: 11, color: event.isDown ? color.accent : color.pool }}>
+                      {event.isDown ? "You're down" : "Looking for a squad?"}
                     </span>
                   ) : hasPool || event.userInPool ? (
                     <>


### PR DESCRIPTION
## Summary
Supersedes #170. The previous fix hid the section until social data loaded, but that caused the entire button to disappear and reappear.

Now when `isDown` is true but `peopleDown` hasn't loaded yet, shows "You're down" as a stable placeholder. Once social data hydrates, it smoothly transitions to the full people list. "Looking for a squad?" only shows when the user is NOT down.

## Test plan
- [ ] Mark yourself as down on an event, reload — section shows "You're down" immediately, no flicker
- [ ] Once social data loads, transitions to full people list
- [ ] When not down, section still hidden until data loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)