### PR TITLE
feat: crew pool visibility inherits from event

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -302,7 +302,19 @@ const EventCard = ({
                 <div style={{ display: "flex", flexDirection: "column", gap: 2, minWidth: 0 }}>
                   {event.peopleDown.length === 0 && !event.userInPool ? (
                     <span style={{ fontFamily: font.mono, fontSize: 11, color: color.pool }}>
-                      Looking for a squad?
+                      Looking for a squad?{" "}
+                      <span style={{
+                        fontSize: 9,
+                        fontWeight: 700,
+                        padding: "1px 4px",
+                        borderRadius: 3,
+                        background: event.isPublic ? "rgba(255,255,255,0.06)" : "rgba(232,255,90,0.12)",
+                        color: event.isPublic ? color.faint : color.accent,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.06em",
+                      }}>
+                        {event.isPublic ? "public" : "friends"}
+                      </span>
                     </span>
                   ) : hasPool || event.userInPool ? (
                     <>

--- a/src/features/events/components/EventLobby.tsx
+++ b/src/features/events/components/EventLobby.tsx
@@ -336,16 +336,32 @@ const EventLobby = ({
         >
           Who&rsquo;s down?
         </h3>
-        <p
-          style={{
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: poolCount > 0 ? 12 : 24 }}>
+          <p
+            style={{
+              fontFamily: font.mono,
+              fontSize: 11,
+              color: color.dim,
+              margin: 0,
+            }}
+          >
+            {event.title}
+          </p>
+          <span style={{
             fontFamily: font.mono,
-            fontSize: 11,
-            color: color.dim,
-            marginBottom: poolCount > 0 ? 12 : 24,
-          }}
-        >
-          {event.title}
-        </p>
+            fontSize: 9,
+            fontWeight: 700,
+            padding: "2px 6px",
+            borderRadius: 4,
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            background: event.isPublic ? "rgba(255,255,255,0.08)" : "rgba(232,255,90,0.15)",
+            color: event.isPublic ? color.dim : color.accent,
+            flexShrink: 0,
+          }}>
+            {event.isPublic ? "public" : "friends & FoF"}
+          </span>
+        </div>
 
         {poolCount > 0 && (
           <div

--- a/supabase/migrations/20260324000003_crew_pool_visibility.sql
+++ b/supabase/migrations/20260324000003_crew_pool_visibility.sql
@@ -1,0 +1,18 @@
+-- Update crew_pool SELECT policy to inherit visibility from the parent event.
+-- Public events: anyone can see pool members.
+-- Friends-only events: only friends & FoF of the event creator can see pool members.
+
+DROP POLICY IF EXISTS "Anyone can view crew pool" ON public.crew_pool;
+
+CREATE POLICY "Crew pool visible based on event visibility" ON public.crew_pool
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.events e
+      WHERE e.id = crew_pool.event_id
+      AND (
+        e.visibility = 'public'
+        OR e.created_by = (SELECT auth.uid())
+        OR public.is_friend_or_fof((SELECT auth.uid()), e.created_by)
+      )
+    )
+  );


### PR DESCRIPTION
## Summary
- **RLS**: crew_pool SELECT policy now checks the parent event's visibility. Public events = anyone can see pool. Friends-only events = only friends & FoF of the event creator can see pool members.
- **EventLobby**: visibility chip ("PUBLIC" or "FRIENDS & FOF") shown next to the event title
- **EventCard**: small visibility chip on the "Looking for a squad?" prompt so users know who can see them before opening the lobby

### Migration
Updates crew_pool SELECT policy to join against events table and check visibility + `is_friend_or_fof()`.

## Test plan
- [ ] Run migration on prod
- [ ] Public event: verify anyone can see pool members, chip says "PUBLIC"
- [ ] Friends-only event: verify only friends & FoF see pool, chip says "FRIENDS & FOF"
- [ ] Verify pool join/leave still works for both visibility types

🤖 Generated with [Claude Code](https://claude.com/claude-code)