### PR TITLE
feat: calendar sync — export and auto-subscribe

### DIFF
--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { getServiceClient } from "@/lib/supabase-admin";
+import { generateICSCalendar, type ICSEventParams } from "@/lib/ics";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ token: string }> },
+) {
+  const { token } = await params;
+
+  const supabase = getServiceClient();
+
+  // Look up user by calendar token
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("calendar_token", token)
+    .single();
+
+  if (profileError || !profile) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Fetch saved events
+  const { data: savedEvents } = await supabase
+    .from("saved_events")
+    .select("*, event:events(*)")
+    .eq("user_id", profile.id);
+
+  // Fetch interest check responses with event dates
+  const { data: checkResponses } = await supabase
+    .from("check_responses")
+    .select("*, check:interest_checks(*)")
+    .eq("user_id", profile.id)
+    .in("status", ["down", "waitlist"]);
+
+  const icsEvents: ICSEventParams[] = [];
+
+  // Add saved events
+  for (const se of savedEvents ?? []) {
+    const ev = se.event;
+    if (!ev?.date) continue;
+    icsEvents.push({
+      uid: ev.id,
+      title: ev.title ?? "Untitled Event",
+      date: ev.date,
+      time: ev.time_display ?? undefined,
+      venue: ev.venue ?? undefined,
+    });
+  }
+
+  // Add interest checks with dates
+  for (const cr of checkResponses ?? []) {
+    const check = cr.check;
+    if (!check?.event_date) continue;
+    icsEvents.push({
+      uid: check.id,
+      title: check.text ?? "Interest Check",
+      date: check.event_date,
+      time: check.event_time ?? undefined,
+      venue: check.location ?? undefined,
+    });
+  }
+
+  const icsContent = generateICSCalendar(icsEvents);
+
+  return new NextResponse(icsContent, {
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Content-Disposition": 'inline; filename="downto.ics"',
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
+  });
+}

--- a/src/features/calendar/components/CalendarView.tsx
+++ b/src/features/calendar/components/CalendarView.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { font, color } from "@/lib/styles";
 import type { Event, InterestCheck } from "@/lib/ui-types";
 import EventCard from "@/features/events/components/EventCard";
+import { generateICSCalendar, downloadICS, buildGoogleCalendarUrl, type ICSEventParams } from "@/lib/ics";
+import * as db from "@/lib/db";
 
 const CHECK_DOT_COLOR = "#AF52DE";
 
@@ -34,6 +36,75 @@ const CalendarView = ({
 }) => {
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
   const [selectedDateKey, setSelectedDateKey] = useState<string | null>(null);
+  const [showSyncModal, setShowSyncModal] = useState(false);
+  const [syncSelected, setSyncSelected] = useState<Set<string>>(new Set());
+  const [syncTab, setSyncTab] = useState<"export" | "subscribe">("export");
+  const [calendarToken, setCalendarToken] = useState<string | null>(null);
+  const [tokenLoading, setTokenLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Convert Event or Check to ICS params
+  const eventToICS = (e: Event): ICSEventParams => ({
+    uid: e.id,
+    title: e.title,
+    date: e.rawDate ?? "",
+    time: e.time,
+    venue: e.venue,
+  });
+  const checkToICS = (c: InterestCheck): ICSEventParams => ({
+    uid: c.id,
+    title: c.text,
+    date: c.eventDate ?? "",
+    time: c.eventTime,
+    venue: c.location,
+  });
+
+  // Swipe-to-dismiss for sync modal
+  const syncTouchStartY = useRef(0);
+  const [syncDragOffset, setSyncDragOffset] = useState(0);
+  const syncScrollRef = useRef<HTMLDivElement>(null);
+  const syncIsDragging = useRef(false);
+  const [syncClosing, setSyncClosing] = useState(false);
+
+  const closeSyncModal = () => {
+    setSyncClosing(true);
+    setTimeout(() => { setShowSyncModal(false); setSyncClosing(false); setSyncDragOffset(0); }, 200);
+  };
+
+  const syncHandleSwipeStart = (e: React.TouchEvent) => {
+    syncTouchStartY.current = e.touches[0].clientY;
+    syncIsDragging.current = false;
+  };
+  const syncHandleSwipeMove = (e: React.TouchEvent) => {
+    const dy = e.touches[0].clientY - syncTouchStartY.current;
+    if (dy > 0) { syncIsDragging.current = true; setSyncDragOffset(dy); }
+  };
+  const syncHandleSwipeEnd = () => {
+    if (syncDragOffset > 60) closeSyncModal();
+    else setSyncDragOffset(0);
+    syncIsDragging.current = false;
+  };
+  const syncHandleScrollTouchStart = (e: React.TouchEvent) => {
+    syncTouchStartY.current = e.touches[0].clientY;
+    syncIsDragging.current = false;
+  };
+  const syncHandleScrollTouchMove = (e: React.TouchEvent) => {
+    const dy = e.touches[0].clientY - syncTouchStartY.current;
+    const atTop = syncScrollRef.current ? syncScrollRef.current.scrollTop <= 0 : true;
+    if (atTop && dy > 0) { syncIsDragging.current = true; e.preventDefault(); setSyncDragOffset(dy); }
+  };
+  const syncHandleScrollTouchEnd = () => {
+    if (syncIsDragging.current) syncHandleSwipeEnd();
+  };
+
+  const toggleSyncItem = (id: string) => {
+    setSyncSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   // Sync selectedEvent with latest events prop
   useEffect(() => {
@@ -49,6 +120,58 @@ const CalendarView = ({
   const calendarChecks = checks.filter(
     (c) => c.eventDate && (myCheckResponses[c.id] || c.authorId === userId)
   );
+
+  // All exportable items for sync modal
+  const allExportable: { id: string; label: string; sub: string; params: ICSEventParams }[] = [
+    ...saved.filter((e) => e.rawDate).map((e) => ({
+      id: e.id,
+      label: e.title,
+      sub: [e.date, e.time].filter(Boolean).join(" · "),
+      params: eventToICS(e),
+    })),
+    ...calendarChecks.filter((c) => c.eventDate).map((c) => ({
+      id: `check-${c.id}`,
+      label: c.text,
+      sub: [c.eventDate, c.eventTime].filter(Boolean).join(" · "),
+      params: checkToICS(c),
+    })),
+  ];
+
+  const openSyncModal = () => {
+    setSyncSelected(new Set(allExportable.map((e) => e.id)));
+    setSyncTab("export");
+    setCopied(false);
+    setShowSyncModal(true);
+    // Fetch calendar token for subscribe tab
+    if (!calendarToken && !tokenLoading) {
+      setTokenLoading(true);
+      db.getCalendarToken().then((t) => { setCalendarToken(t); setTokenLoading(false); }).catch(() => setTokenLoading(false));
+    }
+  };
+
+  const webcalUrl = calendarToken
+    ? `webcal://${typeof window !== "undefined" ? window.location.host : ""}/api/calendar/${calendarToken}`
+    : null;
+  const httpsCalUrl = calendarToken
+    ? `${typeof window !== "undefined" ? window.location.origin : ""}/api/calendar/${calendarToken}`
+    : null;
+
+  const copySubscribeUrl = async () => {
+    if (!webcalUrl) return;
+    try { await navigator.clipboard.writeText(webcalUrl); setCopied(true); setTimeout(() => setCopied(false), 2000); } catch {}
+  };
+
+  const handleSync = (target: "google" | "ics") => {
+    const selected = allExportable.filter((e) => syncSelected.has(e.id));
+    if (selected.length === 0) return;
+    if (target === "google" && selected.length === 1) {
+      window.open(buildGoogleCalendarUrl(selected[0].params), "_blank");
+    } else {
+      const cal = generateICSCalendar(selected.map((e) => e.params));
+      downloadICS("downto-calendar.ics", cal);
+    }
+    setShowSyncModal(false);
+  };
 
   // Build a 2-week grid starting from Monday of the current week
   const today = new Date();
@@ -268,15 +391,41 @@ const CalendarView = ({
 
       <div
         style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 12,
+        }}
+      >
+        <span style={{
           fontFamily: font.mono,
           fontSize: 10,
           textTransform: "uppercase",
           letterSpacing: "0.15em",
           color: color.dim,
-          marginBottom: 12,
-        }}
-      >
-        {countLabel}
+        }}>
+          {countLabel}
+        </span>
+        {totalItems > 0 && (
+          <button
+            onClick={openSyncModal}
+            style={{
+              background: "transparent",
+              border: `1px solid ${color.borderMid}`,
+              borderRadius: 8,
+              padding: "4px 10px",
+              fontFamily: font.mono,
+              fontSize: 9,
+              fontWeight: 700,
+              color: color.dim,
+              cursor: "pointer",
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+            }}
+          >
+            Sync
+          </button>
+        )}
       </div>
 
       {totalItems === 0 ? (
@@ -329,7 +478,7 @@ const CalendarView = ({
                     {eDateDay}
                   </div>
                 </div>
-                <div>
+                <div style={{ flex: 1, minWidth: 0 }}>
                   <div
                     style={{
                       fontFamily: font.serif,
@@ -502,6 +651,9 @@ const CalendarView = ({
 
       {selectedEvent && (
         <div
+          onTouchStart={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
+          onTouchEnd={(e) => e.stopPropagation()}
           style={{
             position: "fixed",
             inset: 0,
@@ -555,6 +707,306 @@ const CalendarView = ({
                   : undefined
               }
             />
+          </div>
+        </div>
+      )}
+
+      {/* Sync modal */}
+      {showSyncModal && (
+        <div
+          onTouchStart={(e) => e.stopPropagation()}
+          onTouchMove={(e) => e.stopPropagation()}
+          onTouchEnd={(e) => e.stopPropagation()}
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 9999,
+            display: "flex",
+            alignItems: "flex-end",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            onClick={closeSyncModal}
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: "rgba(0,0,0,0.7)",
+              backdropFilter: syncClosing ? "blur(0px)" : "blur(8px)",
+              WebkitBackdropFilter: syncClosing ? "blur(0px)" : "blur(8px)",
+              opacity: syncClosing ? 0 : 1,
+              transition: "opacity 0.2s ease, backdrop-filter 0.2s ease, -webkit-backdrop-filter 0.2s ease",
+            }}
+          />
+          <div
+            style={{
+              position: "relative",
+              background: color.surface,
+              borderRadius: "24px 24px 0 0",
+              maxWidth: 420,
+              width: "100%",
+              maxHeight: "75vh",
+              display: "flex",
+              flexDirection: "column",
+              animation: syncClosing ? undefined : "slideUp 0.3s ease-out",
+              transform: syncClosing ? "translateY(100%)" : `translateY(${syncDragOffset}px)`,
+              transition: syncClosing ? "transform 0.2s ease-in" : (syncDragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+            }}
+          >
+            {/* Drag handle + header */}
+            <div
+              onTouchStart={syncHandleSwipeStart}
+              onTouchMove={syncHandleSwipeMove}
+              onTouchEnd={syncHandleSwipeEnd}
+              style={{ touchAction: "none", padding: "16px 20px 0" }}
+            >
+              <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
+                <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2 }} />
+              </div>
+              <h3 style={{ fontFamily: font.serif, fontSize: 18, color: color.text, margin: "0 0 12px", fontWeight: 400 }}>
+                Sync to Calendar
+              </h3>
+
+              {/* Tabs */}
+              <div style={{ display: "flex", gap: 0, marginBottom: 12, borderBottom: `1px solid ${color.border}` }}>
+                {(["export", "subscribe"] as const).map((tab) => (
+                  <button
+                    key={tab}
+                    onClick={() => setSyncTab(tab)}
+                    style={{
+                      flex: 1,
+                      padding: "8px 0",
+                      background: "transparent",
+                      border: "none",
+                      borderBottom: syncTab === tab ? `2px solid ${color.accent}` : "2px solid transparent",
+                      fontFamily: font.mono,
+                      fontSize: 11,
+                      fontWeight: syncTab === tab ? 700 : 400,
+                      color: syncTab === tab ? color.accent : color.dim,
+                      cursor: "pointer",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    {tab === "export" ? "Export" : "Auto Sync"}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Tab content */}
+            {syncTab === "export" ? (
+              <>
+                {/* Select all / count */}
+                <div style={{ padding: "0 20px", display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
+                  <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>
+                    {syncSelected.size} of {allExportable.length} selected
+                  </span>
+                  <button
+                    onClick={() => {
+                      if (syncSelected.size === allExportable.length) setSyncSelected(new Set());
+                      else setSyncSelected(new Set(allExportable.map((e) => e.id)));
+                    }}
+                    style={{
+                      background: "transparent",
+                      border: "none",
+                      fontFamily: font.mono,
+                      fontSize: 10,
+                      color: color.accent,
+                      cursor: "pointer",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                      padding: "4px 0",
+                    }}
+                  >
+                    {syncSelected.size === allExportable.length ? "Deselect All" : "Select All"}
+                  </button>
+                </div>
+
+                {/* Selectable event list */}
+                <div
+                  ref={syncScrollRef}
+                  onTouchStart={syncHandleScrollTouchStart}
+                  onTouchMove={syncHandleScrollTouchMove}
+                  onTouchEnd={syncHandleScrollTouchEnd}
+                  style={{ flex: 1, overflowY: "auto", padding: "0 20px", overscrollBehavior: "contain" }}
+                >
+                  {allExportable.map((item) => {
+                    const selected = syncSelected.has(item.id);
+                    return (
+                      <div
+                        key={item.id}
+                        onClick={() => toggleSyncItem(item.id)}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 12,
+                          padding: "10px 0",
+                          borderBottom: `1px solid ${color.border}`,
+                          cursor: "pointer",
+                        }}
+                      >
+                        <div style={{
+                          width: 20,
+                          height: 20,
+                          borderRadius: 6,
+                          border: `2px solid ${selected ? color.accent : color.borderMid}`,
+                          background: selected ? color.accent : "transparent",
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                          flexShrink: 0,
+                          transition: "all 0.15s",
+                        }}>
+                          {selected && <span style={{ color: "#000", fontSize: 12, lineHeight: 1 }}>✓</span>}
+                        </div>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{
+                            fontFamily: font.mono,
+                            fontSize: 12,
+                            color: selected ? color.text : color.muted,
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                          }}>
+                            {item.label}
+                          </div>
+                          <div style={{ fontFamily: font.mono, fontSize: 10, color: color.faint }}>
+                            {item.sub}
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {/* Export action buttons */}
+                <div style={{ padding: "16px 20px calc(16px + env(safe-area-inset-bottom, 0px))", display: "flex", gap: 8 }}>
+                  <button
+                    onClick={() => handleSync("google")}
+                    disabled={syncSelected.size === 0}
+                    style={{
+                      flex: 1,
+                      padding: "12px 0",
+                      background: "transparent",
+                      border: `1px solid ${syncSelected.size > 0 ? color.borderMid : color.border}`,
+                      borderRadius: 12,
+                      color: syncSelected.size > 0 ? color.text : color.faint,
+                      fontFamily: font.mono,
+                      fontSize: 12,
+                      fontWeight: 700,
+                      cursor: syncSelected.size > 0 ? "pointer" : "default",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    Google Cal
+                  </button>
+                  <button
+                    onClick={() => handleSync("ics")}
+                    disabled={syncSelected.size === 0}
+                    style={{
+                      flex: 1,
+                      padding: "12px 0",
+                      background: syncSelected.size > 0 ? color.accent : color.border,
+                      border: "none",
+                      borderRadius: 12,
+                      color: syncSelected.size > 0 ? "#000" : color.faint,
+                      fontFamily: font.mono,
+                      fontSize: 12,
+                      fontWeight: 700,
+                      cursor: syncSelected.size > 0 ? "pointer" : "default",
+                      textTransform: "uppercase",
+                      letterSpacing: "0.08em",
+                    }}
+                  >
+                    Download .ics
+                  </button>
+                </div>
+              </>
+            ) : (
+              /* Subscribe tab */
+              <div style={{ padding: "0 20px calc(20px + env(safe-area-inset-bottom, 0px))" }}>
+                <p style={{ fontFamily: font.mono, fontSize: 11, color: color.muted, lineHeight: 1.6, marginBottom: 16 }}>
+                  Subscribe once and your calendar app will automatically stay in sync. New events you save will appear automatically — no duplicates.
+                </p>
+
+                {tokenLoading ? (
+                  <div style={{ fontFamily: font.mono, fontSize: 11, color: color.faint, textAlign: "center", padding: 20 }}>
+                    Loading...
+                  </div>
+                ) : webcalUrl ? (
+                  <>
+                    {/* URL display */}
+                    <div style={{
+                      background: color.deep,
+                      border: `1px solid ${color.border}`,
+                      borderRadius: 10,
+                      padding: "10px 12px",
+                      marginBottom: 12,
+                      fontFamily: font.mono,
+                      fontSize: 10,
+                      color: color.dim,
+                      wordBreak: "break-all",
+                      lineHeight: 1.5,
+                    }}>
+                      {webcalUrl}
+                    </div>
+
+                    {/* Actions */}
+                    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                      <a
+                        href={webcalUrl}
+                        style={{
+                          display: "block",
+                          padding: "12px 0",
+                          background: color.accent,
+                          border: "none",
+                          borderRadius: 12,
+                          color: "#000",
+                          fontFamily: font.mono,
+                          fontSize: 12,
+                          fontWeight: 700,
+                          cursor: "pointer",
+                          textTransform: "uppercase",
+                          letterSpacing: "0.08em",
+                          textAlign: "center",
+                          textDecoration: "none",
+                        }}
+                      >
+                        Subscribe in Calendar App
+                      </a>
+                      <button
+                        onClick={copySubscribeUrl}
+                        style={{
+                          padding: "12px 0",
+                          background: "transparent",
+                          border: `1px solid ${color.borderMid}`,
+                          borderRadius: 12,
+                          color: copied ? color.accent : color.text,
+                          fontFamily: font.mono,
+                          fontSize: 12,
+                          fontWeight: 700,
+                          cursor: "pointer",
+                          textTransform: "uppercase",
+                          letterSpacing: "0.08em",
+                        }}
+                      >
+                        {copied ? "Copied!" : "Copy URL"}
+                      </button>
+                    </div>
+
+                    <p style={{ fontFamily: font.mono, fontSize: 9, color: color.faint, lineHeight: 1.5, marginTop: 14, textAlign: "center" }}>
+                      Works with Apple Calendar, Google Calendar, Outlook, and any app that supports webcal subscriptions. Your calendar will refresh automatically.
+                    </p>
+                  </>
+                ) : (
+                  <div style={{ fontFamily: font.mono, fontSize: 11, color: color.faint, textAlign: "center", padding: 20 }}>
+                    Could not load subscription URL.
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -69,6 +69,20 @@ export async function getProfileById(id: string): Promise<Profile | null> {
   return data;
 }
 
+export async function getCalendarToken(): Promise<string | null> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('calendar_token')
+    .eq('id', user.id)
+    .single();
+
+  if (error || !data?.calendar_token) return null;
+  return data.calendar_token;
+}
+
 export async function getFriendshipWith(userId: string): Promise<{ id: string; status: string; isRequester: boolean } | null> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return null;

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -1,0 +1,220 @@
+/**
+ * .ics (iCalendar) generation and Google Calendar URL builder.
+ * No external dependencies — RFC 5545 compliant.
+ */
+
+export interface ICSEventParams {
+  uid: string;
+  title: string;
+  date: string;       // ISO date: "2026-02-14"
+  time?: string;       // Display time: "11PM-5AM", "8pm", "8:00 PM", "TBD", etc.
+  venue?: string;
+  description?: string;
+}
+
+// ── Time parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a time string like "8pm", "11PM", "8:00 PM", "Doors 8pm" into { hours, minutes }.
+ * When `inferAmPm` is provided, bare numbers like "11" are interpreted using that hint.
+ */
+function parseTime(raw: string, inferAmPm?: "am" | "pm"): { hours: number; minutes: number } | null {
+  // Try with explicit AM/PM first
+  const m = raw.trim().match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i);
+  if (m) {
+    let hours = parseInt(m[1], 10);
+    const minutes = m[2] ? parseInt(m[2], 10) : 0;
+    const ampm = m[3].toLowerCase();
+    if (ampm === "pm" && hours < 12) hours += 12;
+    if (ampm === "am" && hours === 12) hours = 0;
+    if (hours > 23 || minutes > 59) return null;
+    return { hours, minutes };
+  }
+
+  // Bare number like "11" or "11:00" — use inferAmPm if provided
+  const bare = raw.trim().match(/(\d{1,2})(?::(\d{2}))?/);
+  if (bare && inferAmPm) {
+    let hours = parseInt(bare[1], 10);
+    const minutes = bare[2] ? parseInt(bare[2], 10) : 0;
+    if (inferAmPm === "pm" && hours < 12) hours += 12;
+    if (inferAmPm === "am" && hours === 12) hours = 0;
+    if (hours > 23 || minutes > 59) return null;
+    return { hours, minutes };
+  }
+
+  return null;
+}
+
+/** Detect the AM/PM from a string, if present */
+function detectAmPm(raw: string): "am" | "pm" | null {
+  if (/am/i.test(raw)) return "am";
+  if (/pm/i.test(raw)) return "pm";
+  return null;
+}
+
+/** Parse display time like "11PM-5AM", "11-5pm", "8pm" into start/end times */
+function parseTimeRange(display: string): {
+  start: { hours: number; minutes: number };
+  end?: { hours: number; minutes: number };
+  endNextDay?: boolean;
+} | null {
+  if (!display || display === "TBD") return null;
+
+  // Try range: "11PM-5AM" or "11-5pm" or "11PM - 5AM"
+  const rangeMatch = display.match(/^(.+?)\s*[-–]\s*(.+)$/);
+  if (rangeMatch) {
+    const [, rawStart, rawEnd] = rangeMatch;
+    const startAmPm = detectAmPm(rawStart);
+    const endAmPm = detectAmPm(rawEnd);
+
+    // Infer missing AM/PM from the other side:
+    // "11-5pm" → end is PM, start 11 is before 5pm → 11am
+    // "2-5pm" → end is PM, start 2 is before 5 in same period → 2pm
+    // "11-5am" → end is AM → start is PM (overnight)
+    const inferStart = startAmPm ?? (() => {
+      if (!endAmPm) return null;
+      const sNum = parseInt(rawStart.match(/\d+/)?.[0] ?? "0", 10);
+      const eNum = parseInt(rawEnd.match(/\d+/)?.[0] ?? "0", 10);
+      if (endAmPm === "am") return "pm" as const; // "11-5am" → 11pm-5am overnight
+      // endAmPm is "pm": decide if start is AM or PM
+      // If start hour > end hour (e.g. 11 > 5), it's likely a daytime span: 11am-5pm
+      // If start hour <= end hour (e.g. 2 < 5), same period: 2pm-5pm
+      if (sNum > eNum) return "am" as const; // "11-5pm" → 11am-5pm
+      return "pm" as const; // "2-5pm" → 2pm-5pm
+    })();
+    const inferEnd = endAmPm ?? startAmPm;
+
+    const start = parseTime(rawStart, inferStart ?? undefined);
+    const end = parseTime(rawEnd, inferEnd ?? undefined);
+    if (start && end) {
+      const endNextDay = end.hours < start.hours || (end.hours === start.hours && end.minutes < start.minutes);
+      return { start, end, endNextDay };
+    }
+  }
+
+  // Single time: "8pm"
+  const single = parseTime(display);
+  if (single) return { start: single };
+
+  return null;
+}
+
+// ── .ics formatting helpers ──────────────────────────────────────────────
+
+function pad(n: number): string {
+  return n.toString().padStart(2, "0");
+}
+
+function formatICSDate(isoDate: string): string {
+  // "2026-02-14" -> "20260214"
+  return isoDate.replace(/-/g, "");
+}
+
+function formatICSDateTime(isoDate: string, hours: number, minutes: number): string {
+  return `${formatICSDate(isoDate)}T${pad(hours)}${pad(minutes)}00`;
+}
+
+function addDays(isoDate: string, days: number): string {
+  const d = new Date(isoDate + "T00:00:00");
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+function escapeICS(text: string): string {
+  return text.replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\n/g, "\\n");
+}
+
+// ── Public API ───────────────────────────────────────────────────────────
+
+export function generateICSEvent(params: ICSEventParams): string {
+  const { uid, title, date, time, venue, description } = params;
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const parsed = parseTimeRange(time ?? "");
+
+  const lines: string[] = [
+    "BEGIN:VEVENT",
+    `UID:${uid}@downto.app`,
+    `DTSTAMP:${formatICSDate(new Date().toISOString().split("T")[0])}T000000Z`,
+    `SUMMARY:${escapeICS(title)}`,
+  ];
+
+  if (parsed) {
+    lines.push(`DTSTART;TZID=${tz}:${formatICSDateTime(date, parsed.start.hours, parsed.start.minutes)}`);
+    if (parsed.end) {
+      const endDate = parsed.endNextDay ? addDays(date, 1) : date;
+      lines.push(`DTEND;TZID=${tz}:${formatICSDateTime(endDate, parsed.end.hours, parsed.end.minutes)}`);
+    } else {
+      // Default 2-hour duration
+      const endH = parsed.start.hours + 2;
+      const endDate = endH >= 24 ? addDays(date, 1) : date;
+      lines.push(`DTEND;TZID=${tz}:${formatICSDateTime(endDate, endH % 24, parsed.start.minutes)}`);
+    }
+  } else {
+    // All-day event
+    lines.push(`DTSTART;VALUE=DATE:${formatICSDate(date)}`);
+    lines.push(`DTEND;VALUE=DATE:${formatICSDate(addDays(date, 1))}`);
+  }
+
+  if (venue) lines.push(`LOCATION:${escapeICS(venue)}`);
+  if (description) lines.push(`DESCRIPTION:${escapeICS(description)}`);
+
+  lines.push("END:VEVENT");
+  return lines.join("\r\n");
+}
+
+export function generateICSCalendar(events: ICSEventParams[]): string {
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//downto//downto.app//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    ...events.map(generateICSEvent),
+    "END:VCALENDAR",
+  ];
+  return lines.join("\r\n");
+}
+
+export function downloadICS(filename: string, content: string): void {
+  const blob = new Blob([content], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function buildGoogleCalendarUrl(params: ICSEventParams): string {
+  const { title, date, time, venue, description } = params;
+  const parsed = parseTimeRange(time ?? "");
+
+  const base = "https://calendar.google.com/calendar/render";
+  const query = new URLSearchParams({ action: "TEMPLATE", text: title });
+
+  if (parsed) {
+    const start = formatICSDateTime(date, parsed.start.hours, parsed.start.minutes);
+    let end: string;
+    if (parsed.end) {
+      const endDate = parsed.endNextDay ? addDays(date, 1) : date;
+      end = formatICSDateTime(endDate, parsed.end.hours, parsed.end.minutes);
+    } else {
+      const endH = parsed.start.hours + 2;
+      const endDate = endH >= 24 ? addDays(date, 1) : date;
+      end = formatICSDateTime(endDate, endH % 24, parsed.start.minutes);
+    }
+    query.set("dates", `${start}/${end}`);
+  } else {
+    // All-day
+    const start = formatICSDate(date);
+    const end = formatICSDate(addDays(date, 1));
+    query.set("dates", `${start}/${end}`);
+  }
+
+  if (venue) query.set("location", venue);
+  if (description) query.set("details", description);
+
+  return `${base}?${query.toString()}`;
+}

--- a/supabase/migrations/20260325000001_add_calendar_token.sql
+++ b/supabase/migrations/20260325000001_add_calendar_token.sql
@@ -1,0 +1,7 @@
+-- Add a unique token for webcal subscription URLs (no auth headers needed)
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS calendar_token UUID DEFAULT gen_random_uuid();
+
+-- Ensure uniqueness
+CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_calendar_token
+  ON public.profiles (calendar_token);


### PR DESCRIPTION
## Summary
- Add .ics file export and webcal subscription for syncing saved events and interest checks to external calendar apps
- New `src/lib/ics.ts`: RFC 5545 compliant .ics generation, Google Calendar URL builder, smart time range parser (handles `11-5pm` → 11am–5pm, `11PM-5AM` → overnight, `8pm` → 2hr default, `TBD` → all-day)
- New API route `/api/calendar/[token]`: serves a dynamic .ics feed for a user's saved events + responded checks, authenticated via unique `calendar_token` UUID
- Migration adds `calendar_token` UUID column to profiles
- Sync modal in CalendarView with two tabs:
  - **Export**: select/deselect individual events, export to Google Calendar (opens pre-filled) or download .ics (Apple Calendar, Outlook, etc.)
  - **Auto Sync**: webcal subscription URL — subscribe once, calendar app polls automatically. UID-based dedup prevents duplicate entries
- Block pull-to-refresh while calendar sheets are open

Closes #16

## Test plan
- [ ] Open Cal tab → tap "Sync" button → modal opens with Export tab
- [ ] Select/deselect individual events, verify Select All / Deselect All
- [ ] Tap "Google Cal" with 1 event selected → opens Google Calendar pre-filled
- [ ] Tap "Download .ics" → downloads file, opens correctly in calendar app
- [ ] Switch to "Auto Sync" tab → subscription URL is shown
- [ ] Tap "Subscribe in Calendar App" → native calendar subscription prompt
- [ ] Tap "Copy URL" → copies to clipboard
- [ ] Verify time parsing: events with ranges (e.g. "11-5pm") export with correct start/end times, not as all-day
- [ ] Pull-to-refresh does not activate while sync modal or event detail sheet is open
- [ ] Run migration: `calendar_token` column exists on profiles with unique values

🤖 Generated with [Claude Code](https://claude.com/claude-code)