### PR TITLE
fix: calendar sync timezone and date bugs

### DIFF
--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -3,10 +3,12 @@ import { getServiceClient } from "@/lib/supabase-admin";
 import { generateICSCalendar, type ICSEventParams } from "@/lib/ics";
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ token: string }> },
 ) {
   const { token } = await params;
+  const url = new URL(request.url);
+  const timezone = url.searchParams.get("tz") ?? "America/New_York";
 
   const supabase = getServiceClient();
 
@@ -62,7 +64,7 @@ export async function GET(
     });
   }
 
-  const icsContent = generateICSCalendar(icsEvents);
+  const icsContent = generateICSCalendar(icsEvents, timezone);
 
   return new NextResponse(icsContent, {
     headers: {

--- a/src/features/calendar/components/CalendarView.tsx
+++ b/src/features/calendar/components/CalendarView.tsx
@@ -149,11 +149,12 @@ const CalendarView = ({
     }
   };
 
+  const userTz = typeof window !== "undefined" ? Intl.DateTimeFormat().resolvedOptions().timeZone : "America/New_York";
   const webcalUrl = calendarToken
-    ? `webcal://${typeof window !== "undefined" ? window.location.host : ""}/api/calendar/${calendarToken}`
+    ? `webcal://${typeof window !== "undefined" ? window.location.host : ""}/api/calendar/${calendarToken}?tz=${encodeURIComponent(userTz)}`
     : null;
   const httpsCalUrl = calendarToken
-    ? `${typeof window !== "undefined" ? window.location.origin : ""}/api/calendar/${calendarToken}`
+    ? `${typeof window !== "undefined" ? window.location.origin : ""}/api/calendar/${calendarToken}?tz=${encodeURIComponent(userTz)}`
     : null;
 
   const copySubscribeUrl = async () => {

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -115,9 +115,13 @@ function formatICSDateTime(isoDate: string, hours: number, minutes: number): str
 }
 
 function addDays(isoDate: string, days: number): string {
-  const d = new Date(isoDate + "T00:00:00");
-  d.setDate(d.getDate() + days);
-  return d.toISOString().split("T")[0];
+  // Parse manually to avoid UTC timezone shift
+  const [y, m, d] = isoDate.split("-").map(Number);
+  const date = new Date(y, m - 1, d + days);
+  const ry = date.getFullYear();
+  const rm = (date.getMonth() + 1).toString().padStart(2, "0");
+  const rd = date.getDate().toString().padStart(2, "0");
+  return `${ry}-${rm}-${rd}`;
 }
 
 function escapeICS(text: string): string {
@@ -126,9 +130,9 @@ function escapeICS(text: string): string {
 
 // ── Public API ───────────────────────────────────────────────────────────
 
-export function generateICSEvent(params: ICSEventParams): string {
+export function generateICSEvent(params: ICSEventParams, timezone?: string): string {
   const { uid, title, date, time, venue, description } = params;
-  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
   const parsed = parseTimeRange(time ?? "");
 
   const lines: string[] = [
@@ -162,14 +166,14 @@ export function generateICSEvent(params: ICSEventParams): string {
   return lines.join("\r\n");
 }
 
-export function generateICSCalendar(events: ICSEventParams[]): string {
+export function generateICSCalendar(events: ICSEventParams[], timezone?: string): string {
   const lines = [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
     "PRODID:-//downto//downto.app//EN",
     "CALSCALE:GREGORIAN",
     "METHOD:PUBLISH",
-    ...events.map(generateICSEvent),
+    ...events.map((e) => generateICSEvent(e, timezone)),
     "END:VCALENDAR",
   ];
   return lines.join("\r\n");


### PR DESCRIPTION
## Summary
- Fix `addDays()` using `.toISOString()` which converts to UTC, shifting dates backward in western timezones (e.g. March 26 becoming March 25)
- Fix server-side .ics generation using server timezone instead of user's — API route now accepts `?tz=` query param, defaults to `America/New_York`
- Webcal subscription URL includes user's browser timezone
- `generateICSEvent`/`generateICSCalendar` accept optional timezone override

## Test plan
- [ ] Export an event via .ics — verify correct date (e.g. March 26 = Thursday, not Wednesday)
- [ ] Export an event with time range — verify correct start/end times in calendar app
- [ ] Subscribe via webcal URL — verify events appear with correct timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)