### PR TITLE
feat: implement signup cap for v0 stage

### DIFF
--- a/src/app/api/auth/check-signup/route.ts
+++ b/src/app/api/auth/check-signup/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { getServiceClient } from "@/lib/supabase-admin";
+
+// Maximum number of users allowed during v0. Override via env var.
+const SIGNUP_CAP = parseInt(process.env.SIGNUP_CAP ?? "200", 10);
+
+export async function POST(request: Request) {
+  const { email } = await request.json();
+  if (!email) {
+    return NextResponse.json({ error: "Email required" }, { status: 400 });
+  }
+
+  const supabase = getServiceClient();
+
+  // Check if a profile already exists for this email (existing users can always log in).
+  // We query auth.users via the service client to find by email.
+  const { count: existingCount } = await supabase
+    .rpc("check_email_exists", { p_email: email.toLowerCase() });
+
+  // If the RPC doesn't exist yet, fall back to allowing (fail open).
+  // The RPC is created in the signup-cap migration.
+  if (existingCount !== null && existingCount > 0) {
+    return NextResponse.json({ allowed: true, existing: true });
+  }
+
+  // New user — check total count against cap
+  const { count, error } = await supabase
+    .from("profiles")
+    .select("*", { count: "exact", head: true });
+
+  if (error) {
+    return NextResponse.json({ allowed: true, existing: false });
+  }
+
+  if ((count ?? 0) >= SIGNUP_CAP) {
+    return NextResponse.json({
+      allowed: false,
+      existing: false,
+      message: "we're at capacity right now — join the waitlist and we'll let you in soon",
+    });
+  }
+
+  return NextResponse.json({ allowed: true, existing: false });
+}

--- a/src/features/auth/components/AuthScreen.tsx
+++ b/src/features/auth/components/AuthScreen.tsx
@@ -25,10 +25,30 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [capBlocked, setCapBlocked] = useState(false);
+
   const handleSendCode = async () => {
     if (!email.includes("@")) return;
     setLoading(true);
     setError(null);
+    setCapBlocked(false);
+
+    // Check signup cap before sending OTP
+    try {
+      const res = await fetch("/api/auth/check-signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (!data.allowed) {
+        setCapBlocked(true);
+        setLoading(false);
+        return;
+      }
+    } catch {
+      // Fail open — if check fails, allow through
+    }
 
     const { error } = await supabase.auth.signInWithOtp({ email });
 
@@ -132,6 +152,26 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
         >
           {error}
         </p>
+      )}
+
+      {capBlocked && (
+        <div
+          style={{
+            background: color.card,
+            border: `1px solid ${color.border}`,
+            borderRadius: 14,
+            padding: "20px",
+            marginBottom: 24,
+            textAlign: "center",
+          }}
+        >
+          <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 8 }}>
+            we&apos;re at capacity
+          </p>
+          <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, lineHeight: 1.6, marginBottom: 0 }}>
+            we&apos;re keeping things small for now. if you already have an account, try logging in with your email. otherwise, sit tight — we&apos;ll open up more spots soon.
+          </p>
+        </div>
       )}
 
       {step === "email" ? (

--- a/supabase/migrations/20260325000002_signup_cap.sql
+++ b/supabase/migrations/20260325000002_signup_cap.sql
@@ -1,0 +1,6 @@
+-- RPC to check if an email already exists in auth.users.
+-- SECURITY DEFINER so it can read auth.users from the service client.
+CREATE OR REPLACE FUNCTION public.check_email_exists(p_email TEXT)
+RETURNS INTEGER AS $$
+  SELECT COUNT(*)::INTEGER FROM auth.users WHERE email = LOWER(p_email);
+$$ LANGUAGE sql SECURITY DEFINER STABLE;


### PR DESCRIPTION
## Summary
- Add a signup cap to control new user registrations during v0 stage
- Before sending OTP, check if email belongs to an existing user (always allowed) or if total user count is under the cap
- Cap controlled via `SIGNUP_CAP` env var (default: 200)
- Shows "at capacity" message for new signups when full, with friendly copy
- Fails open on API errors — signups are never accidentally blocked
- New `check_email_exists` RPC (SECURITY DEFINER) queries `auth.users` by email

Closes #111

## Test plan
- [ ] Existing user enters email → OTP sent normally, no cap check blocks them
- [ ] New user enters email when under cap → OTP sent normally
- [ ] Set `SIGNUP_CAP=0` → new user sees "at capacity" message, no OTP sent
- [ ] Existing user with `SIGNUP_CAP=0` → still gets through (login always works)
- [ ] API route returns 400 if no email provided
- [ ] If `/api/auth/check-signup` is unreachable, signup proceeds (fail open)
- [ ] Run migration for `check_email_exists` RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)