### PR TITLE
feat: tappable profiles on event poster and @mentions

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -11,7 +11,7 @@ import EditCheckModal from "./EditCheckModal";
 import CheckActionsSheet from "./CheckActionsSheet";
 import { useFeedContext } from "@/features/checks/context/FeedContext";
 
-function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: boolean; coAuthors?: { name: string }[] }) {
+function Linkify({ children, dimmed, coAuthors, onViewProfile }: { children: string; dimmed?: boolean; coAuthors?: { name: string; userId?: string }[]; onViewProfile?: (userId: string) => void }) {
   const tokenRe = /(https?:\/\/[^\s),]+|@\S+)/g;
   const parts = children.split(tokenRe);
   if (parts.length === 1) return <>{children}</>;
@@ -39,7 +39,17 @@ function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: b
         if (/^@\S+/.test(part)) {
           const mention = part.slice(1).toLowerCase();
           const matched = coAuthors?.find(ca => ca.name.toLowerCase() === mention || ca.name.split(" ")[0]?.toLowerCase() === mention);
-          return <span key={i} className="text-dt font-semibold">@{matched ? matched.name : part.slice(1)}</span>;
+          const canTap = matched?.userId && onViewProfile;
+          return (
+            <span
+              key={i}
+              className="text-dt font-semibold"
+              style={canTap ? { cursor: "pointer" } : undefined}
+              onClick={canTap ? (e) => { e.stopPropagation(); onViewProfile!(matched!.userId!); } : undefined}
+            >
+              @{matched ? matched.name : part.slice(1)}
+            </span>
+          );
         }
         return <React.Fragment key={i}>{part}</React.Fragment>;
       })}
@@ -227,7 +237,7 @@ export default function CheckCard({
           <div className="mb-3">
             <div className="flex items-start gap-1.5">
               <p className="font-serif text-lg text-white m-0 font-normal leading-snug flex-1">
-                <Linkify coAuthors={check.coAuthors}>{check.text}</Linkify>
+                <Linkify coAuthors={check.coAuthors} onViewProfile={onViewProfile}>{check.text}</Linkify>
               </p>
               {(check.isYours || check.isCoAuthor) && (
                 <button

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -12,6 +12,7 @@ const EventCard = ({
   onToggleDown,
   onOpenSocial,
   onLongPress,
+  onViewProfile,
   isNew,
 }: {
   event: Event;
@@ -20,6 +21,7 @@ const EventCard = ({
   onToggleDown: () => void;
   onOpenSocial: () => void;
   onLongPress?: () => void;
+  onViewProfile?: (userId: string) => void;
   isNew?: boolean;
 }) => {
   const [hovered, setHovered] = useState(false);
@@ -125,6 +127,7 @@ const EventCard = ({
           hasPool={hasPool}
           actionButtons={actionButtons}
           onOpenSocial={onOpenSocial}
+          onViewProfile={onViewProfile}
           onClose={() => setShowDetail(false)}
         />
       )}
@@ -254,7 +257,7 @@ interface Person { name: string; avatar: string; mutual?: boolean; inPool?: bool
 function EventDetailSheet({
   event, userId, sourceLink, hasDetails,
   poolPeople, poolFriends, poolStrangerCount, nonPoolFriends, mutuals, others, hasPool,
-  actionButtons, onOpenSocial, onClose,
+  actionButtons, onOpenSocial, onViewProfile, onClose,
 }: {
   event: Event;
   userId?: string | null;
@@ -264,6 +267,7 @@ function EventDetailSheet({
   nonPoolFriends: Person[]; mutuals: Person[]; others: Person[]; hasPool: boolean;
   actionButtons: React.ReactNode;
   onOpenSocial: () => void;
+  onViewProfile?: (userId: string) => void;
   onClose: () => void;
 }) {
   const { visible, entering, closing, close } = useModalTransition(true, onClose);
@@ -381,7 +385,7 @@ function EventDetailSheet({
             event={event} userId={userId} sourceLink={sourceLink}
             poolPeople={poolPeople} poolFriends={poolFriends} poolStrangerCount={poolStrangerCount}
             nonPoolFriends={nonPoolFriends} mutuals={mutuals} others={others} hasPool={hasPool}
-            actionButtons={actionButtons} onOpenSocial={onOpenSocial}
+            actionButtons={actionButtons} onOpenSocial={onOpenSocial} onViewProfile={onViewProfile}
           />
         </div>
       </div>
@@ -400,25 +404,35 @@ interface SheetProps {
   nonPoolFriends: Person[]; mutuals: Person[]; others: Person[]; hasPool: boolean;
   actionButtons: React.ReactNode;
   onOpenSocial: () => void;
+  onViewProfile?: (userId: string) => void;
 }
 
 // Poster inline element (with optional note flowing on same line)
-function PosterInline({ event, userId, note }: { event: Event; userId?: string | null; note?: boolean }) {
+function PosterInline({ event, userId, note, onViewProfile }: { event: Event; userId?: string | null; note?: boolean; onViewProfile?: (userId: string) => void }) {
   if (!event.posterName) return null;
   const name = event.createdBy === userId ? "You" : event.posterName;
+  const canTap = event.createdBy && event.createdBy !== userId && onViewProfile;
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-      <div style={{
-        width: 20, height: 20, borderRadius: "50%",
-        background: event.createdBy === userId ? color.accent : color.borderLight,
-        color: event.createdBy === userId ? "#000" : color.dim,
-        display: "flex", alignItems: "center", justifyContent: "center",
-        fontFamily: font.mono, fontSize: 8, fontWeight: 700, flexShrink: 0,
-      }}>
+      <div
+        onClick={canTap ? (e) => { e.stopPropagation(); onViewProfile!(event.createdBy!); } : undefined}
+        style={{
+          width: 20, height: 20, borderRadius: "50%",
+          background: event.createdBy === userId ? color.accent : color.borderLight,
+          color: event.createdBy === userId ? "#000" : color.dim,
+          display: "flex", alignItems: "center", justifyContent: "center",
+          fontFamily: font.mono, fontSize: 8, fontWeight: 700, flexShrink: 0,
+          cursor: canTap ? "pointer" : "default",
+        }}>
         {event.posterAvatar || event.posterName[0]?.toUpperCase()}
       </div>
       <div style={{ fontFamily: font.mono, fontSize: 11, lineHeight: 1.5, minWidth: 0 }}>
-        <span style={{ color: color.muted, fontWeight: 700 }}>{name}</span>
+        <span
+          onClick={canTap ? (e) => { e.stopPropagation(); onViewProfile!(event.createdBy!); } : undefined}
+          style={{ color: color.muted, fontWeight: 700, cursor: canTap ? "pointer" : "default" }}
+        >
+          {name}
+        </span>
         {note && event.note && (
           <span style={{ color: color.dim }}>{" "}{event.note}</span>
         )}
@@ -621,7 +635,7 @@ function SheetHero(props: SheetProps) {
       {(event.posterName || event.note || sourceLink) && (
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <PosterInline event={event} userId={userId} note />
+            <PosterInline event={event} userId={userId} note onViewProfile={props.onViewProfile} />
             {!event.posterName && event.note && (
               <div style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, lineHeight: 1.5 }}>
                 {event.note}

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -10,7 +10,7 @@ import FeedEmptyState from "./FeedEmptyState";
 import InstallBanner from "./InstallBanner";
 import { useFeedContext } from "@/features/checks/context/FeedContext";
 
-function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: boolean; coAuthors?: { name: string }[] }) {
+function Linkify({ children, dimmed, coAuthors, onViewProfile }: { children: string; dimmed?: boolean; coAuthors?: { name: string; userId?: string }[]; onViewProfile?: (userId: string) => void }) {
   const tokenRe = /(https?:\/\/[^\s),]+|@\S+)/g;
   const parts = children.split(tokenRe);
   if (parts.length === 1) return <>{children}</>;
@@ -36,7 +36,17 @@ function Linkify({ children, dimmed, coAuthors }: { children: string; dimmed?: b
         if (/^@\S+/.test(part)) {
           const mention = part.slice(1).toLowerCase();
           const matched = coAuthors?.find(ca => ca.name.toLowerCase() === mention || ca.name.split(" ")[0]?.toLowerCase() === mention);
-          return <span key={i} className="text-dt font-semibold">@{matched ? matched.name : part.slice(1)}</span>;
+          const canTap = matched?.userId && onViewProfile;
+          return (
+            <span
+              key={i}
+              className="text-dt font-semibold"
+              style={canTap ? { cursor: "pointer" } : undefined}
+              onClick={canTap ? (e) => { e.stopPropagation(); onViewProfile!(matched!.userId!); } : undefined}
+            >
+              @{matched ? matched.name : part.slice(1)}
+            </span>
+          );
         }
         return <React.Fragment key={i}>{part}</React.Fragment>;
       })}
@@ -225,6 +235,7 @@ export default function FeedView({
                   onToggleDown={() => toggleDown(item.data.id)}
                   onOpenSocial={() => onOpenSocial(item.data)}
                   onLongPress={(item.data.createdBy === userId || !item.data.createdBy || isDemoMode) ? () => onEditEvent(item.data) : undefined}
+                  onViewProfile={onViewProfile}
                   isNew={item.data.id === newlyAddedEventId}
                 />
               )
@@ -257,7 +268,7 @@ export default function FeedView({
                           </span>
                         </div>
                         <p className="font-serif text-base text-neutral-500 m-0 leading-snug">
-                          <Linkify dimmed coAuthors={check.coAuthors}>{check.text}</Linkify>
+                          <Linkify dimmed coAuthors={check.coAuthors} onViewProfile={onViewProfile}>{check.text}</Linkify>
                         </p>
                       </div>
                       <button


### PR DESCRIPTION
## Summary
- Event card detail sheet: tapping the poster name/avatar opens their profile overlay (skipped for your own events)
- @mentions in interest check text: tapping a matched co-author @mention opens their profile overlay
- Both `Linkify` components (in `CheckCard` and `FeedView`) updated to accept `onViewProfile` and wire it to @mention spans
- `onViewProfile` threaded through `FeedView` → `EventCard` → `EventDetailSheet` → `SheetHero` → `PosterInline`

Closes #120

## Test plan
- [ ] In feed, tap an event card → tap poster name in detail sheet → profile overlay opens
- [ ] Your own events: poster shows "You", not tappable
- [ ] Interest check with @mention in text → tap the @mention → profile overlay opens
- [ ] @mention that doesn't match a co-author → styled but not tappable (no crash)
- [ ] Hidden checks section: @mentions also tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)