### PR TITLE
fix: allow re-tagging declined co-authors

### DIFF
--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -108,9 +108,13 @@ const EditCheckModal = ({
         m === f.name.split(' ')[0]?.toLowerCase()
       ))
       .map(f => f.id);
-    // Filter out already-tagged co-authors
-    const existingIds = new Set((check.coAuthors ?? []).map(ca => ca.userId));
-    const newTagIds = taggedIds.filter(id => !existingIds.has(id));
+    // Filter out co-authors that are already pending or accepted (allow re-tagging declined)
+    const activeIds = new Set(
+      (check.coAuthors ?? [])
+        .filter(ca => ca.status === 'pending' || ca.status === 'accepted')
+        .map(ca => ca.userId)
+    );
+    const newTagIds = taggedIds.filter(id => !activeIds.has(id));
 
     // Resolve date: manual > detected > existing check > null
     const resolvedDateLabel = manualDate || detectedDate?.label || check.eventDateLabel || null;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -948,8 +948,8 @@ export async function tagCoAuthors(checkId: string, userIds: string[]): Promise<
   const { error } = await supabase
     .from('check_co_authors')
     .upsert(
-      userIds.map(uid => ({ check_id: checkId, user_id: uid, invited_by: user.id })),
-      { onConflict: 'check_id,user_id', ignoreDuplicates: true }
+      userIds.map(uid => ({ check_id: checkId, user_id: uid, invited_by: user.id, status: 'pending' })),
+      { onConflict: 'check_id,user_id', ignoreDuplicates: false }
     );
 
   if (error) throw error;


### PR DESCRIPTION
## Summary
- **Frontend fix**: `EditCheckModal` now only filters out `pending`/`accepted` co-authors from re-tagging — `declined` users can be tagged again
- **Backend fix**: `tagCoAuthors` upsert changed from `ignoreDuplicates: true` to `false` with explicit `status: 'pending'`, so declined records get reset on re-tag

Closes #97

## Test plan
- [ ] Tag a friend as co-author on a check → they see the tag invite
- [ ] Friend declines the tag
- [ ] Edit the check, re-add the @mention → friend gets tagged again with pending status
- [ ] Friend who already accepted: editing check with their @mention doesn't reset their accepted status (they're filtered out as active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)