### PR TITLE
fix: friend request notification persists until actioned

### DIFF
--- a/src/features/friends/hooks/useFriends.ts
+++ b/src/features/friends/hooks/useFriends.ts
@@ -103,6 +103,7 @@ export function useFriends({ userId, isDemoMode, showToast, loadRealDataRef }: U
 
     try {
       await db.acceptFriendRequest(person.friendshipId);
+      db.markFriendRequestNotificationsRead(id).catch(() => {});
       setFriends((prev) => [...prev, { ...person, status: "friend" as const, availability: "open" as const }]);
       setSuggestions((prev) => prev.filter((s) => s.id !== id));
       showToast(`${person.name} added! \u{1F389}`);
@@ -125,6 +126,7 @@ export function useFriends({ userId, isDemoMode, showToast, loadRealDataRef }: U
 
     try {
       await db.removeFriend(person.friendshipId);
+      db.markFriendRequestNotificationsRead(id).catch(() => {});
       setFriends((prev) => prev.filter((f) => f.id !== id));
       showToast(`Removed ${person.name}`);
     } catch (err) {

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -182,8 +182,14 @@ const NotificationsPanel = ({
                 if (!isDemoMode && userId) {
                   db.markAllNotificationsRead();
                 }
-                setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
-                setUnreadCount(0);
+                // Keep pending friend_request notifications unread
+                const pendingFriendRequestIds = new Set(
+                  notifications
+                    .filter((n) => !n.is_read && n.type === "friend_request" && n.related_user_id && !friends.some((f) => f.id === n.related_user_id))
+                    .map((n) => n.id)
+                );
+                setNotifications((prev) => prev.map((n) => pendingFriendRequestIds.has(n.id) ? n : { ...n, is_read: true }));
+                setUnreadCount(pendingFriendRequestIds.size);
               }}
               style={{
                 background: "none",
@@ -251,8 +257,11 @@ const NotificationsPanel = ({
                 onClick={() => {
                   // Navigate based on type
                   if (n.type === "friend_request" || n.type === "friend_accepted") {
-                    // Mark single notification as read
-                    if (!n.is_read) {
+                    // friend_accepted: mark read on click
+                    // friend_request: only mark read if already actioned (accepted/declined)
+                    const alreadyFriends = n.type === "friend_request" && n.related_user_id &&
+                      friends.some((f) => f.id === n.related_user_id);
+                    if (!n.is_read && (n.type === "friend_accepted" || alreadyFriends)) {
                       if (!isDemoMode && userId) db.markNotificationRead(n.id);
                       setNotifications((prev) =>
                         prev.map((notif) => notif.id === n.id ? { ...notif, is_read: true } : notif)
@@ -260,8 +269,6 @@ const NotificationsPanel = ({
                       setUnreadCount((prev) => Math.max(0, prev - 1));
                     }
                     onClose();
-                    const alreadyFriends = n.type === "friend_request" && n.related_user_id &&
-                      friends.some((f) => f.id === n.related_user_id);
                     onNavigate({
                       type: "friends",
                       tab: n.type === "friend_request" && !alreadyFriends ? "add" : "friends",

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1354,10 +1354,27 @@ export async function markAllNotificationsRead(): Promise<void> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
+  // Skip pending friend_request notifications — they stay unread until actioned
   const { error } = await supabase
     .from('notifications')
     .update({ is_read: true })
     .eq('user_id', user.id)
+    .eq('is_read', false)
+    .neq('type', 'friend_request');
+
+  if (error) throw error;
+}
+
+export async function markFriendRequestNotificationsRead(friendUserId: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { error } = await supabase
+    .from('notifications')
+    .update({ is_read: true })
+    .eq('user_id', user.id)
+    .eq('type', 'friend_request')
+    .eq('related_user_id', friendUserId)
     .eq('is_read', false);
 
   if (error) throw error;


### PR DESCRIPTION
## Summary
- `friend_request` notifications stay unread until the request is accepted or declined
- Clicking the notification navigates to friends tab but no longer marks it read (unless the friendship is already actioned)
- "Mark all read" button skips pending `friend_request` notifications
- New `db.markFriendRequestNotificationsRead(userId)` marks them read when accepting or removing/declining
- Unread count accurately reflects pending friend requests

Closes #99

## Test plan
- [ ] Receive a friend request → notification dot appears
- [ ] Open notifications panel → friend request still shows unread dot
- [ ] Tap "Mark all read" → other notifications clear, friend request stays unread
- [ ] Accept the friend request → notification dot clears
- [ ] Receive another request → decline it → notification dot clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)