### PR TITLE
feat: pin friend requests in notifications, add decline button

### DIFF
--- a/src/features/friends/components/FriendsModal.tsx
+++ b/src/features/friends/components/FriendsModal.tsx
@@ -449,22 +449,42 @@ const FriendsModal = ({
                         @{f.username}
                       </div>
                     </div>
-                    <button
-                      onClick={() => onAcceptRequest(f.id)}
-                      style={{
-                        background: color.accent,
-                        color: "#000",
-                        border: "none",
-                        borderRadius: 8,
-                        padding: "8px 14px",
-                        fontFamily: font.mono,
-                        fontSize: 11,
-                        fontWeight: 700,
-                        cursor: "pointer",
-                      }}
-                    >
-                      Accept
-                    </button>
+                    <div style={{ display: "flex", gap: 6 }}>
+                      {onRemoveFriend && (
+                        <button
+                          onClick={() => onRemoveFriend(f.id)}
+                          style={{
+                            background: "transparent",
+                            color: color.dim,
+                            border: `1px solid ${color.borderMid}`,
+                            borderRadius: 8,
+                            padding: "8px 12px",
+                            fontFamily: font.mono,
+                            fontSize: 11,
+                            fontWeight: 700,
+                            cursor: "pointer",
+                          }}
+                        >
+                          Decline
+                        </button>
+                      )}
+                      <button
+                        onClick={() => onAcceptRequest(f.id)}
+                        style={{
+                          background: color.accent,
+                          color: "#000",
+                          border: "none",
+                          borderRadius: 8,
+                          padding: "8px 14px",
+                          fontFamily: font.mono,
+                          fontSize: 11,
+                          fontWeight: 700,
+                          cursor: "pointer",
+                        }}
+                      >
+                        Accept
+                      </button>
+                    </div>
                   </div>
                 ))}
                 <div style={{ height: 20 }} />

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -240,7 +240,12 @@ const NotificationsPanel = ({
               </p>
             </div>
           ) : (
-            notifications.map((n) => (
+            [...notifications].sort((a, b) => {
+              // Pin unread friend_request notifications to the top
+              const aPin = !a.is_read && a.type === "friend_request" ? 1 : 0;
+              const bPin = !b.is_read && b.type === "friend_request" ? 1 : 0;
+              return bPin - aPin;
+            }).map((n) => (
               <button
                 key={n.id}
                 onClick={() => {


### PR DESCRIPTION
## Summary
- Unread `friend_request` notifications are pinned to the top of the notification list so they don't get buried
- "Decline" button added next to "Accept" on incoming friend requests in FriendsModal — uses existing `onRemoveFriend` to remove the pending friendship

## Test plan
- [ ] Receive a friend request → notification appears at the top of the list
- [ ] Other notifications still show below pinned friend requests
- [ ] Once friend request is actioned, it moves back to normal chronological position
- [ ] Tap into friends → incoming request shows "Decline" and "Accept" buttons
- [ ] Tap "Decline" → request removed, toast confirms
- [ ] Tap "Accept" → friend added as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)