### PR TITLE
feat: enable push notifications from Chrome

### DIFF
--- a/src/features/auth/hooks/useOnboarding.tsx
+++ b/src/features/auth/hooks/useOnboarding.tsx
@@ -5,7 +5,7 @@ import { supabase } from "@/lib/supabase";
 import * as db from "@/lib/db";
 import type { Profile } from "@/lib/types";
 import type { InterestCheck, Tab, Friend } from "@/lib/ui-types";
-import { isIOSNotStandalone } from "@/lib/pushNotifications";
+import { isIOSNotStandalone, isPushSupported } from "@/lib/pushNotifications";
 import AuthScreen from "@/features/auth/components/AuthScreen";
 import ProfileSetupScreen from "@/features/auth/components/ProfileSetupScreen";
 import EnableNotificationsScreen, { IOSInstallScreen } from "@/features/auth/components/EnableNotificationsScreen";
@@ -360,12 +360,15 @@ export function useOnboarding({
         }
         // Fall through to feed wait → friend gate (no install/notifications screens)
       } else {
-        // Normal flow: show install prompt and notifications screen
-        if (!isInPWA && !installDismissed) {
+        // Normal flow: show install prompt for iOS non-standalone, then notifications
+        if (!isInPWA && !installDismissed && isIOSNotStandalone()) {
           return <IOSInstallScreen onComplete={dismissInstall} />;
         }
 
-        if (!notificationsDone && isInPWA) {
+        // Show notifications screen for any browser that supports push
+        // (PWA on iOS, Chrome/Firefox/Safari on desktop or Android)
+        const canShowNotifications = isInPWA || isPushSupported();
+        if (!notificationsDone && canShowNotifications) {
           return (
             <EnableNotificationsScreen
               onComplete={async () => {


### PR DESCRIPTION
## Summary
- The notifications onboarding screen was gated on `isInPWA` (standalone mode only), so Chrome desktop/Android users never saw the push notifications prompt
- Now shows the prompt for any browser that supports Web Push (`isPushSupported()`) — Chrome, Firefox, Edge, Safari, etc.
- iOS non-standalone still shows the install screen (push requires PWA on iOS)
- iOS standalone and all other push-capable browsers show the enable notifications screen

Closes #146

## Test plan
- [ ] New user on Chrome desktop → sees "enable notifications" screen after profile setup
- [ ] Tap "enable notifications" → Chrome permission prompt appears → push works
- [ ] New user on iOS Safari (not installed) → still sees install screen first
- [ ] New user on iOS PWA → sees notifications screen as before
- [ ] New user on a browser without push support → notifications screen skipped
- [ ] "Skip for now" still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)