### PR TITLE
fix: compute date_display from ISO date to prevent wrong day-of-week

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -681,12 +681,17 @@ export default function Home() {
         }
 
         if (!dbEvent) {
+          const dateISO = parseDateToISO(dateDisplay);
+          // Compute date_display from ISO date to ensure correct day-of-week
+          const computedDateDisplay = dateISO
+            ? new Date(dateISO + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" })
+            : dateDisplay;
           dbEvent = await db.createEvent({
             title,
             venue,
             neighborhood: null,
-            date: parseDateToISO(dateDisplay),
-            date_display: dateDisplay,
+            date: dateISO,
+            date_display: computedDateDisplay,
             time_display: timeDisplay,
             vibes,
             image_url: imageUrl,


### PR DESCRIPTION
## Summary
- Event creation was storing raw user/scraper-provided date_display without validating the day name — e.g. "Wed, Mar 26" when March 26 is actually Thursday
- Now computes date_display from the ISO date using `toLocaleDateString()`, matching the existing edit path
- Fixed the Sandy Liang sample sale event directly in prod DB (Wed → Thu)
- Verified no other events in prod have wrong day names

## Test plan
- [ ] Create a new event with a date → verify day-of-week is correct in the card
- [ ] Scrape an IG event → verify date_display has correct day name
- [ ] Edit an event date → day name updates correctly (already worked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)