### PR TITLE
feat: make location clickable to open in maps

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -248,9 +248,24 @@ export default function CheckCard({
             </div>
             {(check.eventDateLabel || check.eventTime || check.location) && (() => {
               const when = [check.eventDateLabel, check.eventTime].filter(Boolean).join(" ");
-              const parts = [when, check.location].filter(Boolean);
-              if (parts.length === 0) return null;
-              return <p className="font-mono text-xs text-neutral-500 m-0 mt-2">{parts.join(" · ")}</p>;
+              if (!when && !check.location) return null;
+              return (
+                <p className="font-mono text-xs text-neutral-500 m-0 mt-2">
+                  {when}
+                  {when && check.location && " · "}
+                  {check.location && (
+                    <a
+                      href={`https://maps.google.com/?q=${encodeURIComponent(check.location)}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      style={{ color: "inherit", textDecoration: "none" }}
+                    >
+                      {check.location}
+                    </a>
+                  )}
+                </p>
+              );
             })()}
             {(check.isYours || check.isCoAuthor) && !check.squadId && myCheckResponses[check.id] !== "down" && check.responses.some(r => r.status === "down") && (
               <button

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -201,9 +201,15 @@ const EventCard = ({
                 {event.time && event.time !== "TBD" && ` ${event.time}`}
               </span>
               {event.venue && event.venue !== "TBD" && (
-                <div style={{ fontFamily: font.mono, fontSize: 12, color: color.dim, marginTop: 2 }}>
+                <a
+                  href={`https://maps.google.com/?q=${encodeURIComponent(event.venue)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  style={{ fontFamily: font.mono, fontSize: 12, color: color.dim, marginTop: 2, display: "block", textDecoration: "none" }}
+                >
                   {event.venue}
-                </div>
+                </a>
               )}
             </div>
 
@@ -674,7 +680,15 @@ function SheetHero(props: SheetProps) {
           {event.date}{event.time && event.time !== "TBD" && ` ${event.time}`}
         </span>
         {event.venue && event.venue !== "TBD" && (
-          <span style={{ fontFamily: font.mono, fontSize: 12, color: color.dim }}>{event.venue}</span>
+          <a
+            href={`https://maps.google.com/?q=${encodeURIComponent(event.venue)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            style={{ fontFamily: font.mono, fontSize: 12, color: color.dim, textDecoration: "none" }}
+          >
+            {event.venue}
+          </a>
         )}
         <span style={{ fontFamily: font.mono, fontSize: 9, fontWeight: 700, padding: "1px 5px", borderRadius: 3, textTransform: "uppercase", letterSpacing: "0.06em", background: event.isPublic ? "rgba(255,255,255,0.06)" : "rgba(232,255,90,0.12)", color: event.isPublic ? color.faint : color.accent }}>
           {event.isPublic ? "public" : "friends"}


### PR DESCRIPTION
## Summary
- Venue/location text in event cards and interest checks now links to Google Maps search
- On mobile, tapping opens the native maps app chooser (Google Maps, Apple Maps, etc.)
- Applied to: EventCard (both inline and detail sheet), CheckCard (metadata line)
- Links use `stopPropagation` so they don't trigger card click/navigation

Closes #109

## Test plan
- [ ] Tap venue on an event card → opens Google Maps with the venue name
- [ ] Tap venue in event detail sheet → same
- [ ] Tap location on an interest check → opens Google Maps
- [ ] On iOS: tapping prompts to open in Apple Maps or Google Maps
- [ ] Events/checks with "TBD" venue → no link shown
- [ ] Tapping the link doesn't accidentally open the detail sheet or navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)