### PR TITLE
feat: undo action after archiving or deleting a check

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -923,6 +923,7 @@ export default function Home() {
             startSquadFromCheck={squadsHook.startSquadFromCheck}
             loadRealData={loadRealData}
             showToast={showToast}
+            showToastWithAction={showToastWithAction}
             onOpenSocial={(e) => squadsHook.setSocialEvent(e)}
             onEditEvent={(e) => setEditingEvent(e)}
             onOpenAdd={() => setAddModalOpen(true)}

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -69,6 +69,7 @@ export interface CheckCardProps {
   onNavigateToGroups: (squadId?: string) => void;
   onViewProfile?: (userId: string) => void;
   showToast: (msg: string) => void;
+  showToastWithAction?: (msg: string, action: () => void) => void;
   loadRealData: () => Promise<void>;
 }
 
@@ -84,6 +85,7 @@ export default function CheckCard({
   onNavigateToGroups,
   onViewProfile,
   showToast,
+  showToastWithAction,
   loadRealData,
 }: CheckCardProps) {
   const {
@@ -447,16 +449,38 @@ export default function CheckCard({
           if (!isDemoMode) {
             try { await db.archiveInterestCheck(check.id); } catch (err) { logError("archiveCheck", err, { checkId: check.id }); }
           }
-          showToast("Check archived");
           await loadRealData();
+          if (showToastWithAction && !isDemoMode) {
+            showToastWithAction("Check archived — undo?", async () => {
+              try { await db.unarchiveInterestCheck(check.id); } catch (err) { logError("unarchiveCheck", err, { checkId: check.id }); }
+              await loadRealData();
+            });
+          } else {
+            showToast("Check archived");
+          }
         }}
         onDelete={async () => {
           setActionsSheetOpen(false);
           if (!isDemoMode) {
-            try { await db.deleteInterestCheck(check.id); } catch (err) { logError("deleteCheck", err, { checkId: check.id }); }
+            // Soft-delete: archive first so undo is possible, then hard-delete after timeout
+            try { await db.archiveInterestCheck(check.id); } catch (err) { logError("archiveCheck", err, { checkId: check.id }); }
           }
-          showToast("Check removed");
           await loadRealData();
+          if (showToastWithAction && !isDemoMode) {
+            const timer = setTimeout(async () => {
+              try { await db.deleteInterestCheck(check.id); } catch (err) { logError("deleteCheck", err, { checkId: check.id }); }
+            }, 4500);
+            showToastWithAction("Check removed — undo?", async () => {
+              clearTimeout(timer);
+              try { await db.unarchiveInterestCheck(check.id); } catch (err) { logError("unarchiveCheck", err, { checkId: check.id }); }
+              await loadRealData();
+            });
+          } else {
+            if (!isDemoMode) {
+              try { await db.deleteInterestCheck(check.id); } catch (err) { logError("deleteCheck", err, { checkId: check.id }); }
+            }
+            showToast("Check removed");
+          }
         }}
       />
 

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -63,6 +63,7 @@ export interface FeedViewProps {
   startSquadFromCheck: (check: InterestCheck) => Promise<void>;
   loadRealData: () => Promise<void>;
   showToast: (msg: string) => void;
+  showToastWithAction?: (msg: string, action: () => void) => void;
   onOpenSocial: (event: Event) => void;
   onEditEvent: (event: Event) => void;
   onOpenAdd: () => void;
@@ -84,6 +85,7 @@ export default function FeedView({
   startSquadFromCheck,
   loadRealData,
   showToast,
+  showToastWithAction,
   onOpenSocial,
   onEditEvent,
   onOpenAdd,
@@ -182,6 +184,7 @@ export default function FeedView({
                 onNavigateToGroups={onNavigateToGroups}
                 onViewProfile={onViewProfile}
                 showToast={showToast}
+                showToastWithAction={showToastWithAction}
                 loadRealData={loadRealData}
               />
             ))}


### PR DESCRIPTION
## Summary
- After archiving or deleting an interest check, a 4-second toast appears with "undo?" — tapping it reverses the action
- **Archive**: archives immediately in DB, undo calls `unarchiveInterestCheck`
- **Delete**: soft-archives first (so undo is possible), then hard-deletes after 4.5s timeout. Undo cancels the timer and unarchives
- `showToastWithAction` threaded through page.tsx → FeedView → CheckCard
- Graceful fallback: if `showToastWithAction` isn't available, uses plain toast (no undo)

Closes #95

## Test plan
- [ ] Archive a check → toast shows "Check archived — undo? tap >" → tap to undo → check reappears
- [ ] Archive a check → let toast expire → check stays archived
- [ ] Delete a check → toast shows "Check removed — undo? tap >" → tap to undo → check reappears
- [ ] Delete a check → let toast expire → check is permanently deleted
- [ ] Demo mode: archive/delete still work with plain toast (no DB calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)