### PR TITLE
feat: friends-of-friends suggestions with via label

### DIFF
--- a/src/features/friends/components/FriendsModal.tsx
+++ b/src/features/friends/components/FriendsModal.tsx
@@ -802,6 +802,9 @@ const FriendsModal = ({
                           }}
                         >
                           @{f.username}
+                          {f.mutualFriendName && (
+                            <span style={{ color: color.accent, marginLeft: 6 }}>via {f.mutualFriendName}</span>
+                          )}
                         </div>
                       </div>
                       <button

--- a/src/features/friends/hooks/useFriends.ts
+++ b/src/features/friends/hooks/useFriends.ts
@@ -25,7 +25,7 @@ export function useFriends({ userId, isDemoMode, showToast, loadRealDataRef }: U
   const hydrateFriends = useCallback((
     friendsList: Awaited<ReturnType<typeof db.getFriends>>,
     pendingRequests: Awaited<ReturnType<typeof db.getPendingRequests>>,
-    suggestedUsers: Profile[],
+    suggestedUsers: (Profile & { mutualFriendName?: string })[],
     outgoingRequests: { profile: Profile; friendshipId: string }[] = []
   ) => {
     const transformedFriends: Friend[] = friendsList.map(({ profile: p, friendshipId }) => ({
@@ -65,6 +65,7 @@ export function useFriends({ userId, isDemoMode, showToast, loadRealDataRef }: U
       avatar: p.avatar_letter,
       status: "none" as const,
       igHandle: p.ig_handle ?? undefined,
+      mutualFriendName: p.mutualFriendName,
     }));
     setSuggestions([...incomingFriends, ...outgoingFriends, ...suggestedFriends]);
   }, []);

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -520,11 +520,27 @@ export async function getOutgoingPendingIds(): Promise<string[]> {
   return (data ?? []).map((r) => r.addressee_id);
 }
 
-export async function getSuggestedUsers(): Promise<Profile[]> {
+export async function getSuggestedUsers(): Promise<(Profile & { mutualFriendName?: string })[]> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
-  // Get all users the current user has any friendship with (pending or accepted)
+  // Try friends-of-friends first
+  const { data: fofData } = await supabase.rpc('get_friends_of_friends');
+  if (fofData && fofData.length > 0) {
+    // Fetch profiles for the suggested users
+    const fofIds = fofData.map((r: { suggested_user_id: string }) => r.suggested_user_id);
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('*')
+      .in('id', fofIds);
+
+    if (profiles && profiles.length > 0) {
+      const nameMap = new Map(fofData.map((r: { suggested_user_id: string; mutual_friend_name: string }) => [r.suggested_user_id, r.mutual_friend_name]));
+      return profiles.map((p) => ({ ...p, mutualFriendName: nameMap.get(p.id) ?? undefined }));
+    }
+  }
+
+  // Fallback: random non-friend users (for users with no friends yet)
   const { data: friendships } = await supabase
     .from('friendships')
     .select('requester_id, addressee_id')

--- a/src/lib/ui-types.ts
+++ b/src/lib/ui-types.ts
@@ -135,6 +135,7 @@ export interface Friend {
   status: "friend" | "pending" | "incoming" | "none";
   availability?: "open" | "awkward" | "not-available";
   igHandle?: string;
+  mutualFriendName?: string;
 }
 
 export type AvailabilityStatus = "open" | "not-available" | "awkward";

--- a/supabase/migrations/20260325000005_fof_suggestions.sql
+++ b/supabase/migrations/20260325000005_fof_suggestions.sql
@@ -1,0 +1,42 @@
+-- Friends-of-friends suggestions with mutual friend context.
+-- SECURITY DEFINER bypasses friendships RLS (can't read other users' friends).
+CREATE OR REPLACE FUNCTION public.get_friends_of_friends()
+RETURNS TABLE(
+  suggested_user_id UUID,
+  mutual_friend_id UUID,
+  mutual_friend_name TEXT
+) AS $$
+  WITH my_friends AS (
+    -- All accepted friends of the current user
+    SELECT CASE WHEN requester_id = auth.uid() THEN addressee_id ELSE requester_id END AS friend_id
+    FROM public.friendships
+    WHERE status = 'accepted'
+      AND (requester_id = auth.uid() OR addressee_id = auth.uid())
+  ),
+  fof AS (
+    -- Friends of my friends (excluding me and my direct friends)
+    SELECT
+      CASE WHEN f.requester_id = mf.friend_id THEN f.addressee_id ELSE f.requester_id END AS fof_id,
+      mf.friend_id AS via_friend_id
+    FROM public.friendships f
+    JOIN my_friends mf ON (f.requester_id = mf.friend_id OR f.addressee_id = mf.friend_id)
+    WHERE f.status = 'accepted'
+      AND CASE WHEN f.requester_id = mf.friend_id THEN f.addressee_id ELSE f.requester_id END != auth.uid()
+  ),
+  -- Exclude anyone I already have a friendship with (any status)
+  existing AS (
+    SELECT CASE WHEN requester_id = auth.uid() THEN addressee_id ELSE requester_id END AS user_id
+    FROM public.friendships
+    WHERE requester_id = auth.uid() OR addressee_id = auth.uid()
+  )
+  SELECT DISTINCT ON (fof.fof_id)
+    fof.fof_id AS suggested_user_id,
+    fof.via_friend_id AS mutual_friend_id,
+    p.display_name AS mutual_friend_name
+  FROM fof
+  JOIN public.profiles p ON p.id = fof.via_friend_id
+  WHERE fof.fof_id NOT IN (SELECT user_id FROM existing)
+    AND NOT EXISTS (SELECT 1 FROM public.profiles pr WHERE pr.id = fof.fof_id AND pr.is_test = true)
+  ORDER BY fof.fof_id, random()
+  LIMIT 20;
+$$ LANGUAGE sql SECURITY DEFINER STABLE;


### PR DESCRIPTION
## Summary
- Friend suggestions now prioritize **friends-of-friends** with a "via [mutual friend name]" label
- New `get_friends_of_friends()` SECURITY DEFINER RPC traverses the friendship graph: my friends → their friends → exclude existing connections
- `getSuggestedUsers()` calls the RPC first, falls back to random non-friend users when the user has no friends yet
- `Friend` interface gains `mutualFriendName?: string` field
- FriendsModal displays "via Sara" in accent color next to the @username for FoF suggestions

Closes #40

## Test plan
- [ ] User with friends → suggestions show friends-of-friends with "via [name]" label
- [ ] User with no friends → suggestions fall back to random users (no "via" label)
- [ ] FoF suggestions exclude existing friends and pending requests
- [ ] Test accounts (`is_test = true`) excluded from suggestions
- [ ] Run migration for `get_friends_of_friends()` RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)