### PR TITLE
fix: clear all squad push notifications when opening chat

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -504,6 +504,18 @@ export default function Home() {
       squadsHook.setAutoSelectSquadId(null);
       readSquadIdsRef.current.add(squad.id);
       db.markSquadNotificationsRead(squad.id).catch(() => {});
+      // Clear OS push notifications for this squad
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.getRegistration().then((reg) => {
+          if (!reg) return;
+          const tags = ["squad_message", "squad_invite", "squad_mention", "date_confirm", "poll_created"];
+          tags.forEach((tag) => {
+            reg.getNotifications({ tag: `${tag}-${squad.id}` }).then((notifs) => {
+              notifs.forEach((n) => n.close());
+            });
+          });
+        });
+      }
       if (squad.hasUnread) {
         squadsHook.setSquads((prev) => prev.map((s) => s.id === squad.id ? { ...s, hasUnread: false } : s));
         notificationsHook.setUnreadSquadCount((prev) => Math.max(0, prev - 1));
@@ -985,8 +997,13 @@ export default function Home() {
               notificationsHook.setUnreadCount(updatedNotifs.filter((n) => !n.is_read).length);
               if ("serviceWorker" in navigator) {
                 navigator.serviceWorker.getRegistration().then((reg) => {
-                  reg?.getNotifications({ tag: `squad_message-${squad.id}` }).then((notifs) => {
-                    notifs.forEach((n) => n.close());
+                  if (!reg) return;
+                  // Clear all push notification types related to this squad
+                  const tags = ["squad_message", "squad_invite", "squad_mention", "date_confirm", "poll_created"];
+                  tags.forEach((tag) => {
+                    reg.getNotifications({ tag: `${tag}-${squad.id}` }).then((notifs) => {
+                      notifs.forEach((n) => n.close());
+                    });
                   });
                 });
               }


### PR DESCRIPTION
## Summary
- Opening a squad chat now clears **all** squad-related push notifications from the OS notification center, not just `squad_message`
- Clears tags: `squad_message`, `squad_invite`, `squad_mention`, `date_confirm`, `poll_created`
- Applied to both entry paths: clicking from groups list and auto-select (from notification click/deep link)

Closes #98

## Test plan
- [ ] Receive a squad message push → open the squad chat → notification clears from OS notification center
- [ ] Receive a squad invite push → open the squad → notification clears
- [ ] Receive a date_confirm push → open the squad → notification clears
- [ ] Click a squad notification in the notification panel → OS notification also clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)