### PR TITLE
fix: define behavior when interest checks expire

### DIFF
--- a/src/app/api/checks/respond-shared/route.ts
+++ b/src/app/api/checks/respond-shared/route.ts
@@ -17,7 +17,7 @@ export async function POST(req: NextRequest) {
   // Only allow responding to checks that have been explicitly shared
   const { data: check, error: checkError } = await admin
     .from('interest_checks')
-    .select('id, shared_at, archived_at')
+    .select('id, shared_at, archived_at, expires_at')
     .eq('id', checkId)
     .single();
 
@@ -29,6 +29,9 @@ export async function POST(req: NextRequest) {
   }
   if (check.archived_at) {
     return NextResponse.json({ error: 'Check is archived' }, { status: 410 });
+  }
+  if (check.expires_at && new Date(check.expires_at) < new Date()) {
+    return NextResponse.json({ error: 'Check has expired' }, { status: 410 });
   }
 
   const { error: upsertError } = await admin

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -315,6 +315,7 @@ export default function CheckCard({
               {!check.isYours && (
                 <div className="flex gap-1.5 items-center ml-auto">
                   <button
+                    disabled={check.expiresIn === "expired" && !myCheckResponses[check.id]}
                     onClick={() => {
                       if (myCheckResponses[check.id] === "down" || myCheckResponses[check.id] === "waitlist") {
                         if (!isDemoMode && check.id) {
@@ -326,12 +327,14 @@ export default function CheckCard({
                         respondToCheck(check.id);
                       }
                     }}
-                    className={`rounded-lg py-1.5 px-2.5 font-mono text-tiny font-bold cursor-pointer whitespace-nowrap ${
-                      myCheckResponses[check.id] === "down"
-                        ? "bg-dt text-black border-none"
+                    className={`rounded-lg py-1.5 px-2.5 font-mono text-tiny font-bold whitespace-nowrap ${
+                      check.expiresIn === "expired" && !myCheckResponses[check.id]
+                        ? "bg-transparent text-neutral-700 border border-neutral-900 cursor-default opacity-50"
+                        : myCheckResponses[check.id] === "down"
+                        ? "bg-dt text-black border-none cursor-pointer"
                         : myCheckResponses[check.id] === "waitlist"
-                        ? "bg-transparent text-neutral-500 border border-dashed border-neutral-800"
-                        : "bg-transparent text-white border border-neutral-800"
+                        ? "bg-transparent text-neutral-500 border border-dashed border-neutral-800 cursor-pointer"
+                        : "bg-transparent text-white border border-neutral-800 cursor-pointer"
                     }`}
                   >
                     {myCheckResponses[check.id] === "down" ? "✓ Down" : myCheckResponses[check.id] === "waitlist" ? "✓ Waitlisted" : "Down"}

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -79,6 +79,7 @@ function transformCheck(c: ActiveCheck, userId: string | null): InterestCheck {
     letterboxdUrl: c.letterboxd_url ?? undefined,
     vibes: mm?.vibes,
     createdAt: c.created_at,
+    expiresAt: c.expires_at ?? undefined,
     coAuthors,
     isCoAuthor,
     pendingTagForYou,
@@ -453,6 +454,35 @@ export function useChecks({ userId, isDemoMode, profile, friendCount, showToast,
       db.unhideCheck(checkId).catch((err) => logError("unhideCheck", err, { checkId }));
     }
   };
+
+  // Recalculate expiry every 30s so stale checks auto-hide
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setChecks(prev => {
+        let changed = false;
+        const updated = prev.map(c => {
+          if (!c.expiresAt || !c.createdAt || c.expiresIn === "open") return c;
+          const now = new Date();
+          const expires = new Date(c.expiresAt);
+          const created = new Date(c.createdAt);
+          const totalDuration = expires.getTime() - created.getTime();
+          const msElapsed = now.getTime() - created.getTime();
+          const expiryPercent = Math.min(100, (msElapsed / totalDuration) * 100);
+          const msRemaining = expires.getTime() - now.getTime();
+          const hoursRemaining = Math.floor(msRemaining / (1000 * 60 * 60));
+          const minsRemaining = Math.floor((msRemaining % (1000 * 60 * 60)) / (1000 * 60));
+          const expiresIn = hoursRemaining > 0 ? `${hoursRemaining}h` : minsRemaining > 0 ? `${minsRemaining}m` : "expired";
+          if (c.expiresIn !== expiresIn || Math.abs(c.expiryPercent - expiryPercent) > 1) {
+            changed = true;
+            return { ...c, expiresIn, expiryPercent };
+          }
+          return c;
+        });
+        return changed ? updated : prev;
+      });
+    }, 30_000);
+    return () => clearInterval(timer);
+  }, []);
 
   // Subscribe to realtime interest check changes
   useEffect(() => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -865,6 +865,17 @@ export async function respondToCheck(
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
+  // Guard: don't allow responses to expired checks
+  const { data: check } = await supabase
+    .from('interest_checks')
+    .select('expires_at')
+    .eq('id', checkId)
+    .single();
+
+  if (check?.expires_at && new Date(check.expires_at) < new Date()) {
+    throw new Error('Check has expired');
+  }
+
   const { data, error } = await supabase
     .from('check_responses')
     .upsert({

--- a/src/lib/ui-types.ts
+++ b/src/lib/ui-types.ts
@@ -74,6 +74,7 @@ export interface InterestCheck {
   pendingTagForYou?: boolean;
   commentCount?: number;
   createdAt?: string;
+  expiresAt?: string;
 }
 
 export interface ScrapedEvent {


### PR DESCRIPTION
## Summary
- **Server-side guard**: `respondToCheck()` and shared check API now reject responses to expired checks (returns error/410)
- **Client-side timer**: 30s interval recalculates `expiresIn` and `expiryPercent` so stale checks auto-hide without requiring a page reload
- **Expiry UX**: Down button is disabled with dimmed styling when a check expires (users who already responded can still undo)

No migrations required — uses existing `expires_at` column.

Closes #27

## Test plan
- [ ] Create a check with a short expiry (e.g. 1 hour), wait for it to expire — should auto-hide from feed without reload
- [ ] Expired check's Down button should appear dimmed and be unclickable
- [ ] Attempt to respond to an expired check via API — should get rejected
- [ ] Shared check link for an expired check — should return 410
- [ ] Non-expired checks behave normally (Down button works, timer updates countdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)