### PR TITLE
fix: preload event social data before showing feed

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -223,9 +223,7 @@ export default function Home() {
       setArchivedChecks(archivedChecksList);
       checksHook.hydrateLeftChecks(leftChecksList);
 
-      setFeedLoaded(true);
-
-      // Phase 4: Backfill social data (peopleDown + crew pool)
+      // Phase 4: Fetch social data before showing feed so it doesn't pop in
       const savedEventIds = savedEvents.map((se) => se.event!.id);
       const allEventIds = [...new Set([...savedEventIds, ...publicEvents.map((e) => e.id), ...friendsEvents.map((e) => e.id)])];
       if (allEventIds.length > 0) {
@@ -240,6 +238,8 @@ export default function Home() {
           logWarn("loadPeopleDown", "Failed to load social data", { error: err });
         }
       }
+
+      setFeedLoaded(true);
 
     } catch (err) {
       logError("loadRealData", err);


### PR DESCRIPTION
## Summary
- Move social data fetch (peopleDown, crewPool, userPool) before `setFeedLoaded(true)` so squad info renders with the initial feed instead of popping in after
- Spinner stays slightly longer but the feed appears complete — no visual pop-in

## Test plan
- [ ] Load the feed — event cards should show "N down" avatars immediately, no delayed pop-in
- [ ] Verify feed still loads correctly with no regressions
- [ ] If social data fetch fails, feed should still appear (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)