### PR TITLE
feat: push notification when friend marks down on event

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -66,6 +66,8 @@ self.addEventListener("notificationclick", (event) => {
     tab = relatedId ? `/?tab=groups&squadId=${relatedId}` : "/?tab=groups";
   } else if (type === "event_reminder") {
     tab = "/?tab=calendar";
+  } else if (type === "event_down" || type === "friend_event") {
+    tab = "/?tab=feed";
   }
 
   event.waitUntil(

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -296,6 +296,16 @@ const NotificationsPanel = ({
                     }
                     onClose();
                     onNavigate({ type: "groups", squadId: squadId ?? undefined });
+                  } else if (n.type === "event_down" || n.type === "friend_event") {
+                    if (!n.is_read) {
+                      if (!isDemoMode && userId) db.markNotificationRead(n.id);
+                      setNotifications((prev) =>
+                        prev.map((notif) => notif.id === n.id ? { ...notif, is_read: true } : notif)
+                      );
+                      setUnreadCount((prev) => Math.max(0, prev - 1));
+                    }
+                    onClose();
+                    onNavigate({ type: "feed" });
                   } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag") {
                     // Mark single notification as read (except check_tag — cleared on accept/decline)
                     if (!n.is_read && n.type !== "check_tag") {
@@ -333,6 +343,8 @@ const NotificationsPanel = ({
                       : n.type === "date_confirm" ? "#E8FF5A22"
                       : n.type === "check_tag" ? "#E8FF5A22"
                       : n.type === "squad_join_request" ? "#AF52DE22"
+                      : n.type === "event_down" ? "#E8FF5A22"
+                      : n.type === "friend_event" ? "#E8FF5A22"
                       : "#5856D622",
                     display: "flex",
                     alignItems: "center",
@@ -348,6 +360,8 @@ const NotificationsPanel = ({
                     : n.type === "date_confirm" ? "📅"
                     : n.type === "check_tag" ? "🏷️"
                     : n.type === "squad_join_request" ? "🙋"
+                    : n.type === "event_down" ? "✋"
+                    : n.type === "friend_event" ? "🎉"
                     : "💬"}
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>

--- a/supabase/migrations/20260326000001_notify_friend_event_down.sql
+++ b/supabase/migrations/20260326000001_notify_friend_event_down.sql
@@ -1,0 +1,102 @@
+-- Notify event creator and friends when someone marks "down" on an event.
+-- Also adds 'event_down' notification type.
+
+-- 1. Add event_down to notification types
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN (
+    'friend_request', 'friend_accepted', 'check_response',
+    'squad_message', 'squad_invite', 'friend_check', 'date_confirm',
+    'check_tag', 'check_comment', 'poll_created', 'squad_join_request',
+    'squad_mention', 'comment_mention', 'friend_event', 'event_reminder',
+    'event_down'
+  ));
+
+-- 2. Trigger function: notify when someone marks down on an event
+CREATE OR REPLACE FUNCTION public.notify_event_down()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_user_name TEXT;
+  v_event_title TEXT;
+  v_event_creator UUID;
+  v_friend_id UUID;
+BEGIN
+  -- Only fire when is_down changes to true
+  IF NOT NEW.is_down OR (OLD IS NOT NULL AND OLD.is_down) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Get the user's display name and event info
+  SELECT display_name INTO v_user_name
+  FROM public.profiles WHERE id = NEW.user_id;
+
+  SELECT title, created_by INTO v_event_title, v_event_creator
+  FROM public.events WHERE id = NEW.event_id;
+
+  v_user_name := COALESCE(v_user_name, 'Someone');
+  v_event_title := COALESCE(v_event_title, 'an event');
+
+  -- Notify the event creator if they're a different person and a friend
+  IF v_event_creator IS NOT NULL
+    AND v_event_creator != NEW.user_id
+    AND EXISTS (
+      SELECT 1 FROM public.friendships
+      WHERE status = 'accepted'
+        AND ((requester_id = NEW.user_id AND addressee_id = v_event_creator)
+          OR (requester_id = v_event_creator AND addressee_id = NEW.user_id))
+    )
+  THEN
+    INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_event_id)
+    VALUES (
+      v_event_creator,
+      'event_down',
+      v_user_name || ' is down',
+      LEFT(v_event_title, 80),
+      NEW.user_id,
+      NEW.event_id
+    );
+  END IF;
+
+  -- Notify other friends who are already down for this event
+  FOR v_friend_id IN
+    SELECT se.user_id
+    FROM public.saved_events se
+    WHERE se.event_id = NEW.event_id
+      AND se.is_down = true
+      AND se.user_id != NEW.user_id
+      AND se.user_id != COALESCE(v_event_creator, '00000000-0000-0000-0000-000000000000')
+      AND EXISTS (
+        SELECT 1 FROM public.friendships
+        WHERE status = 'accepted'
+          AND ((requester_id = NEW.user_id AND addressee_id = se.user_id)
+            OR (requester_id = se.user_id AND addressee_id = NEW.user_id))
+      )
+  LOOP
+    INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_event_id)
+    VALUES (
+      v_friend_id,
+      'event_down',
+      v_user_name || ' is also down',
+      LEFT(v_event_title, 80),
+      NEW.user_id,
+      NEW.event_id
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 3. Trigger on saved_events UPDATE (is_down toggled)
+DROP TRIGGER IF EXISTS on_event_down ON public.saved_events;
+CREATE TRIGGER on_event_down
+  AFTER UPDATE ON public.saved_events
+  FOR EACH ROW EXECUTE FUNCTION public.notify_event_down();
+
+-- Also fire on INSERT with is_down=true (e.g. saveEvent + toggleDown in one step)
+DROP TRIGGER IF EXISTS on_event_down_insert ON public.saved_events;
+CREATE TRIGGER on_event_down_insert
+  AFTER INSERT ON public.saved_events
+  FOR EACH ROW
+  WHEN (NEW.is_down = true)
+  EXECUTE FUNCTION public.notify_event_down();


### PR DESCRIPTION
## Summary
Core loop fix: users now get push notifications when a friend marks "I'm Down" on an event.

**DB trigger** on `saved_events` fires when `is_down` → `true`:
- Notifies event creator: "[name] is down" + event title (if they're friends)
- Notifies other friends already down: "[name] is also down" (so the group knows)
- Only fires between accepted friends — no stranger notifications

**UI updates:**
- `event_down` notification type with ✋ emoji in NotificationsPanel
- `friend_event` notifications get 🎉 emoji
- Both click through to feed tab
- Service worker routes `event_down`/`friend_event` clicks correctly
- Push payload includes `related_event_id`

## Test plan
- [ ] Run migration → `event_down` type added, trigger created
- [ ] Friend marks down on your event → you get push notification "[name] is down"
- [ ] You're already down, another friend marks down → you get "[name] is also down"
- [ ] Stranger marks down → no notification (not friends)
- [ ] Tap notification → app opens to feed tab
- [ ] Notification shows in panel with ✋ emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)