### PR TITLE
feat: add gear menu with share option on event cards

### DIFF
--- a/src/features/events/components/EventActionsSheet.tsx
+++ b/src/features/events/components/EventActionsSheet.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { font, color } from "@/lib/styles";
+
+export default function EventActionsSheet({
+  open,
+  onClose,
+  onEdit,
+  onShare,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onEdit?: () => void;
+  onShare?: () => void;
+}) {
+  const touchStartY = useRef(0);
+  const [dragOffset, setDragOffset] = useState(0);
+  const [closing, setClosing] = useState(false);
+  const isDragging = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  const dismiss = () => {
+    setClosing(true);
+    setTimeout(() => { setClosing(false); setDragOffset(0); onClose(); }, 250);
+  };
+
+  const finishSwipe = () => {
+    if (dragOffset > 60) dismiss();
+    else setDragOffset(0);
+    isDragging.current = false;
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+    isDragging.current = false;
+  };
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
+  };
+  const handleTouchEnd = () => { if (isDragging.current) finishSwipe(); };
+
+  if (!open) return null;
+
+  const actionRow = (label: string, icon: string, onClick: () => void) => (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        width: "100%",
+        padding: "14px 0",
+        background: "transparent",
+        border: "none",
+        borderBottom: `1px solid ${color.border}`,
+        fontFamily: font.mono,
+        fontSize: 13,
+        color: color.text,
+        cursor: "pointer",
+        textAlign: "left",
+      }}
+    >
+      <span style={{ fontSize: 16, width: 24, textAlign: "center" }}>{icon}</span>
+      {label}
+    </button>
+  );
+
+  return (
+    <>
+      <div
+        onClick={dismiss}
+        onTouchStart={(e) => e.stopPropagation()}
+        onTouchMove={(e) => e.stopPropagation()}
+        onTouchEnd={(e) => e.stopPropagation()}
+        style={{
+          position: "fixed",
+          inset: 0,
+          background: "rgba(0,0,0,0.7)",
+          backdropFilter: "blur(8px)",
+          WebkitBackdropFilter: "blur(8px)",
+          zIndex: 100,
+        }}
+      />
+      <div
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        style={{
+          position: "fixed",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: color.surface,
+          borderRadius: "24px 24px 0 0",
+          maxWidth: 420,
+          margin: "0 auto",
+          zIndex: 101,
+          animation: closing ? undefined : "slideUp 0.3s ease-out",
+          transform: closing ? "translateY(100%)" : dragOffset > 0 ? `translateY(${dragOffset}px)` : undefined,
+          transition: closing ? "transform 0.25s ease-in" : dragOffset > 0 ? undefined : "transform 0.25s ease-out",
+          paddingBottom: "env(safe-area-inset-bottom, 20px)",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "center", padding: "12px 0 8px" }}>
+          <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2 }} />
+        </div>
+        <div style={{ padding: "0 20px 20px" }}>
+          <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, margin: "0 0 8px", fontWeight: 400 }}>
+            Event actions
+          </p>
+          {onShare && actionRow("Share event", "🔗", () => { dismiss(); onShare(); })}
+          {onEdit && actionRow("Edit event", "✎", () => { dismiss(); onEdit(); })}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { font, color } from "@/lib/styles";
 import type { Event } from "@/lib/ui-types";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import EventActionsSheet from "./EventActionsSheet";
 
 const EventCard = ({
   event,
@@ -26,6 +27,7 @@ const EventCard = ({
 }) => {
   const [hovered, setHovered] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
+  const [actionsOpen, setActionsOpen] = useState(false);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressFired = useRef(false);
   const touchMoved = useRef(false);
@@ -110,8 +112,24 @@ const EventCard = ({
 
   const hasDetails = !!(event.posterName || event.note || event.movieTitle || event.vibe.length > 0 || sourceLink);
 
+  const shareEvent = async () => {
+    const url = event.igUrl || event.diceUrl || event.letterboxdUrl || `${window.location.origin}`;
+    const text = `${event.title}${event.venue && event.venue !== "TBD" ? ` @ ${event.venue}` : ""}`;
+    if (navigator.share) {
+      try { await navigator.share({ title: event.title, text, url }); } catch { /* cancelled */ }
+    } else {
+      try { await navigator.clipboard.writeText(`${text}\n${url}`); } catch { /* fallback */ }
+    }
+  };
+
   return (
     <>
+      <EventActionsSheet
+        open={actionsOpen}
+        onClose={() => setActionsOpen(false)}
+        onShare={shareEvent}
+        onEdit={onLongPress}
+      />
       {showDetail && (
         <EventDetailSheet
           event={event}
@@ -184,14 +202,12 @@ const EventCard = ({
               >
                 {event.title}
               </h3>
-              {onLongPress && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); onLongPress(); }}
-                  className="bg-transparent border-none text-neutral-600 font-mono text-tiny cursor-pointer p-1 shrink-0 ml-2"
-                >
-                  ✎
-                </button>
-              )}
+              <button
+                onClick={(e) => { e.stopPropagation(); setActionsOpen(true); }}
+                className="bg-transparent border-none text-neutral-600 font-mono text-tiny cursor-pointer p-1 shrink-0 ml-2"
+              >
+                ⚙
+              </button>
             </div>
 
             {/* Date, time, venue */}


### PR DESCRIPTION
## Summary
- Replace ✎ edit button on event cards with ⚙ gear that opens an actions sheet
- **Share event**: uses Web Share API on mobile (native share sheet), clipboard fallback on desktop. Shares event title + venue + source URL (IG/Dice/Letterboxd link)
- **Edit event**: same as previous ✎ behavior, only shows for event creators
- Gear shows on all event cards so anyone can share, not just the creator

## Test plan
- [ ] Tap ⚙ on any event card → actions sheet opens with "Share event"
- [ ] On mobile: tap Share → native share sheet with event title + link
- [ ] On desktop: tap Share → copies to clipboard
- [ ] On your own event: sheet shows both "Share event" and "Edit event"
- [ ] On someone else's event: sheet shows only "Share event"
- [ ] Swipe down to dismiss actions sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)