### PR TITLE
fix: only show gear menu on events you own

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -202,12 +202,14 @@ const EventCard = ({
               >
                 {event.title}
               </h3>
-              <button
-                onClick={(e) => { e.stopPropagation(); setActionsOpen(true); }}
-                className="bg-transparent border-none text-neutral-600 font-mono text-tiny cursor-pointer p-1 shrink-0 ml-2"
-              >
-                ⚙
-              </button>
+              {onLongPress && (
+                <button
+                  onClick={(e) => { e.stopPropagation(); setActionsOpen(true); }}
+                  className="bg-transparent border-none text-neutral-600 font-mono text-tiny cursor-pointer p-1 shrink-0 ml-2"
+                >
+                  ⚙
+                </button>
+              )}
             </div>
 
             {/* Date, time, venue */}


### PR DESCRIPTION
## Summary
- Hide the ⚙ gear button on event cards the user doesn't own
- Only shows when `onLongPress` (edit) is available, which is gated to the event creator

## Test plan
- [ ] Your own event → ⚙ gear visible, opens actions sheet with Share + Edit
- [ ] Someone else's event → no gear button

🤖 Generated with [Claude Code](https://claude.com/claude-code)