### PR TITLE
fix: prevent waitlisted users from editing squad size and re-joining

### DIFF
--- a/src/app/api/squads/update-size/route.ts
+++ b/src/app/api/squads/update-size/route.ts
@@ -22,16 +22,16 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'No squad for this check' }, { status: 400 });
   }
 
-  // Verify caller is a squad member
+  // Verify caller is an active squad member (not waitlisted)
   const { data: membership } = await supabase
     .from('squad_members')
-    .select('id')
+    .select('id, role')
     .eq('squad_id', squad.id)
     .eq('user_id', user.id)
     .maybeSingle();
 
-  if (!membership) {
-    return NextResponse.json({ error: 'Not a squad member' }, { status: 403 });
+  if (!membership || membership.role === 'waitlist') {
+    return NextResponse.json({ error: 'Not an active squad member' }, { status: 403 });
   }
 
   const { getServiceClient } = await import('@/lib/supabase-admin');

--- a/supabase/migrations/20260326000005_fix_squad_size_exploit.sql
+++ b/supabase/migrations/20260326000005_fix_squad_size_exploit.sql
@@ -1,0 +1,61 @@
+-- Fix exploit: waitlisted user could edit squad size, un-down, re-down to join.
+
+-- 1. update-size: restrict to check author or squad creator only
+-- (handled in API route, not SQL — see route.ts change)
+
+-- 2. auto_leave_squad_on_event_undown: don't delete waitlisted members on un-down.
+-- They stay waitlisted so re-downing won't re-add them as full members.
+CREATE OR REPLACE FUNCTION public.auto_leave_squad_on_event_undown()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_squad RECORD;
+  v_display_name TEXT;
+  v_remaining INT;
+  v_was_member BOOLEAN;
+BEGIN
+  IF OLD.is_down = true AND NEW.is_down = false THEN
+
+    SELECT p.display_name INTO v_display_name
+    FROM public.profiles p
+    WHERE p.id = OLD.user_id;
+
+    FOR v_squad IN
+      SELECT s.id FROM public.squads s WHERE s.event_id = OLD.event_id
+    LOOP
+      -- Check if user is an active member (not waitlisted)
+      SELECT EXISTS (
+        SELECT 1 FROM public.squad_members
+        WHERE squad_id = v_squad.id AND user_id = OLD.user_id AND role = 'member'
+      ) INTO v_was_member;
+
+      -- Only remove active members; waitlisted users stay on waitlist
+      IF v_was_member THEN
+        DELETE FROM public.squad_members
+        WHERE squad_id = v_squad.id
+          AND user_id = OLD.user_id;
+
+        INSERT INTO public.messages (squad_id, sender_id, text, is_system)
+        VALUES (v_squad.id, NULL, v_display_name || ' left the squad', TRUE);
+
+        SELECT COUNT(*) INTO v_remaining
+        FROM public.squad_members
+        WHERE squad_id = v_squad.id AND role = 'member';
+
+        IF v_remaining = 1 THEN
+          INSERT INTO public.messages (squad_id, sender_id, text, is_system)
+          VALUES (v_squad.id, NULL,
+            'You''re the last one here — invite more people or this squad will dissolve', TRUE);
+        ELSIF v_remaining = 0 THEN
+          DELETE FROM public.squads WHERE id = v_squad.id;
+        END IF;
+      END IF;
+    END LOOP;
+
+    DELETE FROM public.crew_pool
+    WHERE user_id = OLD.user_id
+      AND event_id = OLD.event_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
Fixes an exploit chain where a waitlisted user could:
1. Edit squad size (increase it) while waitlisted
2. Un-down from the event
3. Re-down → auto-squad trigger adds them as a full member, bypassing waitlist

**Fixes:**
- **update-size API**: now checks `role != 'waitlist'` — only active squad members can change size
- **auto_leave_squad_on_event_undown**: only removes active members on un-down. Waitlisted users stay on the waitlist, so re-downing won't re-trigger the auto-add (the trigger checks `NOT EXISTS squad_members`)

## Test plan
- [ ] Run migration
- [ ] Active squad member → can change squad size ✓
- [ ] Waitlisted user → cannot change squad size (403)
- [ ] Waitlisted user un-downs → stays on waitlist (not removed)
- [ ] Waitlisted user re-downs → still waitlisted (not promoted to member)
- [ ] Active member un-downs → removed from squad + "left the squad" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)