### PR TITLE
fix: unread dot not showing for new squad messages after leaving chat

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1074,6 +1074,8 @@ export default function Home() {
           userId={userId}
           onClose={() => {
             const origin = squadChatOrigin;
+            // Allow future messages to show unread dot again
+            if (selectedSquad?.id) readSquadIdsRef.current.delete(selectedSquad.id);
             setSelectedSquad(null);
             setSquadChatOrigin(null);
             if (origin && origin !== tab) {


### PR DESCRIPTION
## Summary
The unread red dot on the Squads tab wasn't showing for new messages after you'd previously opened that squad's chat.

**Root cause:** \`readSquadIdsRef\` (a suppression set) added squad IDs when opening a chat but never removed them when closing. This caused \`onUnreadSquadIds\` to permanently suppress the unread dot for any squad you'd ever opened.

**Fix:** Clear the squad ID from \`readSquadIdsRef\` when closing the chat, so new messages that arrive after leaving can trigger the dot again.

## Test plan
- [ ] Open a squad chat → close it → friend sends a message → red dot appears on Squads tab
- [ ] Open a squad chat → messages arrive while in chat → no dot (correct, you're reading)
- [ ] Close chat → pull to refresh → dot still shows if there are unread messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)