### PR TITLE
fix: store scraped thumbnail and prevent chat message race

### DIFF
--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -235,6 +235,8 @@ const AddModal = ({
         isPublicPost: data.isPublicPost || false,
         igUrl: data.igUrl,
         diceUrl: data.diceUrl,
+        raUrl: data.raUrl,
+        thumbnail: data.thumbnail,
       });
       setEventVisibility(data.isPublicPost ? 'public' : 'public');
 

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -294,6 +294,7 @@ const SquadChat = ({
     db.getSquadMessages(localSquad.id).then((raw) => {
       if (stale) return;
       const msgs = raw.map((msg) => ({
+        id: msg.id,
         sender: msg.is_system || !msg.sender_id ? "system" : (msg.sender_id === userId ? "You" : (msg.sender?.display_name ?? "Unknown")),
         text: msg.text,
         time: formatTimeAgo(new Date(msg.created_at)),
@@ -302,7 +303,13 @@ const SquadChat = ({
         ...(msg.message_type === 'poll' ? { messageType: 'poll' as const, messageId: msg.id } : {}),
       }));
       const last = msgs.length > 0 ? msgs[msgs.length - 1] : null;
-      setMessages(msgs);
+      // Merge: keep any realtime messages that arrived before this fetch completed
+      setMessages((prev) => {
+        const fetchedIds = new Set(msgs.map((m) => m.id));
+        const realtimeOnly = prev.filter((m) => m.id && !fetchedIds.has(m.id));
+        const merged = [...msgs, ...realtimeOnly];
+        return merged;
+      });
       onSquadUpdateRef.current((prev) =>
         prev.map((s) =>
           s.id === localSquad.id
@@ -323,6 +330,7 @@ const SquadChat = ({
       const isSystem = newMessage.is_system || newMessage.sender_id === null;
       const senderName = isSystem ? "system" : (newMessage.sender?.display_name ?? "Unknown");
       const msg = {
+        id: newMessage.id,
         sender: senderName,
         text: newMessage.text,
         time: "now",
@@ -347,7 +355,10 @@ const SquadChat = ({
         }).catch(() => {});
       }
       const lastMsgPreview = isSystem ? newMessage.text : `${senderName}: ${newMessage.text}`;
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) => {
+        if (prev.some((m) => m.id && m.id === msg.id)) return prev;
+        return [...prev, msg];
+      });
       // Also update the squad list
       onSquadUpdateRef.current((prev) =>
         prev.map((s) =>

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -156,6 +156,7 @@ export function useSquads({ userId, isDemoMode, profile, checksRef, dispatch, sh
         .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
       const lastRawMessage = sortedRawMessages.length > 0 ? sortedRawMessages[sortedRawMessages.length - 1] : null;
       const messages = sortedRawMessages.map((msg) => ({
+          id: msg.id,
           sender: msg.is_system ? "system" : (msg.sender_id === userId ? "You" : (msg.sender?.display_name ?? "Unknown")),
           text: msg.text,
           time: formatTimeAgo(new Date(msg.created_at)),

--- a/src/lib/ui-types.ts
+++ b/src/lib/ui-types.ts
@@ -114,7 +114,7 @@ export interface Squad {
   waitlistedMembers?: { name: string; avatar: string; userId: string }[];
   downResponders?: { name: string; avatar: string; userId: string }[];
   dateStatus?: 'proposed' | 'locked';
-  messages: { sender: string; text: string; time: string; isYou?: boolean; messageType?: 'date_confirm' | 'poll'; messageId?: string }[];
+  messages: { id?: string; sender: string; text: string; time: string; isYou?: boolean; messageType?: 'date_confirm' | 'poll'; messageId?: string }[];
   lastMsg: string;
   time: string;
   meetingSpot?: string;


### PR DESCRIPTION
## Summary
- **IG image fix**: `thumbnail` (and `raUrl`) from scrape API response was never stored in `scraped` state, so all Instagram events got a placeholder image instead of the actual post flyer. Backfill already applied for existing events.
- **Chat race condition**: Realtime messages in squad chat could be overwritten by a concurrent initial fetch, causing messages like "still down" to pop in and out. Fixed by tracking message IDs and merging instead of replacing.

## Test plan
- [ ] Scrape an Instagram event URL → verify the post image shows on the event card (not an Unsplash placeholder)
- [ ] Open a squad chat with active date confirm → verify "still down" messages persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)