### PR TITLE
fix: race condition causing inconsistent squad unread dots

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -245,13 +245,17 @@ export default function Home() {
 
       setFeedLoaded(true);
 
+      // Reload notifications AFTER squads are hydrated to avoid race condition
+      // where onUnreadSquadIds sets hasUnread on stale squad state
+      notificationsHook.loadNotifications();
+
     } catch (err) {
       logError("loadRealData", err);
     } finally {
       isLoadingRef.current = false;
       setFeedLoaded(true);
     }
-  }, [isDemoMode, userId, checksHook.hydrateChecks, squadsHook.hydrateSquads, friendsHook.hydrateFriends, hydrateEvents, hydrateSocialData]);
+  }, [isDemoMode, userId, checksHook.hydrateChecks, squadsHook.hydrateSquads, friendsHook.hydrateFriends, hydrateEvents, hydrateSocialData, notificationsHook.loadNotifications]);
 
   loadRealDataRef.current = loadRealData;
 

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -75,17 +75,6 @@ export function useNotifications({ userId, isDemoMode, onUnreadSquadIds }: UseNo
     }
   }, [unreadCount, unreadSquadCount]);
 
-  // Reload notifications on app focus
-  useEffect(() => {
-    if (isDemoMode || !userId) return;
-    const handleVisibility = () => {
-      if (document.visibilityState === "visible") {
-        loadNotificationsRef.current();
-      }
-    };
-    document.addEventListener("visibilitychange", handleVisibility);
-    return () => document.removeEventListener("visibilitychange", handleVisibility);
-  }, [isDemoMode, userId]);
 
   return {
     notifications,


### PR DESCRIPTION
## Summary
The squad unread dots were inconsistent because two async operations raced on visibility change:
1. \`loadRealData\` → \`hydrateSquads\` (replaces squad list, preserves old hasUnread)
2. \`loadNotifications\` → \`onUnreadSquadIds\` (sets hasUnread on squads)

If (2) ran before (1) finished, its \`setSquads\` call operated on stale state that (1) then overwrote.

**Fix:** Call \`loadNotifications\` at the end of \`loadRealData\` (after squads are hydrated) instead of in a separate visibility change handler. This guarantees \`onUnreadSquadIds\` always operates on the freshest squad state.

## Test plan
- [ ] Open app → squads with unread messages show red dot
- [ ] Switch to another app → come back → dots still correct
- [ ] Pull to refresh → dots update correctly
- [ ] Receive message while app is backgrounded → come back → dot appears
- [ ] Open squad chat → dot clears → leave → new message → dot reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)