### PR TITLE
refactor: squad unread tracking via read cursors

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,7 +76,6 @@ export default function Home() {
   const [selectedSquad, setSelectedSquad] = useState<Squad | null>(null);
   const selectedSquadIdRef = useRef<string | null>(null);
   selectedSquadIdRef.current = selectedSquad?.id ?? null;
-  const readSquadIdsRef = useRef<Set<string>>(new Set());
   const [viewingUserId, setViewingUserId] = useState<string | null>(null);
 
   // ─── Ref for onboarding hook's setShowAddGlow (declared after checksHook) ──
@@ -146,21 +145,7 @@ export default function Home() {
     },
   });
 
-  const notificationsHook = useNotifications({
-    userId,
-    isDemoMode,
-    onUnreadSquadIds: (ids) => {
-      const openId = selectedSquadIdRef.current;
-      const recentlyRead = readSquadIdsRef.current;
-      // Remove confirmed-read squads from the suppression set
-      for (const id of recentlyRead) {
-        if (!ids.includes(id)) recentlyRead.delete(id);
-      }
-      squadsHook.setSquads((prev) => prev.map((s) =>
-        ids.includes(s.id) && s.id !== openId && !recentlyRead.has(s.id) ? { ...s, hasUnread: true } : s
-      ));
-    },
-  });
+  const notificationsHook = useNotifications({ userId, isDemoMode });
 
   // ─── Onboarding hook ───────────────────────────────────────────────────
   const onboarding = useOnboarding({
@@ -201,6 +186,7 @@ export default function Home() {
         fofAnnotations,
         archivedChecksList,
         leftChecksList,
+        unreadSquadIds,
       ] = await Promise.all([
         db.getSavedEvents(),
         db.getPublicEvents(),
@@ -215,6 +201,7 @@ export default function Home() {
         db.getFofAnnotations().catch((err) => { logWarn("loadFofAnnotations", "Failed", { error: err }); return [] as { check_id: string; via_friend_name: string }[]; }),
         db.getArchivedChecks().catch((err) => { logWarn("loadArchivedChecks", "Failed", { error: err }); return [] as { id: string; text: string; archived_at: string }[]; }),
         db.getLeftChecks().catch((err) => { logWarn("loadLeftChecks", "Failed", { error: err }); return [] as Awaited<ReturnType<typeof db.getLeftChecks>>; }),
+        db.getUnreadSquadIds().catch(() => [] as string[]),
       ]);
 
       // Phase 2: Transform events via useEvents hook
@@ -223,7 +210,7 @@ export default function Home() {
       // Phase 3: Hydrate domain hooks
       friendsHook.hydrateFriends(friendsList, pendingRequests, suggestedUsers, outgoingRequests);
       checksHook.hydrateChecks(activeChecks, hiddenIds, fofAnnotations);
-      squadsHook.hydrateSquads(squadsList);
+      squadsHook.hydrateSquads(squadsList, unreadSquadIds);
       setArchivedChecks(archivedChecksList);
       checksHook.hydrateLeftChecks(leftChecksList);
 
@@ -371,11 +358,10 @@ export default function Home() {
         // Skip notifications about own messages and for the currently-open squad
         if (newNotif.related_user_id === userId) return;
         if (newNotif.related_squad_id && newNotif.related_squad_id === selectedSquadIdRef.current) {
-          db.markSquadNotificationsRead(newNotif.related_squad_id).catch(() => {});
+          // User is in this chat — update cursor, skip UI
+          db.markSquadRead(newNotif.related_squad_id).catch(() => {});
           return;
         }
-        notificationsHook.setHasUnreadSquadMessage(true);
-        notificationsHook.setUnreadSquadCount((prev) => prev + 1);
         if (newNotif.related_squad_id) {
           squadsHook.setSquads((prev) => prev.map((s) =>
             s.id === newNotif.related_squad_id ? { ...s, hasUnread: true } : s
@@ -510,8 +496,7 @@ export default function Home() {
     if (squad) {
       setSelectedSquad({ ...squad, hasUnread: false });
       squadsHook.setAutoSelectSquadId(null);
-      readSquadIdsRef.current.add(squad.id);
-      db.markSquadNotificationsRead(squad.id).catch(() => {});
+      db.markSquadRead(squad.id).catch(() => {});
       // Clear OS push notifications for this squad
       if ("serviceWorker" in navigator) {
         navigator.serviceWorker.getRegistration().then((reg) => {
@@ -526,13 +511,7 @@ export default function Home() {
       }
       if (squad.hasUnread) {
         squadsHook.setSquads((prev) => prev.map((s) => s.id === squad.id ? { ...s, hasUnread: false } : s));
-        notificationsHook.setUnreadSquadCount((prev) => Math.max(0, prev - 1));
       }
-      const updatedNotifs = notificationsHook.notifications.map((n) =>
-        n.related_squad_id === squad.id ? { ...n, is_read: true } : n
-      );
-      notificationsHook.setNotifications(updatedNotifs);
-      notificationsHook.setUnreadCount(updatedNotifs.filter((n) => !n.is_read).length);
     }
   }, [squadsHook.autoSelectSquadId, squadsHook.squads]);
 
@@ -992,23 +971,14 @@ export default function Home() {
             onSelectSquad={(squad) => {
               setSelectedSquad(squad);
               setSquadChatOrigin("groups");
-              readSquadIdsRef.current.add(squad.id);
-              // Clear all notification state for this squad
-              db.markSquadNotificationsRead(squad.id).catch(() => {});
+              db.markSquadRead(squad.id).catch(() => {});
               if (squad.hasUnread) {
                 squadsHook.setSquads((prev) => prev.map((s) => s.id === squad.id ? { ...s, hasUnread: false } : s));
-                notificationsHook.setUnreadSquadCount((prev) => Math.max(0, prev - 1));
               }
-              // Clear bell badge: mark squad notifications read locally and recompute count
-              const updatedNotifs = notificationsHook.notifications.map((n) =>
-                n.related_squad_id === squad.id ? { ...n, is_read: true } : n
-              );
-              notificationsHook.setNotifications(updatedNotifs);
-              notificationsHook.setUnreadCount(updatedNotifs.filter((n) => !n.is_read).length);
+              // Clear OS push notifications for this squad
               if ("serviceWorker" in navigator) {
                 navigator.serviceWorker.getRegistration().then((reg) => {
                   if (!reg) return;
-                  // Clear all push notification types related to this squad
                   const tags = ["squad_message", "squad_invite", "squad_mention", "date_confirm", "poll_created"];
                   tags.forEach((tag) => {
                     reg.getNotifications({ tag: `${tag}-${squad.id}` }).then((notifs) => {
@@ -1078,8 +1048,6 @@ export default function Home() {
           userId={userId}
           onClose={() => {
             const origin = squadChatOrigin;
-            // Allow future messages to show unread dot again
-            if (selectedSquad?.id) readSquadIdsRef.current.delete(selectedSquad.id);
             setSelectedSquad(null);
             setSquadChatOrigin(null);
             if (origin && origin !== tab) {

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -21,35 +21,21 @@ export type AppNotification = {
 interface UseNotificationsParams {
   userId: string | null;
   isDemoMode: boolean;
-  onUnreadSquadIds?: (ids: string[]) => void;
 }
 
-export function useNotifications({ userId, isDemoMode, onUnreadSquadIds }: UseNotificationsParams) {
+export function useNotifications({ userId, isDemoMode }: UseNotificationsParams) {
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
-  const [unreadSquadCount, setUnreadSquadCount] = useState(0);
-  const [hasUnreadSquadMessage, setHasUnreadSquadMessage] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
-
-  const onUnreadSquadIdsRef = useRef(onUnreadSquadIds);
-  onUnreadSquadIdsRef.current = onUnreadSquadIds;
 
   const loadNotifications = useCallback(async () => {
     try {
-      const [notifs, count, unreadSquadIds] = await Promise.all([
+      const [notifs, count] = await Promise.all([
         db.getNotifications(),
         db.getUnreadCount(),
-        db.getUnreadSquadIds(),
       ]);
       setNotifications(notifs);
       setUnreadCount(count);
-      setUnreadSquadCount(unreadSquadIds.length);
-      if (unreadSquadIds.length > 0) {
-        setHasUnreadSquadMessage(true);
-        onUnreadSquadIdsRef.current?.(unreadSquadIds);
-      } else {
-        setHasUnreadSquadMessage(false);
-      }
     } catch (err) {
       logWarn("loadNotifications", "Failed to load notifications", { error: err });
     }
@@ -64,27 +50,21 @@ export function useNotifications({ userId, isDemoMode, onUnreadSquadIds }: UseNo
     loadNotificationsRef.current();
   }, [isDemoMode, userId]);
 
-  // Sync total unread count to PWA app badge (bell + squad messages)
+  // Sync bell unread count to PWA app badge
   useEffect(() => {
     if (!("setAppBadge" in navigator)) return;
-    const total = unreadCount + unreadSquadCount;
-    if (total > 0) {
-      navigator.setAppBadge(total).catch(() => {});
+    if (unreadCount > 0) {
+      navigator.setAppBadge(unreadCount).catch(() => {});
     } else {
       navigator.clearAppBadge().catch(() => {});
     }
-  }, [unreadCount, unreadSquadCount]);
-
+  }, [unreadCount]);
 
   return {
     notifications,
     setNotifications,
     unreadCount,
     setUnreadCount,
-    unreadSquadCount,
-    setUnreadSquadCount,
-    hasUnreadSquadMessage,
-    setHasUnreadSquadMessage,
     notificationsOpen,
     setNotificationsOpen,
     loadNotifications,

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -129,7 +129,7 @@ export function useSquads({ userId, isDemoMode, profile, checksRef, dispatch, sh
     return null;
   });
 
-  const hydrateSquads = useCallback((squadsList: Awaited<ReturnType<typeof db.getSquads>>) => {
+  const hydrateSquads = useCallback((squadsList: Awaited<ReturnType<typeof db.getSquads>>, unreadSquadIds?: string[]) => {
     const transformedSquads: Squad[] = squadsList.map((s) => {
       const myMembership = (s.members ?? []).find((m) => m.user_id === userId);
       const isWaitlisted = myMembership?.role === 'waitlist';
@@ -198,13 +198,22 @@ export function useSquads({ userId, isDemoMode, profile, checksRef, dispatch, sh
     transformedSquads.sort((a, b) =>
       new Date(b.lastActivityAt!).getTime() - new Date(a.lastActivityAt!).getTime()
     );
-    // Preserve hasUnread flags from previous state (skip currently-open squad)
-    setSquads((prev) => {
-      const unreadMap = new Map(prev.filter((s) => s.hasUnread).map((s) => [s.id, true]));
-      if (openSquadIdRef?.current) unreadMap.delete(openSquadIdRef.current);
-      if (unreadMap.size === 0) return transformedSquads;
-      return transformedSquads.map((s) => unreadMap.has(s.id) ? { ...s, hasUnread: true } : s);
-    });
+    // Set hasUnread from cursor-based unread IDs (source of truth)
+    if (unreadSquadIds) {
+      const unreadSet = new Set(unreadSquadIds);
+      const openId = openSquadIdRef?.current;
+      setSquads(transformedSquads.map((s) =>
+        unreadSet.has(s.id) && s.id !== openId ? { ...s, hasUnread: true } : s
+      ));
+    } else {
+      // Fallback: preserve hasUnread from previous state (e.g. realtime updates between hydrations)
+      setSquads((prev) => {
+        const unreadMap = new Map(prev.filter((s) => s.hasUnread).map((s) => [s.id, true]));
+        if (openSquadIdRef?.current) unreadMap.delete(openSquadIdRef.current);
+        if (unreadMap.size === 0) return transformedSquads;
+        return transformedSquads.map((s) => unreadMap.has(s.id) ? { ...s, hasUnread: true } : s);
+      });
+    }
 
     // Link checks to their squads (distinguish member vs waitlisted)
     const checkToSquad = new Map<string, { squadId: string; inSquad: boolean; isWaitlisted: boolean; eventIsoDate?: string; dateStatus?: string }>();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1340,18 +1340,22 @@ export async function getUnreadSquadIds(): Promise<string[]> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return [];
 
-  const { data, error } = await supabase
-    .from('notifications')
-    .select('related_squad_id')
-    .eq('user_id', user.id)
-    .eq('is_read', false)
-    .in('type', ['squad_message', 'squad_mention'])
-    .not('related_squad_id', 'is', null)
-    .neq('related_user_id', user.id);  // exclude self-notifications
-
+  const { data, error } = await supabase.rpc('get_unread_squad_ids', { p_user_id: user.id });
   if (error) return [];
-  const ids = new Set(data.map((n) => n.related_squad_id as string));
-  return [...ids];
+  return (data ?? []).map((r: { squad_id: string }) => r.squad_id);
+}
+
+export async function markSquadRead(squadId: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { error } = await supabase
+    .from('squad_read_cursors')
+    .upsert(
+      { user_id: user.id, squad_id: squadId, last_read_at: new Date().toISOString() },
+      { onConflict: 'user_id,squad_id' }
+    );
+  if (error) throw error;
 }
 
 export async function markNotificationRead(notificationId: string): Promise<void> {

--- a/supabase/migrations/20260327000001_squad_read_cursors.sql
+++ b/supabase/migrations/20260327000001_squad_read_cursors.sql
@@ -1,0 +1,58 @@
+-- Replace notification-row-based squad unread tracking with read cursors.
+-- One row per user per squad instead of one notification row per message per member.
+
+-- 1. New table
+CREATE TABLE IF NOT EXISTS public.squad_read_cursors (
+  user_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  squad_id UUID NOT NULL REFERENCES public.squads(id) ON DELETE CASCADE,
+  last_read_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, squad_id)
+);
+
+CREATE INDEX idx_squad_read_cursors_squad ON public.squad_read_cursors(squad_id);
+
+-- 2. RLS
+ALTER TABLE public.squad_read_cursors ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own cursors" ON public.squad_read_cursors
+  FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY "Users can insert own cursors" ON public.squad_read_cursors
+  FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY "Users can update own cursors" ON public.squad_read_cursors
+  FOR UPDATE USING (user_id = auth.uid());
+
+-- 3. Seed cursors for existing squad members (so they don't see old messages as unread)
+INSERT INTO public.squad_read_cursors (user_id, squad_id, last_read_at)
+SELECT sm.user_id, sm.squad_id, NOW()
+FROM public.squad_members sm
+WHERE sm.role != 'waitlist'
+ON CONFLICT DO NOTHING;
+
+-- 4. Auto-create cursor when user joins a squad
+CREATE OR REPLACE FUNCTION public.init_squad_read_cursor()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.role IS DISTINCT FROM 'waitlist' THEN
+    INSERT INTO public.squad_read_cursors (user_id, squad_id, last_read_at)
+    VALUES (NEW.user_id, NEW.squad_id, NOW())
+    ON CONFLICT (user_id, squad_id) DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_squad_member_init_cursor ON public.squad_members;
+CREATE TRIGGER on_squad_member_init_cursor
+  AFTER INSERT ON public.squad_members
+  FOR EACH ROW EXECUTE FUNCTION public.init_squad_read_cursor();
+
+-- 5. RPC: get squad IDs with unread messages for a user
+CREATE OR REPLACE FUNCTION public.get_unread_squad_ids(p_user_id UUID)
+RETURNS TABLE(squad_id UUID) AS $$
+  SELECT DISTINCT m.squad_id
+  FROM public.messages m
+  JOIN public.squad_read_cursors src ON src.squad_id = m.squad_id AND src.user_id = p_user_id
+  WHERE m.created_at > src.last_read_at
+    AND m.sender_id IS DISTINCT FROM p_user_id
+    AND m.is_system = false;
+$$ LANGUAGE sql SECURITY DEFINER STABLE;


### PR DESCRIPTION
## Summary
Replace notification-row-based squad unread tracking with a read cursor system. One row per user per squad instead of one notification per message per member.

**Before:** Every squad message created N notification rows (one per member). Unread = query notifications WHERE is_read=false. Mark read = bulk UPDATE hundreds of rows. 5+ state variables with race conditions.

**After:** One cursor row per user per squad. Unread = messages.created_at > cursor.last_read_at. Mark read = single UPSERT. No client-side suppression set needed.

### Changes
- **Migration**: \`squad_read_cursors\` table, RLS, seed, auto-create trigger, \`get_unread_squad_ids\` RPC
- **db.ts**: \`getUnreadSquadIds\` → RPC call; new \`markSquadRead\` → cursor upsert
- **useNotifications**: removed \`unreadSquadCount\`, \`hasUnreadSquadMessage\`, \`onUnreadSquadIds\` — now bell-only
- **useSquads**: \`hydrateSquads\` accepts \`unreadSquadIds\` param, sets \`hasUnread\` from cursor (source of truth)
- **page.tsx**: removed \`readSquadIdsRef\`, simplified squad open/close handlers, \`loadRealData\` fetches unread IDs in parallel

**Push notifications unchanged** — the trigger still creates notification rows for the webhook. They're just no longer used for unread UI tracking.

## Test plan
- [x] Run migration
- [ ] Open app → squads with unread messages show red dot
- [ ] Open squad chat → dot clears, cursor updated
- [ ] Close chat → new message arrives → dot reappears
- [ ] Pull to refresh → dots resync from cursor
- [ ] App backgrounded → messages arrive → come back → dots correct
- [ ] Push notifications still delivered when not in chat
- [ ] Push suppressed when in the chat (service worker unchanged)
- [ ] New squad member → cursor auto-created → no old messages shown as unread

🤖 Generated with [Claude Code](https://claude.com/claude-code)