### PR TITLE
feat: one-time instant friendship URLs

### DIFF
--- a/src/app/friend/page.tsx
+++ b/src/app/friend/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import { font, color } from "@/lib/styles";
+import Grain from "@/app/components/Grain";
+
+/**
+ * /friend?token=<uuid>
+ *
+ * Landing page for one-time instant friendship links.
+ * - If logged in: redeems immediately
+ * - If not logged in: shows creator info + "Join to connect" → stores token, redirects to auth
+ *
+ * Security:
+ * - UUID v4 token (128-bit, unguessable)
+ * - One-time use (redeemed_by set on first use)
+ * - 24h expiry
+ * - Max 5 active links per creator (enforced in create_friend_link RPC)
+ * - Cannot use your own link
+ * - Signup cap still enforced (auth flow checks independently)
+ */
+
+export default function FriendLinkPage() {
+  const [status, setStatus] = useState<"loading" | "redeemed" | "error" | "login-needed">("loading");
+  const [creatorName, setCreatorName] = useState<string | null>(null);
+  const [creatorAvatar, setCreatorAvatar] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+
+    if (!token) {
+      setStatus("error");
+      setErrorMsg("Invalid link");
+      return;
+    }
+
+    (async () => {
+      // Check if user is logged in
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (!session) {
+        // Store token for post-auth redemption
+        localStorage.setItem("pendingFriendToken", token);
+
+        // Fetch creator info via public lookup (service client not needed — use anon)
+        // We can't look up the creator without auth, so just show generic UI
+        setStatus("login-needed");
+        return;
+      }
+
+      // Logged in — try to redeem
+      try {
+        const { data, error } = await supabase.rpc("redeem_friend_link", { p_token: token });
+
+        if (error) {
+          setStatus("error");
+          setErrorMsg(error.message);
+          return;
+        }
+
+        const result = data as { success?: boolean; error?: string; creator_name?: string; already_friends?: boolean };
+
+        if (result.error) {
+          if (result.already_friends) {
+            setStatus("redeemed");
+            setCreatorName(result.creator_name ?? null);
+          } else {
+            setStatus("error");
+            setErrorMsg(result.error);
+          }
+          return;
+        }
+
+        setStatus("redeemed");
+        setCreatorName(result.creator_name ?? null);
+        setCreatorAvatar(result.creator_name?.[0]?.toUpperCase() ?? null);
+
+        // Clear the pending token
+        localStorage.removeItem("pendingFriendToken");
+      } catch {
+        setStatus("error");
+        setErrorMsg("Something went wrong");
+      }
+    })();
+  }, []);
+
+  return (
+    <div style={{
+      maxWidth: 420,
+      margin: "0 auto",
+      minHeight: "100vh",
+      background: color.bg,
+      padding: "80px 24px",
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      textAlign: "center",
+    }}>
+      <Grain />
+
+      {status === "loading" && (
+        <p style={{ fontFamily: font.mono, fontSize: 12, color: color.dim }}>Loading...</p>
+      )}
+
+      {status === "redeemed" && (
+        <>
+          {creatorAvatar && (
+            <div style={{
+              width: 64, height: 64, borderRadius: "50%",
+              background: color.accent, color: "#000",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              fontFamily: font.mono, fontSize: 24, fontWeight: 700,
+              marginBottom: 20,
+            }}>
+              {creatorAvatar}
+            </div>
+          )}
+          <h1 style={{ fontFamily: font.serif, fontSize: 32, color: color.text, fontWeight: 400, marginBottom: 8 }}>
+            you&apos;re connected!
+          </h1>
+          <p style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 32, lineHeight: 1.6 }}>
+            you and {creatorName ?? "your friend"} are now friends on down to
+          </p>
+          <a
+            href="/"
+            style={{
+              display: "block",
+              width: "100%",
+              padding: 16,
+              background: color.accent,
+              color: "#000",
+              border: "none",
+              borderRadius: 12,
+              fontFamily: font.mono,
+              fontSize: 14,
+              fontWeight: 700,
+              textAlign: "center",
+              textDecoration: "none",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+            }}
+          >
+            Open App
+          </a>
+        </>
+      )}
+
+      {status === "login-needed" && (
+        <>
+          <h1 style={{ fontFamily: font.serif, fontSize: 32, color: color.text, fontWeight: 400, marginBottom: 8 }}>
+            you&apos;ve been invited
+          </h1>
+          <p style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 32, lineHeight: 1.6 }}>
+            someone wants to connect with you on down to. sign up or log in to accept.
+          </p>
+          <a
+            href="/?pendingFriend=1"
+            style={{
+              display: "block",
+              width: "100%",
+              padding: 16,
+              background: color.accent,
+              color: "#000",
+              border: "none",
+              borderRadius: 12,
+              fontFamily: font.mono,
+              fontSize: 14,
+              fontWeight: 700,
+              textAlign: "center",
+              textDecoration: "none",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+            }}
+          >
+            Join to Connect
+          </a>
+        </>
+      )}
+
+      {status === "error" && (
+        <>
+          <h1 style={{ fontFamily: font.serif, fontSize: 32, color: color.text, fontWeight: 400, marginBottom: 8 }}>
+            link expired
+          </h1>
+          <p style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 32, lineHeight: 1.6 }}>
+            {errorMsg || "This friend link is no longer valid. Ask your friend to send a new one."}
+          </p>
+          <a
+            href="/"
+            style={{
+              display: "block",
+              width: "100%",
+              padding: 16,
+              background: "transparent",
+              color: color.text,
+              border: `1px solid ${color.borderMid}`,
+              borderRadius: 12,
+              fontFamily: font.mono,
+              fontSize: 14,
+              fontWeight: 700,
+              textAlign: "center",
+              textDecoration: "none",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+            }}
+          >
+            Go to App
+          </a>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/features/auth/hooks/useOnboarding.tsx
+++ b/src/features/auth/hooks/useOnboarding.tsx
@@ -374,6 +374,13 @@ export function useOnboarding({
         }
       }
 
+      // Auto-redeem pending friend link (from /friend?token=xxx flow)
+      const pendingFriendToken = typeof window !== "undefined" ? localStorage.getItem("pendingFriendToken") : null;
+      if (pendingFriendToken) {
+        localStorage.removeItem("pendingFriendToken");
+        db.redeemFriendLink(pendingFriendToken).catch(() => {});
+      }
+
       // Wait for feed data before setting up friend gate
       if (!feedLoaded) return <div style={{ minHeight: "100vh", background: "#111" }} />;
 

--- a/src/features/friends/components/FriendsModal.tsx
+++ b/src/features/friends/components/FriendsModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { font, color } from "@/lib/styles";
 import type { Friend } from "@/lib/ui-types";
+import * as db from "@/lib/db";
 import { logError } from "@/lib/logger";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
 
@@ -386,6 +387,39 @@ const FriendsModal = ({
           </>
         ) : (
           <>
+            {/* Invite link */}
+            <button
+              onClick={async () => {
+                try {
+                  const token = await db.createFriendLink();
+                  const url = `${window.location.origin}/friend?token=${token}`;
+                  if (navigator.share) {
+                    await navigator.share({ title: "Add me on down to", url });
+                  } else {
+                    await navigator.clipboard.writeText(url);
+                    // TODO: show toast
+                  }
+                } catch { /* cancelled or error */ }
+              }}
+              style={{
+                width: "100%",
+                padding: "12px 0",
+                background: "transparent",
+                border: `1px dashed ${color.borderMid}`,
+                borderRadius: 12,
+                color: color.accent,
+                fontFamily: font.mono,
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                marginBottom: 16,
+              }}
+            >
+              Share invite link
+            </button>
+
             {/* Incoming requests */}
             {incomingRequests.length > 0 && (
               <>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -469,6 +469,22 @@ export async function removeFriend(friendshipId: string): Promise<void> {
   if (error) throw error;
 }
 
+// ============================================================================
+// FRIEND LINKS
+// ============================================================================
+
+export async function createFriendLink(): Promise<string> {
+  const { data, error } = await supabase.rpc('create_friend_link');
+  if (error) throw error;
+  return data as string;
+}
+
+export async function redeemFriendLink(token: string): Promise<{ success?: boolean; error?: string; creator_name?: string; already_friends?: boolean }> {
+  const { data, error } = await supabase.rpc('redeem_friend_link', { p_token: token });
+  if (error) throw error;
+  return data as { success?: boolean; error?: string; creator_name?: string; already_friends?: boolean };
+}
+
 export function subscribeToFriendships(
   userId: string,
   callback: (event: 'INSERT' | 'UPDATE' | 'DELETE', friendship: Friendship) => void

--- a/supabase/migrations/20260327000003_friend_links.sql
+++ b/supabase/migrations/20260327000003_friend_links.sql
@@ -1,0 +1,130 @@
+-- One-time instant friendship URLs.
+-- Security: UUID v4 token (unguessable), one-time use, 24h expiry, max 5 active per user.
+
+CREATE TABLE IF NOT EXISTS public.friend_links (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  token UUID NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+  redeemed_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  redeemed_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '24 hours'),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_friend_links_token ON public.friend_links(token);
+CREATE INDEX idx_friend_links_creator ON public.friend_links(creator_id);
+
+-- RLS
+ALTER TABLE public.friend_links ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own links" ON public.friend_links
+  FOR SELECT USING (creator_id = auth.uid());
+CREATE POLICY "Users can create own links" ON public.friend_links
+  FOR INSERT WITH CHECK (creator_id = auth.uid());
+
+-- RPC: create a friend link (enforces max 5 active per user)
+CREATE OR REPLACE FUNCTION public.create_friend_link()
+RETURNS UUID AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_active_count INT;
+  v_token UUID;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Count active (unredeemed, unexpired) links
+  SELECT COUNT(*) INTO v_active_count
+  FROM public.friend_links
+  WHERE creator_id = v_user_id
+    AND redeemed_by IS NULL
+    AND expires_at > NOW();
+
+  IF v_active_count >= 5 THEN
+    RAISE EXCEPTION 'Too many active friend links (max 5)';
+  END IF;
+
+  INSERT INTO public.friend_links (creator_id)
+  VALUES (v_user_id)
+  RETURNING token INTO v_token;
+
+  RETURN v_token;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- RPC: redeem a friend link (one-time use, creates mutual friendship)
+CREATE OR REPLACE FUNCTION public.redeem_friend_link(p_token UUID)
+RETURNS JSONB AS $$
+DECLARE
+  v_user_id UUID := auth.uid();
+  v_link RECORD;
+  v_creator_name TEXT;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Find the link
+  SELECT * INTO v_link
+  FROM public.friend_links
+  WHERE token = p_token
+  FOR UPDATE; -- lock to prevent double-redemption
+
+  IF v_link IS NULL THEN
+    RETURN jsonb_build_object('error', 'Link not found');
+  END IF;
+
+  IF v_link.redeemed_by IS NOT NULL THEN
+    RETURN jsonb_build_object('error', 'Link already used');
+  END IF;
+
+  IF v_link.expires_at < NOW() THEN
+    RETURN jsonb_build_object('error', 'Link expired');
+  END IF;
+
+  IF v_link.creator_id = v_user_id THEN
+    RETURN jsonb_build_object('error', 'Cannot use your own link');
+  END IF;
+
+  -- Check if already friends
+  IF EXISTS (
+    SELECT 1 FROM public.friendships
+    WHERE status = 'accepted'
+      AND ((requester_id = v_user_id AND addressee_id = v_link.creator_id)
+        OR (requester_id = v_link.creator_id AND addressee_id = v_user_id))
+  ) THEN
+    RETURN jsonb_build_object('error', 'Already friends', 'already_friends', true);
+  END IF;
+
+  -- Mark link as redeemed
+  UPDATE public.friend_links
+  SET redeemed_by = v_user_id, redeemed_at = NOW()
+  WHERE id = v_link.id;
+
+  -- Create or accept friendship
+  -- If there's a pending request in either direction, accept it
+  UPDATE public.friendships
+  SET status = 'accepted', updated_at = NOW()
+  WHERE status = 'pending'
+    AND ((requester_id = v_user_id AND addressee_id = v_link.creator_id)
+      OR (requester_id = v_link.creator_id AND addressee_id = v_user_id));
+
+  -- If no existing friendship, create one as accepted
+  IF NOT FOUND THEN
+    INSERT INTO public.friendships (requester_id, addressee_id, status)
+    VALUES (v_link.creator_id, v_user_id, 'accepted')
+    ON CONFLICT (requester_id, addressee_id) DO UPDATE SET status = 'accepted', updated_at = NOW();
+  END IF;
+
+  -- Get creator name for the response
+  SELECT display_name INTO v_creator_name
+  FROM public.profiles WHERE id = v_link.creator_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'creator_id', v_link.creator_id,
+    'creator_name', COALESCE(v_creator_name, 'Someone')
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
Share a link via iMessage/text → recipient opens it → both are instantly connected as friends. No pending request needed.

### Security safeguards
- **UUID v4 token** — 128-bit, effectively unguessable
- **One-time use** — redeemed_by is set on first redemption, subsequent attempts fail
- **24h expiry** — links auto-expire
- **Max 5 active links** per creator (RPC enforced)
- **Cannot use own link** — RPC rejects self-redemption
- **Signup cap independent** — friend link doesn't bypass auth signup cap
- **Existing friendships handled** — returns "already friends" instead of erroring

### Implementation
- **Migration**: \`friend_links\` table with RLS, \`create_friend_link\` and \`redeem_friend_link\` RPCs
- **\`/friend?token=xxx\`**: landing page — auto-redeems if logged in, stores token + redirects to auth if not
- **Post-auth redemption**: \`useOnboarding\` checks \`pendingFriendToken\` in localStorage after login
- **\`FriendsModal\`**: "Share invite link" button in Add tab — uses Web Share API on mobile, clipboard on desktop
- **\`db.ts\`**: \`createFriendLink()\` and \`redeemFriendLink()\` wrappers

Closes #60

## Test plan
- [ ] Run migration
- [ ] Tap "Share invite link" in Add tab → native share sheet / clipboard
- [ ] Open link while logged in → auto-redeems, shows "you're connected!"
- [ ] Open link while logged out → shows invite page → sign up → auto-redeems after auth
- [ ] Use same link twice → "Link already used" error
- [ ] Wait 24h → "Link expired" error
- [ ] Use own link → "Cannot use your own link" error
- [ ] Create 6 links → "Too many active friend links" error
- [ ] Already friends → shows "you're connected!" (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)