### PR TITLE
feat: waitlist when signup cap is reached

### DIFF
--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -262,5 +262,9 @@ export async function GET(request: NextRequest) {
       commentsByDate,
       messagesByDate,
     },
+    waitlist: await (async () => {
+      const { data, count } = await admin.from("waitlist").select("*", { count: "exact" }).order("created_at", { ascending: false }).limit(20);
+      return { total: count ?? 0, recent: data ?? [] };
+    })(),
   });
 }

--- a/src/app/api/auth/check-signup/route.ts
+++ b/src/app/api/auth/check-signup/route.ts
@@ -33,12 +33,39 @@ export async function POST(request: Request) {
   }
 
   if ((count ?? 0) >= SIGNUP_CAP) {
+    // Check if already on waitlist
+    const { count: waitlistCount } = await supabase
+      .from("waitlist")
+      .select("*", { count: "exact", head: true })
+      .eq("email", email.toLowerCase());
+
     return NextResponse.json({
       allowed: false,
       existing: false,
+      alreadyWaitlisted: (waitlistCount ?? 0) > 0,
       message: "we're at capacity right now — join the waitlist and we'll let you in soon",
     });
   }
 
   return NextResponse.json({ allowed: true, existing: false });
+}
+
+// PUT: join waitlist
+export async function PUT(request: Request) {
+  const { email } = await request.json();
+  if (!email || !email.includes("@")) {
+    return NextResponse.json({ error: "Valid email required" }, { status: 400 });
+  }
+
+  const supabase = getServiceClient();
+
+  const { error } = await supabase
+    .from("waitlist")
+    .upsert({ email: email.toLowerCase() }, { onConflict: "email" });
+
+  if (error) {
+    return NextResponse.json({ error: "Failed to join waitlist" }, { status: 500 });
+  }
+
+  return NextResponse.json({ joined: true });
 }

--- a/src/features/auth/components/AuthScreen.tsx
+++ b/src/features/auth/components/AuthScreen.tsx
@@ -26,6 +26,8 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
   const [error, setError] = useState<string | null>(null);
 
   const [capBlocked, setCapBlocked] = useState(false);
+  const [waitlistJoined, setWaitlistJoined] = useState(false);
+  const [joiningWaitlist, setJoiningWaitlist] = useState(false);
 
   const handleSendCode = async () => {
     if (!email.includes("@")) return;
@@ -43,6 +45,7 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
       const data = await res.json();
       if (!data.allowed) {
         setCapBlocked(true);
+        if (data.alreadyWaitlisted) setWaitlistJoined(true);
         setLoading(false);
         return;
       }
@@ -165,12 +168,63 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
             textAlign: "center",
           }}
         >
-          <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 8 }}>
-            we&apos;re at capacity
-          </p>
-          <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, lineHeight: 1.6, marginBottom: 0 }}>
-            we&apos;re keeping things small for now. if you already have an account, try logging in with your email. otherwise, sit tight — we&apos;ll open up more spots soon.
-          </p>
+          {waitlistJoined ? (
+            <>
+              <p style={{ fontFamily: font.serif, fontSize: 18, color: color.accent, marginBottom: 8 }}>
+                you&apos;re on the list
+              </p>
+              <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, lineHeight: 1.6, marginBottom: 0 }}>
+                we&apos;ll let you know when a spot opens up. if you already have an account, try logging in with your email.
+              </p>
+            </>
+          ) : (
+            <>
+              <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 8 }}>
+                we&apos;re at capacity
+              </p>
+              <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, lineHeight: 1.6, marginBottom: 16 }}>
+                we&apos;re keeping things small for now. drop your email and we&apos;ll let you in when there&apos;s room.
+              </p>
+              <button
+                onClick={async () => {
+                  if (!email.includes("@")) return;
+                  setJoiningWaitlist(true);
+                  try {
+                    await fetch("/api/auth/check-signup", {
+                      method: "PUT",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ email }),
+                    });
+                    setWaitlistJoined(true);
+                  } catch {
+                    setError("Failed to join waitlist");
+                  } finally {
+                    setJoiningWaitlist(false);
+                  }
+                }}
+                disabled={!email.includes("@") || joiningWaitlist}
+                style={{
+                  width: "100%",
+                  padding: "14px",
+                  background: email.includes("@") ? color.accent : color.borderMid,
+                  color: email.includes("@") ? "#000" : color.dim,
+                  border: "none",
+                  borderRadius: 12,
+                  fontFamily: font.mono,
+                  fontSize: 13,
+                  fontWeight: 700,
+                  cursor: email.includes("@") ? "pointer" : "not-allowed",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                }}
+              >
+                {joiningWaitlist ? "Joining..." : "Join Waitlist"}
+              </button>
+              <p style={{ fontFamily: font.mono, fontSize: 10, color: color.faint, marginTop: 10, marginBottom: 0 }}>
+                already have an account? just enter your email above and send code.
+              </p>
+            </>
+          )}
         </div>
       )}
 

--- a/supabase/migrations/20260327000004_waitlist.sql
+++ b/supabase/migrations/20260327000004_waitlist.sql
@@ -1,0 +1,10 @@
+-- Waitlist for when signup cap is reached.
+-- Stores email + timestamp so admin can manually invite later.
+
+CREATE TABLE IF NOT EXISTS public.waitlist (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- No RLS needed — only accessed via service client in API route.


### PR DESCRIPTION
## Summary
When the signup cap blocks a new user, show a "Join Waitlist" button instead of a dead-end message. Emails collected for manual outreach.

- **Waitlist table**: email + created_at, unique on email
- **check-signup API**: returns \`alreadyWaitlisted\` flag; new PUT method to join
- **AuthScreen**: uses the email already entered in the field, shows "you're on the list" confirmation after joining, detects if already waitlisted
- **Admin metrics**: adds waitlist total count + 20 most recent entries

Closes #183

## Test plan
- [ ] Run migration
- [ ] Set SIGNUP_CAP low → enter new email → see "Join Waitlist" button
- [ ] Tap "Join Waitlist" → shows "you're on the list" confirmation
- [ ] Enter same email again → immediately shows "you're on the list" (already waitlisted)
- [ ] Existing user email → bypasses cap, gets OTP normally
- [ ] Admin metrics endpoint → shows waitlist count and entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)