### PR TITLE
feat: comment/mention notifications open check with comments visible

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -77,7 +77,7 @@ self.addEventListener("notificationclick", (event) => {
     tab = "/?tab=profile&openFriends=1";
   } else if (type === "squad_message" || type === "squad_invite") {
     tab = relatedId ? `/?tab=groups&squadId=${relatedId}` : "/?tab=groups";
-  } else if (type === "check_response" || type === "friend_check") {
+  } else if (type === "check_response" || type === "friend_check" || type === "check_comment" || type === "comment_mention") {
     tab = relatedId ? `/?tab=feed&checkId=${relatedId}` : "/?tab=feed";
   } else if (type === "date_confirm") {
     tab = relatedId ? `/?tab=groups&squadId=${relatedId}` : "/?tab=groups";

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import * as db from "@/lib/db";
 import type { Profile } from "@/lib/types";
 import type { InterestCheck, Friend } from "@/lib/ui-types";
@@ -97,6 +97,14 @@ export default function CheckCard({
   } = useFeedContext();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
+
+  // Auto-open comments when navigated to this check via notification
+  useEffect(() => {
+    if (newlyAddedCheckId === check.id && !isCommentsOpen) {
+      openComments();
+      setIsCommentsOpen(true);
+    }
+  }, [newlyAddedCheckId, check.id]);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [actionsSheetOpen, setActionsSheetOpen] = useState(false);
 

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -304,6 +304,16 @@ const NotificationsPanel = ({
                     }
                     onClose();
                     onNavigate({ type: "feed" });
+                  } else if (n.type === "check_comment" || n.type === "comment_mention") {
+                    if (!n.is_read) {
+                      if (userId) db.markNotificationRead(n.id);
+                      setNotifications((prev) =>
+                        prev.map((notif) => notif.id === n.id ? { ...notif, is_read: true } : notif)
+                      );
+                      setUnreadCount((prev) => Math.max(0, prev - 1));
+                    }
+                    onClose();
+                    onNavigate({ type: "feed", checkId: n.related_check_id ?? undefined });
                   } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag") {
                     // Mark single notification as read (except check_tag — cleared on accept/decline)
                     if (!n.is_read && n.type !== "check_tag") {


### PR DESCRIPTION
## Summary
Comment and @mention notifications now properly navigate to the check and auto-open the comments section.

**Before:** Tapping a \`comment_mention\` or \`check_comment\` notification did nothing — the click handler had no case for these types.

**After:**
- NotificationsPanel routes both types to \`{ type: "feed", checkId }\`
- Service worker routes push notification clicks to \`/?tab=feed&checkId=\`
- CheckCard auto-opens comments when navigated to via \`newlyAddedCheckId\`

Closes #229

## Test plan
- [ ] Receive a comment notification → tap → navigates to feed, check highlighted, comments open
- [ ] Receive a @mention in comment → tap → same behavior
- [ ] Push notification click (app closed) → opens app to feed with check + comments visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)