### PR TITLE
fix: squad button showing Join when already a member

### DIFF
--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -66,6 +66,8 @@ function transformCheck(c: ActiveCheck, userId: string | null): InterestCheck {
     maxSquadSize: c.max_squad_size,
     squadId: c.squads?.find((s) => !s.archived_at)?.id,
     squadMemberCount: c.squads?.find((s) => !s.archived_at)?.members?.filter((m) => (m as { role?: string }).role !== 'waitlist')?.length ?? 0,
+    inSquad: !!userId && !!(c.squads?.find((s) => !s.archived_at)?.members?.some((m) => (m as { user_id?: string }).user_id === userId && (m as { role?: string }).role !== 'waitlist')),
+    isWaitlisted: !!userId && !!(c.squads?.find((s) => !s.archived_at)?.members?.some((m) => (m as { user_id?: string }).user_id === userId && (m as { role?: string }).role === 'waitlist')),
     eventDate: c.event_date ?? undefined,
     eventDateLabel: c.event_date ? new Date(c.event_date + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }) : undefined,
     eventTime: c.event_time?.replace(/\s*[Aa][Mm]/g, 'am').replace(/\s*[Pp][Mm]/g, 'pm') ?? undefined,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -616,20 +616,16 @@ export async function getSharedCheck(checkId: string) {
 
     const { data: squad } = await supabase
       .from('squads')
-      .select('id, members:squad_members(id)')
+      .select('id, members:squad_members(id, user_id, role)')
       .eq('check_id', checkId)
       .is('archived_at', null)
       .maybeSingle();
     if (squad) {
       squadId = squad.id;
-      squadMemberCount = (squad.members as { id: string }[])?.length ?? 0;
-      const { data: membership } = await supabase
-        .from('squad_members')
-        .select('id')
-        .eq('squad_id', squad.id)
-        .eq('user_id', user.id)
-        .maybeSingle();
-      inSquad = !!membership;
+      const members = squad.members as { id: string; user_id: string; role: string }[];
+      squadMemberCount = members?.filter((m) => m.role !== 'waitlist')?.length ?? 0;
+      const myMembership = members?.find((m) => m.user_id === user.id);
+      inSquad = !!myMembership && myMembership.role !== 'waitlist';
     }
   }
 
@@ -733,7 +729,7 @@ export async function getActiveChecks(): Promise<(InterestCheck & { author: Prof
       *,
       author:profiles!author_id(*),
       responses:check_responses(*, user:profiles!user_id(*)),
-      squads(id, archived_at, members:squad_members(id, role)),
+      squads(id, archived_at, members:squad_members(id, user_id, role)),
       co_authors:check_co_authors(*, user:profiles!user_id(*))
     `)
     .or(`expires_at.gt.${new Date().toISOString()},expires_at.is.null,event_date.gte.${new Date().toISOString().slice(0, 10)}`)


### PR DESCRIPTION
## Summary
- Squad members query was missing `user_id`, so `inSquad` and `isWaitlisted` were never computed — button always showed "Join Squad"
- Added `user_id` to squad members select and derived both fields in `transformCheck`
- Fixed `getCheckById` to exclude waitlisted users from member count

## Test plan
- [ ] Respond "down" to a check that auto-creates a squad → button should show "💬 Squad →"
- [ ] Join a squad via "Join Squad →" → button should update to "💬 Squad →" after reload
- [ ] When squad is full and user joins waitlist → button should show "Waitlisted"

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)