### PR TITLE
fix: update EditCheckModal to match creation flow UI

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -91,6 +91,7 @@ export default function CheckCard({
     pendingDownCheckIds,
     newlyAddedCheckId,
     respondToCheck,
+    clearResponse,
     acceptCoAuthorTag,
     declineCoAuthorTag,
     hideCheck,
@@ -321,6 +322,7 @@ export default function CheckCard({
                     disabled={check.expiresIn === "expired" && !myCheckResponses[check.id]}
                     onClick={() => {
                       if (myCheckResponses[check.id] === "down" || myCheckResponses[check.id] === "waitlist") {
+                        clearResponse(check.id);
                         if (check.id) {
                           db.removeCheckResponse(check.id)
                             .then(() => loadRealData())
@@ -492,7 +494,7 @@ export default function CheckCard({
         onSave={async (updates) => {
           setEditModalOpen(false);
           try {
-            await db.updateInterestCheck(check.id, { text: updates.text, event_date: updates.eventDate, event_time: updates.eventTime, date_flexible: updates.dateFlexible, time_flexible: updates.timeFlexible });
+            await db.updateInterestCheck(check.id, { text: updates.text, event_date: updates.eventDate, event_time: updates.eventTime, date_flexible: updates.dateFlexible, time_flexible: updates.timeFlexible, location: updates.location });
             if (updates.taggedFriendIds && updates.taggedFriendIds.length > 0) await db.tagCoAuthors(check.id, updates.taggedFriendIds);
             if (check.squadId) await db.updateSquadName(check.squadId, updates.text);
           } catch (err) { logError("updateCheck", err, { checkId: check.id }); showToast("Failed to save changes"); return; }

--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { font, color } from "@/lib/styles";
-import { parseNaturalDate, parseNaturalTime, parseNaturalLocation, parseDateToISO } from "@/lib/utils";
+import { parseNaturalDate, parseNaturalTime, parseDateToISO } from "@/lib/utils";
 import type { InterestCheck } from "@/lib/ui-types";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
 
@@ -25,6 +25,7 @@ const EditCheckModal = ({
     eventTime: string | null;
     dateFlexible: boolean;
     timeFlexible: boolean;
+    location?: string | null;
     taggedFriendIds?: string[];
   }) => void;
   friends?: { id: string; name: string; avatar: string }[];
@@ -32,13 +33,8 @@ const EditCheckModal = ({
   onRemoveTag?: (checkId: string, userId: string) => Promise<void>;
 }) => {
   const [text, setText] = useState("");
-  const [manualDate, setManualDate] = useState<string | null>(null);
-  const [manualTime, setManualTime] = useState<string | null>(null);
-  const [manualLocation, setManualLocation] = useState<string | null>(null);
-  const [dateLocked, setDateLocked] = useState(false);
-  const [timeLocked, setTimeLocked] = useState(false);
-  const [locationLocked, setLocationLocked] = useState(false);
-  const [editingChip, setEditingChip] = useState<"date" | "time" | "location" | null>(null);
+  const [whenInput, setWhenInput] = useState("");
+  const [whereInput, setWhereInput] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
   const { visible, entering, closing, close } = useModalTransition(open, onClose);
@@ -51,13 +47,12 @@ const EditCheckModal = ({
   useEffect(() => {
     if (check && open) {
       setText(check.text);
-      setManualDate(check.eventDateLabel || check.eventDate || null);
-      setManualTime(check.eventTime || null);
-      setManualLocation(null);
-      setDateLocked(!check.dateFlexible);
-      setTimeLocked(!check.timeFlexible);
-      setLocationLocked(false);
-      setEditingChip(null);
+      // Combine existing date + time into the when input
+      const parts: string[] = [];
+      if (check.eventDateLabel || check.eventDate) parts.push(check.eventDateLabel || check.eventDate!);
+      if (check.eventTime) parts.push(check.eventTime);
+      setWhenInput(parts.join(" "));
+      setWhereInput(check.location || "");
       setMentionQuery(null);
       setMentionIdx(-1);
     }
@@ -91,15 +86,21 @@ const EditCheckModal = ({
 
   if (!visible || !check) return null;
 
-  const detectedDate = text ? parseNaturalDate(text) : null;
-  const detectedTime = text ? parseNaturalTime(text) : null;
-  const detectedLocation = text ? parseNaturalLocation(text) : null;
+  const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
+  const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
+  const whenPreview = (() => {
+    if (!parsedDate && !parsedTime) return null;
+    const parts: string[] = [];
+    if (parsedDate) parts.push(parsedDate.label);
+    if (parsedTime) parts.push(parsedTime);
+    return parts.join(" ");
+  })();
 
   const handleSave = () => {
     const trimmed = text.trim();
     if (!trimmed) return;
 
-    // Extract @mentions → friend IDs for new tags (match username or display name)
+    // Extract @mentions → friend IDs for new tags
     const mentionNames = [...trimmed.matchAll(/@(\S+)/g)].map(m => m[1].toLowerCase());
     const taggedIds = (friends ?? [])
       .filter(f => mentionNames.some(m =>
@@ -108,7 +109,6 @@ const EditCheckModal = ({
         m === f.name.split(' ')[0]?.toLowerCase()
       ))
       .map(f => f.id);
-    // Filter out co-authors that are already pending or accepted (allow re-tagging declined)
     const activeIds = new Set(
       (check.coAuthors ?? [])
         .filter(ca => ca.status === 'pending' || ca.status === 'accepted')
@@ -116,20 +116,25 @@ const EditCheckModal = ({
     );
     const newTagIds = taggedIds.filter(id => !activeIds.has(id));
 
-    // Resolve date: manual > detected > existing check > null
-    const resolvedDateLabel = manualDate || detectedDate?.label || check.eventDateLabel || null;
-    const resolvedDateISO = manualDate
-      ? (parseNaturalDate(manualDate)?.iso || parseDateToISO(manualDate) || check.eventDate || null)
-      : (detectedDate?.iso || check.eventDate || null);
-    const resolvedTime = manualTime || detectedTime || check.eventTime || null;
+    // Resolve date: parsed > existing
+    const resolvedDateISO = parsedDate?.iso
+      ?? (parseDateToISO(whenInput) || null)
+      ?? check.eventDate
+      ?? null;
+    const resolvedDateLabel = parsedDate?.label
+      ?? (resolvedDateISO ? whenInput.trim() : null)
+      ?? check.eventDateLabel
+      ?? null;
+    const resolvedTime = parsedTime ?? check.eventTime ?? null;
 
     onSave({
       text: trimmed,
       eventDate: resolvedDateISO,
       eventDateLabel: resolvedDateLabel,
       eventTime: resolvedTime,
-      dateFlexible: !dateLocked,
-      timeFlexible: !timeLocked,
+      dateFlexible: true,
+      timeFlexible: true,
+      location: whereInput.trim() || null,
       taggedFriendIds: newTagIds.length > 0 ? newTagIds : undefined,
     });
   };
@@ -203,7 +208,6 @@ const EditCheckModal = ({
               onChange={(e) => {
                 const val = e.target.value.slice(0, 280);
                 setText(val);
-                // Detect @mention
                 const cursor = e.target.selectionStart ?? val.length;
                 const before = val.slice(0, cursor);
                 const atMatch = before.match(/@([^\s@]*)$/);
@@ -282,157 +286,59 @@ const EditCheckModal = ({
             })()}
           </div>
 
-          {/* Date / Time / Location chips — always visible */}
-          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: 12 }}>
-            {([
-              {
-                key: "date" as const,
-                placeholder: "date?",
-                detected: detectedDate?.label ?? null,
-                manual: manualDate,
-                setManual: setManualDate,
-                locked: dateLocked,
-                setLocked: setDateLocked,
-              },
-              {
-                key: "time" as const,
-                placeholder: "time?",
-                detected: detectedTime ?? null,
-                manual: manualTime,
-                setManual: setManualTime,
-                locked: timeLocked,
-                setLocked: setTimeLocked,
-              },
-              {
-                key: "location" as const,
-                placeholder: "location?",
-                detected: detectedLocation ?? null,
-                manual: manualLocation,
-                setManual: setManualLocation,
-                locked: locationLocked,
-                setLocked: setLocationLocked,
-              },
-            ] as const).map((chip) => {
-              const value = chip.manual !== null ? chip.manual : chip.detected;
-              const hasValue = !!value;
-              const isEditing = editingChip === chip.key;
-
-              if (isEditing) {
-                const validate = (v: string): string | null => {
-                  if (!v) return "";
-                  if (chip.key === "date") {
-                    const parsed = parseNaturalDate(v);
-                    if (parsed) return parsed.label;
-                    if (parseDateToISO(v)) return v;
-                    return null;
-                  }
-                  if (chip.key === "time") {
-                    const parsed = parseNaturalTime(v);
-                    if (parsed) return parsed;
-                    return null;
-                  }
-                  return v;
-                };
-                return (
-                  <input
-                    key={chip.key}
-                    autoFocus
-                    placeholder={chip.key === "date" ? "e.g. friday, mar 7" : chip.key === "time" ? "e.g. 7pm, noon" : "e.g. Jollibee"}
-                    defaultValue={value ?? ""}
-                    onBlur={(e) => {
-                      const v = e.target.value.trim();
-                      const result = validate(v);
-                      if (result !== null) {
-                        chip.setManual(result);
-                        setEditingChip(null);
-                      } else {
-                        e.target.style.borderColor = "#ff4444";
-                        setTimeout(() => {
-                          e.target.style.borderColor = color.accent;
-                        }, 800);
-                        e.target.focus();
-                      }
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        (e.target as HTMLInputElement).blur();
-                      }
-                      if (e.key === "Escape") {
-                        setEditingChip(null);
-                      }
-                    }}
-                    style={{
-                      padding: "6px 10px",
-                      background: "rgba(232,255,90,0.08)",
-                      border: `1px solid ${color.accent}`,
-                      borderRadius: 8,
-                      fontFamily: font.mono,
-                      fontSize: 11,
-                      color: color.accent,
-                      fontWeight: 600,
-                      outline: "none",
-                      width: 120,
-                      transition: "border-color 0.2s",
-                    }}
-                  />
-                );
-              }
-
-              return (
-                <div
-                  key={chip.key}
-                  onClick={() => setEditingChip(chip.key)}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 4,
-                    padding: "6px 10px",
-                    background: "rgba(232,255,90,0.08)",
-                    borderRadius: 8,
-                    border: "1px solid rgba(232,255,90,0.2)",
-                    cursor: "pointer",
-                  }}
-                >
-                  <span
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      chip.setLocked(!chip.locked);
-                    }}
-                    style={{
-                      fontFamily: font.mono,
-                      fontSize: 11,
-                      color: hasValue ? color.accent : color.dim,
-                      fontWeight: 600,
-                      userSelect: "none",
-                      cursor: "pointer",
-                    }}
-                  >
-                    {hasValue ? value : chip.placeholder}
-                  </span>
-                  {!chip.locked && (
-                    <span
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        chip.setLocked(true);
-                      }}
-                      style={{
-                        padding: "1px 6px",
-                        background: "rgba(232,255,90,0.15)",
-                        borderRadius: 4,
-                        fontFamily: font.mono,
-                        fontSize: 9,
-                        color: color.accent,
-                        cursor: "pointer",
-                      }}
-                    >
-                      flexible
-                    </span>
-                  )}
-                </div>
-              );
-            })}
+          {/* When / Where inputs — matching creation flow */}
+          <div style={{ display: "flex", gap: 8, marginBottom: 4 }}>
+            <input
+              type="text"
+              placeholder="when? (e.g. tmr 7pm)"
+              value={whenInput}
+              onChange={(e) => setWhenInput(e.target.value)}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                padding: "10px 12px",
+                background: color.deep,
+                border: `1px solid ${color.borderMid}`,
+                borderRadius: 10,
+                fontFamily: font.mono,
+                fontSize: 11,
+                color: color.text,
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+            />
+            <input
+              type="text"
+              placeholder="where?"
+              value={whereInput}
+              onChange={(e) => setWhereInput(e.target.value)}
+              style={{
+                flex: 0.6,
+                minWidth: 0,
+                padding: "10px 12px",
+                background: color.deep,
+                border: `1px solid ${color.borderMid}`,
+                borderRadius: 10,
+                fontFamily: font.mono,
+                fontSize: 11,
+                color: color.text,
+                outline: "none",
+                boxSizing: "border-box",
+              }}
+            />
           </div>
+          {whenPreview && (
+            <div style={{
+              fontFamily: font.mono,
+              fontSize: 10,
+              color: color.dim,
+              marginBottom: 8,
+              paddingLeft: 2,
+            }}>
+              {whenPreview}
+            </div>
+          )}
+          {!whenPreview && <div style={{ marginBottom: 8 }} />}
         </div>
 
         {/* Save button */}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -840,7 +840,7 @@ export async function getArchivedChecks(): Promise<{ id: string; text: string; a
 
 export async function updateInterestCheck(
   checkId: string,
-  updates: { text?: string; max_squad_size?: number; event_date?: string | null; event_time?: string | null; date_flexible?: boolean; time_flexible?: boolean }
+  updates: { text?: string; max_squad_size?: number; event_date?: string | null; event_time?: string | null; date_flexible?: boolean; time_flexible?: boolean; location?: string | null }
 ): Promise<void> {
   const { error } = await supabase
     .from('interest_checks')


### PR DESCRIPTION
## Summary
- Replaced chip-based date/time/location UI ("Mon, Apr 20 [flexible]") with side-by-side "when?" / "where?" inputs matching the creation flow
- Natural language date/time parsing with preview, same as FirstCheckScreen and CreateModal
- Added location to the `updateInterestCheck` DB flow so edits persist

## Test plan
- [ ] Edit a check → verify when/where inputs appear side-by-side (no more chips)
- [ ] Existing date/time pre-populates the "when?" field
- [ ] Typing natural language shows parsed preview below
- [ ] Location edits persist after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)