### PR TITLE
fix: clear squad button when un-downing a check

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -676,6 +676,7 @@ export default function Home() {
       newlyAddedCheckId: checksHook.newlyAddedCheckId,
       leftChecks: checksHook.leftChecks,
       respondToCheck: checksHook.respondToCheck,
+      clearResponse: checksHook.clearResponse,
       acceptCoAuthorTag: checksHook.acceptCoAuthorTag,
       declineCoAuthorTag: checksHook.declineCoAuthorTag,
       hideCheck: checksHook.hideCheck,

--- a/src/features/checks/context/FeedContext.tsx
+++ b/src/features/checks/context/FeedContext.tsx
@@ -18,6 +18,7 @@ export interface FeedContextValue {
 
   // — Check actions —
   respondToCheck: (checkId: string) => void;
+  clearResponse: (checkId: string) => void;
   acceptCoAuthorTag: (checkId: string) => Promise<void>;
   declineCoAuthorTag: (checkId: string) => Promise<void>;
   hideCheck: (checkId: string) => void;

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -157,7 +157,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
       type: CheckActionType.SYNC_CHECKS,
       checks: transformedChecks,
       hiddenIds,
-      ...(Object.keys(restoredResponses).length > 0 && { responses: restoredResponses }),
+      responses: restoredResponses,
     });
   }, [userId]);
 
@@ -312,6 +312,10 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     db.removeLeftCheck(checkId).catch((err) => logError('removeLeftCheck', err, { checkId }));
   }, [respondToCheck]);
 
+  const clearResponse = (checkId: string) => {
+    dispatch({ type: CheckActionType.CLEAR_RESPONSE, checkId });
+  };
+
   const hideCheck = async (checkId: string) => {
     dispatch({ type: CheckActionType.SET_HIDDEN, checkId, hidden: true });
     db.hideCheck(checkId).catch((err) => logError("hideCheck", err, { checkId }));
@@ -348,6 +352,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     loadChecks,
     hydrateChecks,
     respondToCheck,
+    clearResponse,
     handleCreateCheck,
     acceptCoAuthorTag,
     declineCoAuthorTag,

--- a/src/features/checks/reducers/checksReducer.ts
+++ b/src/features/checks/reducers/checksReducer.ts
@@ -27,6 +27,7 @@ export const CheckActionType = {
   UPSERT_CHECK:       "UPSERT_CHECK",
   PATCH_CHECKS:       "PATCH_CHECKS",
   SET_RESPONSE:       "SET_RESPONSE",
+  CLEAR_RESPONSE:     "CLEAR_RESPONSE",
   MERGE_RESPONSES:    "MERGE_RESPONSES",
   SET_PENDING:        "SET_PENDING",
   SET_HIDDEN:         "SET_HIDDEN",
@@ -46,6 +47,8 @@ export type ChecksAction =
   | { type: typeof CheckActionType.PATCH_CHECKS; patches: Array<{ id: string; patch: Partial<InterestCheck> }> }
   // Optimistic response — patches "You" into check.responses + myCheckResponses
   | { type: typeof CheckActionType.SET_RESPONSE; checkId: string; status: "down" | "waitlist"; avatarLetter?: string }
+  // Optimistic un-down — removes "You" from check.responses + myCheckResponses
+  | { type: typeof CheckActionType.CLEAR_RESPONSE; checkId: string }
   // Bulk response merge — for shared check injection
   | { type: typeof CheckActionType.MERGE_RESPONSES; responses: Record<string, "down" | "waitlist"> }
   // Pending spinner (pending: true = add, false = remove)
@@ -96,8 +99,10 @@ function patchYouResponses(
 export function checksReducer(state: ChecksState, action: ChecksAction): ChecksState {
   switch (action.type) {
     case CheckActionType.SYNC_CHECKS: {
+      // When responses are provided (hydrate path), replace rather than merge
+      // so removed responses don't persist as stale entries
       const responses = action.responses
-        ? { ...state.myCheckResponses, ...action.responses }
+        ? action.responses
         : state.myCheckResponses;
       const checks = patchYouResponses(mergeChecks(state.checks, action.checks), responses);
       return {
@@ -133,6 +138,15 @@ export function checksReducer(state: ChecksState, action: ChecksAction): ChecksS
         return { ...c, responses };
       });
       return { ...state, checks, myCheckResponses: { ...state.myCheckResponses, [checkId]: status } };
+    }
+    case CheckActionType.CLEAR_RESPONSE: {
+      const { checkId } = action;
+      const checks = state.checks.map((c) => {
+        if (c.id !== checkId) return c;
+        return { ...c, responses: c.responses.filter((r) => r.name !== "You") };
+      });
+      const { [checkId]: _, ...rest } = state.myCheckResponses;
+      return { ...state, checks, myCheckResponses: rest };
     }
     case CheckActionType.MERGE_RESPONSES:
       return { ...state, myCheckResponses: { ...state.myCheckResponses, ...action.responses } };


### PR DESCRIPTION
## Summary
- Squad button ("Join Squad → 0/∞") persisted after un-downing a check because `myCheckResponses` was never cleared
- Added `CLEAR_RESPONSE` reducer action for immediate optimistic UI update on un-down
- Fixed `SYNC_CHECKS` to replace (not merge) responses, preventing stale entries from surviving reloads

## Test plan
- [ ] Respond "Down" to a check that has a squad
- [ ] Click "Down" again to un-down
- [ ] Verify the squad button disappears immediately
- [ ] Refresh the page and verify it stays gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)