### PR TITLE
refactor: use API_BASE prefix on all fetch calls

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Fragment } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/features/auth/hooks/useAuth";
+import { API_BASE } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
 import { color, font } from "@/lib/styles";
 
@@ -83,7 +84,7 @@ export default function AdminPage() {
       }
 
       const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      const res = await fetch(`/api/admin/metrics?tz=${encodeURIComponent(tz)}`, {
+      const res = await fetch(`${API_BASE}/api/admin/metrics?tz=${encodeURIComponent(tz)}`, {
         headers: { Authorization: `Bearer ${session.access_token}` },
       });
 

--- a/src/app/check/[id]/cta.tsx
+++ b/src/app/check/[id]/cta.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
+import { API_BASE } from "@/lib/db";
 import { font, color } from "@/lib/styles";
 
 type State = "loading" | "logged-out" | "ready" | "submitting" | "done";
@@ -21,7 +22,7 @@ export default function CheckPreviewCTA({ checkId }: { checkId: string }) {
       const token = (await supabase.auth.getSession()).data.session?.access_token;
       if (!token) { setState("logged-out"); return; }
 
-      const res = await fetch("/api/checks/respond-shared", {
+      const res = await fetch(`${API_BASE}/api/checks/respond-shared`, {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
         body: JSON.stringify({ checkId, response: "down" }),

--- a/src/app/components/UpdateBanner.tsx
+++ b/src/app/components/UpdateBanner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { logVersionPing } from "@/lib/db";
+import { logVersionPing, API_BASE } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
 import { font, color } from "@/lib/styles";
 
@@ -38,7 +38,7 @@ export default function UpdateBanner() {
   // Check if a newer build is available
   const checkForUpdate = async (): Promise<boolean> => {
     try {
-      const r = await fetch("/api/version");
+      const r = await fetch(`${API_BASE}/api/version`);
       const { buildId } = await r.json();
       return !!buildId && buildId !== CLIENT_BUILD_ID;
     } catch {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useAppNavigation } from "@/app/hooks/useAppNavigation";
 import { useEvents } from "@/features/events/hooks/useEvents";
 import { supabase } from "@/lib/supabase";
 import * as db from "@/lib/db";
+import { API_BASE } from "@/lib/db";
 import { font, color } from "@/lib/styles";
 import { sanitize, sanitizeVibes, parseDateToISO, toLocalISODate } from "@/lib/utils";
 import type { Profile } from "@/lib/types";
@@ -418,7 +419,7 @@ export default function Home() {
   const handleSetSquadDate = async (squadDbId: string, date: string, time?: string | null, locked?: boolean) => {
     const token = (await supabase.auth.getSession()).data.session?.access_token;
     if (!token) return;
-    const res = await fetch('/api/squads/set-date', {
+    const res = await fetch(`${API_BASE}/api/squads/set-date`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ squadId: squadDbId, date, time: time ?? null, locked: !!locked }),
@@ -454,7 +455,7 @@ export default function Home() {
   const handleClearSquadDate = async (squadDbId: string) => {
     const token = (await supabase.auth.getSession()).data.session?.access_token;
     if (!token) return;
-    const res = await fetch('/api/squads/set-date', {
+    const res = await fetch(`${API_BASE}/api/squads/set-date`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ squadId: squadDbId, clear: true }),
@@ -475,7 +476,7 @@ export default function Home() {
   const handleUpdateSquadSize = async (checkId: string, newSize: number) => {
     const token = (await supabase.auth.getSession()).data.session?.access_token;
     if (!token) return;
-    const res = await fetch('/api/squads/update-size', {
+    const res = await fetch(`${API_BASE}/api/squads/update-size`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ checkId, maxSquadSize: newSize }),
@@ -492,7 +493,7 @@ export default function Home() {
   const handleSetMemberRole = async (squadId: string, targetUserId: string, role: string) => {
     const token = (await supabase.auth.getSession()).data.session?.access_token;
     if (!token) return;
-    const res = await fetch('/api/squads/set-member-role', {
+    const res = await fetch(`${API_BASE}/api/squads/set-member-role`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ squadId, userId: targetUserId, role }),
@@ -509,7 +510,7 @@ export default function Home() {
   const handleKickMember = async (squadId: string, targetUserId: string) => {
     const token = (await supabase.auth.getSession()).data.session?.access_token;
     if (!token) return;
-    const res = await fetch('/api/squads/kick-member', {
+    const res = await fetch(`${API_BASE}/api/squads/kick-member`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ squadId, userId: targetUserId }),
@@ -526,7 +527,7 @@ export default function Home() {
   const handleAddMember = async (squadId: string, targetUserId: string) => {
     const token = (await supabase.auth.getSession()).data.session?.access_token;
     if (!token) return;
-    const res = await fetch('/api/squads/add-member', {
+    const res = await fetch(`${API_BASE}/api/squads/add-member`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ squadId, userId: targetUserId }),

--- a/src/features/auth/hooks/useOnboarding.tsx
+++ b/src/features/auth/hooks/useOnboarding.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef, type Dispatch, type ReactNode } from "react";
 import { supabase } from "@/lib/supabase";
 import * as db from "@/lib/db";
+import { API_BASE } from "@/lib/db";
 import type { Profile } from "@/lib/types";
 import type { InterestCheck, Tab, Friend } from "@/lib/ui-types";
 import { type ChecksAction, CheckActionType } from "@/features/checks/reducers/checksReducer";
@@ -338,7 +339,7 @@ export function useOnboarding({
           (async () => {
             const token = (await supabase.auth.getSession()).data.session?.access_token;
             if (token) {
-              fetch("/api/checks/respond-shared", {
+              fetch(`${API_BASE}/api/checks/respond-shared`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
                 body: JSON.stringify({ checkId: pendingCheckId, response: "down" }),

--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -7,6 +7,7 @@ import type { ScrapedEvent } from '@/lib/ui-types';
 import { parseNaturalDate, parseNaturalTime, sanitize } from '@/lib/utils';
 import { logWarn } from '@/lib/logger';
 import * as db from '@/lib/db';
+import { API_BASE } from '@/lib/db';
 
 interface CheckMovie {
   title: string;
@@ -211,7 +212,7 @@ const AddModal = ({
     setError(null);
 
     try {
-      const response = await fetch('/api/scrape', {
+      const response = await fetch(`${API_BASE}/api/scrape`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ url }),
@@ -911,7 +912,7 @@ const AddModal = ({
                     checkMovieLoadingRef.current = true;
                     setCheckMovieLoading(true);
                     const urlToReplace = detectedUrl;
-                    fetch('/api/scrape', {
+                    fetch(`${API_BASE}/api/scrape`, {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({ url: detectedUrl }),
@@ -1514,7 +1515,7 @@ const AddModal = ({
                         setMovieSearching(true);
                         movieSearchTimer.current = setTimeout(async () => {
                           try {
-                            const res = await fetch('/api/search-letterboxd', {
+                            const res = await fetch(`${API_BASE}/api/search-letterboxd`, {
                               method: 'POST',
                               headers: { 'Content-Type': 'application/json' },
                               body: JSON.stringify({ query: val.trim() }),

--- a/src/features/profile/components/ProfileView.tsx
+++ b/src/features/profile/components/ProfileView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { Profile } from "@/lib/types";
+import { API_BASE } from "@/lib/db";
 import { font, color } from "@/lib/styles";
 import type { Friend, AvailabilityStatus } from "@/lib/ui-types";
 import { AVAILABILITY_OPTIONS, EXPIRY_OPTIONS } from "@/lib/ui-types";
@@ -42,7 +43,7 @@ const ProfileView = ({
   useEffect(() => {
     const buildId = process.env.NEXT_PUBLIC_BUILD_ID;
     if (!buildId) return;
-    fetch("/api/version")
+    fetch(`${API_BASE}/api/version`)
       .then((r) => r.json())
       .then(({ buildId: latest }) => setIsLatestBuild(!latest || latest === buildId))
       .catch(() => {});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -635,7 +635,7 @@ export async function getSharedCheck(checkId: string) {
 export async function respondToSharedCheck(checkId: string): Promise<boolean> {
   const token = (await supabase.auth.getSession()).data.session?.access_token;
   if (!token) return false;
-  const res = await fetch('/api/checks/respond-shared', {
+  const res = await fetch(`${API_BASE}/api/checks/respond-shared`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
     body: JSON.stringify({ checkId, response: 'down' }),
@@ -1475,7 +1475,7 @@ export async function extendSquad(squadId: string, days: number = 7): Promise<st
   const token = (await supabase.auth.getSession()).data.session?.access_token;
   if (!token) throw new Error('Not authenticated');
 
-  const res = await fetch('/api/squads/extend', {
+  const res = await fetch(`${API_BASE}/api/squads/extend`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -1518,7 +1518,7 @@ export async function respondToDateConfirm(
   const token = (await supabase.auth.getSession()).data.session?.access_token;
   if (!token) throw new Error('Not authenticated');
 
-  const res = await fetch('/api/squads/confirm-date', {
+  const res = await fetch(`${API_BASE}/api/squads/confirm-date`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -1568,7 +1568,7 @@ export async function createPoll(squadId: string, question: string, options: str
   const token = (await supabase.auth.getSession()).data.session?.access_token;
   if (!token) throw new Error('Not authenticated');
 
-  const res = await fetch('/api/squads/create-poll', {
+  const res = await fetch(`${API_BASE}/api/squads/create-poll`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -1589,7 +1589,7 @@ export async function votePoll(pollId: string, optionIndex: number) {
   const token = (await supabase.auth.getSession()).data.session?.access_token;
   if (!token) throw new Error('Not authenticated');
 
-  const res = await fetch('/api/squads/vote-poll', {
+  const res = await fetch(`${API_BASE}/api/squads/vote-poll`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -1610,7 +1610,7 @@ export async function closePoll(pollId: string) {
   const token = (await supabase.auth.getSession()).data.session?.access_token;
   if (!token) throw new Error('Not authenticated');
 
-  const res = await fetch('/api/squads/close-poll', {
+  const res = await fetch(`${API_BASE}/api/squads/close-poll`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/supabase';
+import { API_BASE } from '@/lib/db';
 
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!;
 
@@ -73,7 +74,7 @@ async function saveSubscriptionToServer(subscription: PushSubscription): Promise
 
   const subJson = subscription.toJSON();
 
-  await fetch('/api/push/subscribe', {
+  await fetch(`${API_BASE}/api/push/subscribe`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -96,7 +97,7 @@ export async function unsubscribeFromPush(
 
     const { data: { session } } = await supabase.auth.getSession();
     if (session) {
-      await fetch('/api/push/subscribe', {
+      await fetch(`${API_BASE}/api/push/subscribe`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Replaced all 22 hardcoded `fetch('/api/...')` calls across 9 files with `${API_BASE}/api/...`
- Uses existing `API_BASE` constant from `db.ts` (defaults to `''` for web, set via `NEXT_PUBLIC_API_BASE` for Capacitor)
- No behavior change for web — empty prefix works identically to before

## Files changed
- `src/lib/db.ts` — 6 calls
- `src/app/page.tsx` — 6 calls
- `src/features/events/components/CreateModal.tsx` — 3 calls
- `src/lib/pushNotifications.ts` — 2 calls
- `src/app/check/[id]/cta.tsx` — 1 call
- `src/features/profile/components/ProfileView.tsx` — 1 call
- `src/app/components/UpdateBanner.tsx` — 1 call
- `src/app/admin/page.tsx` — 1 call
- `src/features/auth/hooks/useOnboarding.tsx` — 1 call

## Test plan
- [ ] App loads and all API calls work as before (no regressions)
- [ ] Setting `NEXT_PUBLIC_API_BASE=http://localhost:3000` works for Capacitor testing

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)