### PR TITLE
fix: date confirm buttons not showing in squad chat

### DIFF
--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -62,6 +62,22 @@ const SquadChat = ({
   // Local squad state for non-message fields (members, sizes, dates, etc.)
   const [localSquad, setLocalSquad] = useState(squad);
 
+  // Sync non-message fields when parent squad prop updates (e.g. after loadRealData)
+  useEffect(() => {
+    setLocalSquad((prev) => ({
+      ...prev,
+      dateStatus: squad.dateStatus,
+      eventIsoDate: squad.eventIsoDate,
+      eventTime: squad.eventTime,
+      members: squad.members,
+      waitlistedMembers: squad.waitlistedMembers,
+      downResponders: squad.downResponders,
+      maxSquadSize: squad.maxSquadSize,
+      expiresAt: squad.expiresAt,
+      meetingSpot: squad.meetingSpot,
+    }));
+  }, [squad.dateStatus, squad.eventIsoDate, squad.eventTime, squad.members, squad.waitlistedMembers, squad.downResponders, squad.maxSquadSize, squad.expiresAt, squad.meetingSpot]);
+
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [entering, setEntering] = useState(true);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);


### PR DESCRIPTION
## Summary
- `localSquad` was a stale copy of the `squad` prop — never synced after mount
- When `dateStatus` changed to `'proposed'` after a data reload, the confirm bar condition never matched because `localSquad.dateStatus` was still `undefined`
- Added a `useEffect` to sync non-message fields (dateStatus, members, dates, etc.) from the parent prop

## Test plan
- [ ] Propose a date in squad chat → other members should see "STILL DOWN" / "I'M OUT" buttons
- [ ] Buttons should appear both on initial load and when date is proposed while chat is open
- [ ] Responding "STILL DOWN" updates to "you're in" status

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)