### PR TITLE
refactor: convert SquadChat, FriendsModal, CalendarView to Tailwind

### DIFF
--- a/src/features/calendar/components/CalendarView.tsx
+++ b/src/features/calendar/components/CalendarView.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { font, color } from "@/lib/styles";
+import cn from "@/lib/tailwindMerge";
 import type { Event, InterestCheck } from "@/lib/ui-types";
 import EventCard from "@/features/events/components/EventCard";
 import { generateICSCalendar, downloadICS, buildGoogleCalendarUrl, type ICSEventParams } from "@/lib/ics";
@@ -326,77 +326,56 @@ const CalendarView = ({
   };
 
   return (
-    <div style={{ padding: "0 20px", animation: "fadeIn 0.3s ease" }}>
-      <h2
-        style={{
-          fontFamily: font.serif,
-          fontSize: 28,
-          color: color.text,
-          marginBottom: 4,
-          fontWeight: 400,
-        }}
-      >
+    <div className="px-5 animate-fade-in">
+      <h2 className="font-serif text-primary mb-1 font-normal" style={{ fontSize: 28 }}>
         Your Events
       </h2>
-      <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, marginBottom: 24 }}>
+      <p className="font-mono text-xs text-dim mb-6" style={{ fontSize: 11 }}>
         {monthLabel}
       </p>
 
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(7, 1fr)",
-          gap: 4,
-          marginBottom: 28,
-        }}
-      >
+      <div className="grid grid-cols-7 gap-1 mb-7">
         {days.map((d, i) => {
           const isSelected = selectedDateKey === d.dateKey;
           const dotColor = isSelected
             ? "#5B9CF6"
             : d.hasEvent
-              ? color.accent
+              ? undefined
               : CHECK_DOT_COLOR;
           return (
           <div
             key={i}
             onClick={() => setSelectedDateKey(isSelected ? null : d.dateKey)}
-            style={{
-              textAlign: "center",
-              padding: "8px 0",
-              borderRadius: 10,
-              background: isSelected ? "#1C3A5E" : d.today ? "#222" : "transparent",
-              cursor: "pointer",
-            }}
+            className={cn(
+              "text-center py-2 rounded-lg cursor-pointer",
+              isSelected && "bg-[#1C3A5E]",
+              !isSelected && d.today && "bg-[#222]",
+              !isSelected && !d.today && "bg-transparent",
+            )}
           >
-            <div
-              style={{
-                fontFamily: font.mono,
-                fontSize: 9,
-                color: color.faint,
-                marginBottom: 4,
-              }}
-            >
+            <div className="font-mono text-faint mb-1" style={{ fontSize: 9 }}>
               {d.label}
             </div>
             <div
+              className={cn(
+                "font-mono text-sm",
+                (d.hasDot || isSelected) ? "font-bold" : "font-normal",
+              )}
               style={{
-                fontFamily: font.mono,
                 fontSize: 13,
-                color: isSelected ? "#5B9CF6" : d.hasDot ? (d.hasEvent ? color.accent : CHECK_DOT_COLOR) : color.dim,
-                fontWeight: d.hasDot || isSelected ? 700 : 400,
+                color: isSelected ? "#5B9CF6" : d.hasDot ? (d.hasEvent ? "#e8ff5a" : CHECK_DOT_COLOR) : undefined,
               }}
             >
               {d.num}
             </div>
             {d.hasDot && (
               <div
+                className={cn(
+                  "w-1 h-1 rounded-full mx-auto mt-1",
+                  !isSelected && d.hasEvent && "bg-dt",
+                )}
                 style={{
-                  width: 4,
-                  height: 4,
-                  borderRadius: "50%",
-                  background: dotColor,
-                  margin: "4px auto 0",
+                  ...(dotColor ? { background: dotColor } : {}),
                 }}
               />
             )}
@@ -405,39 +384,15 @@ const CalendarView = ({
         })}
       </div>
 
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: 12,
-        }}
-      >
-        <span style={{
-          fontFamily: font.mono,
-          fontSize: 10,
-          textTransform: "uppercase",
-          letterSpacing: "0.15em",
-          color: color.dim,
-        }}>
+      <div className="flex items-center justify-between mb-3">
+        <span className="font-mono text-tiny uppercase text-dim" style={{ letterSpacing: "0.15em" }}>
           {countLabel}
         </span>
         {totalItems > 0 && (
           <button
             onClick={openSyncModal}
-            style={{
-              background: "transparent",
-              border: `1px solid ${color.borderMid}`,
-              borderRadius: 8,
-              padding: "4px 10px",
-              fontFamily: font.mono,
-              fontSize: 9,
-              fontWeight: 700,
-              color: color.dim,
-              cursor: "pointer",
-              textTransform: "uppercase",
-              letterSpacing: "0.08em",
-            }}
+            className="bg-transparent border border-border-mid rounded-lg font-mono font-bold text-dim cursor-pointer uppercase"
+            style={{ padding: "4px 10px", fontSize: 9, letterSpacing: "0.08em" }}
           >
             Sync
           </button>
@@ -445,16 +400,7 @@ const CalendarView = ({
       </div>
 
       {totalItems === 0 ? (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "40px 20px",
-            color: color.faint,
-            fontFamily: font.mono,
-            fontSize: 12,
-            lineHeight: 1.8,
-          }}
-        >
+        <div className="text-center text-faint font-mono text-xs" style={{ padding: "40px 20px", lineHeight: 1.8, fontSize: 12 }}>
           {selectedDateKey ? "Nothing on this day." : (<>No events saved yet.<br />Hit + to save your first event.</>)}
         </div>
       ) : (
@@ -467,46 +413,21 @@ const CalendarView = ({
               <div
                 key={e.id}
                 onClick={() => setSelectedEvent(e)}
-                style={{
-                  background: color.card,
-                  borderRadius: 14,
-                  padding: 16,
-                  marginBottom: 8,
-                  border: `1px solid ${color.border}`,
-                  display: "flex",
-                  gap: 14,
-                  alignItems: "center",
-                  cursor: "pointer",
-                }}
+                className="bg-card rounded-xl p-4 mb-2 border border-border flex gap-3.5 items-center cursor-pointer"
               >
-                <div style={{ minWidth: 44, textAlign: "center" }}>
-                  <div
-                    style={{
-                      fontFamily: font.mono,
-                      fontSize: 9,
-                      color: color.accent,
-                      textTransform: "uppercase",
-                    }}
-                  >
+                <div className="min-w-[44px] text-center">
+                  <div className="font-mono text-dt uppercase" style={{ fontSize: 9 }}>
                     {eDateLabel}
                   </div>
-                  <div style={{ fontFamily: font.serif, fontSize: 26, color: color.text }}>
+                  <div className="font-serif text-primary" style={{ fontSize: 26 }}>
                     {eDateDay}
                   </div>
                 </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
-                    style={{
-                      fontFamily: font.serif,
-                      fontSize: 16,
-                      color: color.text,
-                      marginBottom: 2,
-                      fontWeight: 400,
-                    }}
-                  >
+                <div className="flex-1 min-w-0">
+                  <div className="font-serif text-base text-primary mb-0.5 font-normal" style={{ fontSize: 16 }}>
                     {e.title}
                   </div>
-                  <div style={{ fontFamily: font.mono, fontSize: 11, color: color.dim }}>
+                  <div className="font-mono text-xs text-dim" style={{ fontSize: 11 }}>
                     {e.venue} · {e.time}
                   </div>
                 </div>
@@ -519,51 +440,29 @@ const CalendarView = ({
               return (
                 <div
                   key={`check-${c.id}`}
-                  style={{
-                    background: color.card,
-                    borderRadius: 14,
-                    padding: 16,
-                    marginBottom: 8,
-                    border: `1px solid ${color.border}`,
-                    display: "flex",
-                    gap: 14,
-                    alignItems: "center",
-                  }}
+                  className="bg-card rounded-xl p-4 mb-2 border border-border flex gap-3.5 items-center"
                 >
-                  <div style={{ minWidth: 44, textAlign: "center" }}>
-                    <div
-                      style={{
-                        fontFamily: font.mono,
-                        fontSize: 9,
-                        color: CHECK_DOT_COLOR,
-                        textTransform: "uppercase",
-                      }}
-                    >
+                  <div className="min-w-[44px] text-center">
+                    <div className="font-mono uppercase" style={{ fontSize: 9, color: CHECK_DOT_COLOR }}>
                       {cDateLabel}
                     </div>
-                    <div style={{ fontFamily: font.serif, fontSize: 26, color: color.text }}>
+                    <div className="font-serif text-primary" style={{ fontSize: 26 }}>
                       {cDateDay}
                     </div>
                   </div>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <div
-                      style={{
-                        fontFamily: font.serif,
-                        fontSize: 16,
-                        color: color.text,
-                        marginBottom: 2,
-                        fontWeight: 400,
-                      }}
-                    >
+                  <div className="flex-1 min-w-0">
+                    <div className="font-serif text-base text-primary mb-0.5 font-normal" style={{ fontSize: 16 }}>
                       {c.text}
                     </div>
-                    <div style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, display: "flex", alignItems: "center", gap: 6 }}>
+                    <div className="font-mono text-xs text-dim flex items-center gap-1.5" style={{ fontSize: 11 }}>
                       {c.eventTime && <span>{c.eventTime}</span>}
                       {c.eventTime && <span>·</span>}
-                      <span style={{
-                        color: response === "down" ? color.accent : response === "waitlist" ? color.muted : color.dim,
-                        fontWeight: 700,
-                      }}>
+                      <span
+                        className="font-bold"
+                        style={{
+                          color: response === "down" ? "#e8ff5a" : response === "waitlist" ? "#888" : "#666",
+                        }}
+                      >
                         {response === "down" ? "✓ Down" : response === "waitlist" ? "✓ Waitlisted" : "Yours"}
                       </span>
                     </div>
@@ -577,17 +476,7 @@ const CalendarView = ({
 
       {leftChecks.length > 0 && !selectedDateKey && (
         <>
-          <div
-            style={{
-              fontFamily: font.mono,
-              fontSize: 10,
-              textTransform: "uppercase",
-              letterSpacing: "0.15em",
-              color: color.dim,
-              marginTop: 24,
-              marginBottom: 12,
-            }}
-          >
+          <div className="font-mono text-tiny uppercase text-dim mt-6 mb-3" style={{ letterSpacing: "0.15em" }}>
             Left ({leftChecks.length})
           </div>
           {leftChecks.map((c) => {
@@ -595,67 +484,30 @@ const CalendarView = ({
             return (
               <div
                 key={`left-${c.id}`}
-                style={{
-                  background: color.card,
-                  borderRadius: 14,
-                  padding: 16,
-                  marginBottom: 8,
-                  border: `1px solid ${color.border}`,
-                  display: "flex",
-                  gap: 14,
-                  alignItems: "center",
-                  opacity: 0.6,
-                }}
+                className="bg-card rounded-xl p-4 mb-2 border border-border flex gap-3.5 items-center opacity-60"
               >
                 {cardDate && (
-                  <div style={{ minWidth: 44, textAlign: "center" }}>
-                    <div
-                      style={{
-                        fontFamily: font.mono,
-                        fontSize: 9,
-                        color: color.faint,
-                        textTransform: "uppercase",
-                      }}
-                    >
+                  <div className="min-w-[44px] text-center">
+                    <div className="font-mono text-faint uppercase" style={{ fontSize: 9 }}>
                       {cardDate.label}
                     </div>
-                    <div style={{ fontFamily: font.serif, fontSize: 26, color: color.muted }}>
+                    <div className="font-serif text-muted" style={{ fontSize: 26 }}>
                       {cardDate.day}
                     </div>
                   </div>
                 )}
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div
-                    style={{
-                      fontFamily: font.serif,
-                      fontSize: 16,
-                      color: color.muted,
-                      marginBottom: 2,
-                      fontWeight: 400,
-                    }}
-                  >
+                <div className="flex-1 min-w-0">
+                  <div className="font-serif text-base text-muted mb-0.5 font-normal" style={{ fontSize: 16 }}>
                     {c.text}
                   </div>
-                  <div style={{ fontFamily: font.mono, fontSize: 11, color: color.faint }}>
+                  <div className="font-mono text-xs text-faint" style={{ fontSize: 11 }}>
                     {c.author}{c.eventTime ? ` · ${c.eventTime}` : ""}
                   </div>
                 </div>
                 <button
                   onClick={() => onRedownFromLeft?.(c.id)}
-                  style={{
-                    fontFamily: font.mono,
-                    fontSize: 12,
-                    fontWeight: 700,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.08em",
-                    color: color.accent,
-                    background: "transparent",
-                    border: `1px solid ${color.borderMid}`,
-                    borderRadius: 12,
-                    padding: "8px 14px",
-                    cursor: "pointer",
-                    whiteSpace: "nowrap",
-                  }}
+                  className="font-mono text-xs font-bold uppercase text-dt bg-transparent border border-border-mid rounded-xl cursor-pointer whitespace-nowrap"
+                  style={{ letterSpacing: "0.08em", padding: "8px 14px", fontSize: 12 }}
                 >
                   Re-down
                 </button>
@@ -670,47 +522,18 @@ const CalendarView = ({
           onTouchStart={(e) => e.stopPropagation()}
           onTouchMove={(e) => e.stopPropagation()}
           onTouchEnd={(e) => e.stopPropagation()}
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 100,
-            display: "flex",
-            alignItems: "flex-end",
-            justifyContent: "center",
-          }}
+          className="fixed inset-0 z-100 flex items-end justify-center"
         >
           <div
             onClick={() => setSelectedEvent(null)}
-            style={{
-              position: "absolute",
-              inset: 0,
-              background: "rgba(0,0,0,0.7)",
-              backdropFilter: "blur(8px)",
-              WebkitBackdropFilter: "blur(8px)",
-            }}
+            className="absolute inset-0 bg-black/70 backdrop-blur-[8px]"
+            style={{ WebkitBackdropFilter: "blur(8px)" }}
           />
           <div
-            style={{
-              position: "relative",
-              background: color.surface,
-              borderRadius: "24px 24px 0 0",
-              width: "100%",
-              maxWidth: 420,
-              padding: "16px 16px 40px",
-              maxHeight: "85vh",
-              overflowY: "auto",
-              animation: "slideUp 0.3s ease-out",
-            }}
+            className="relative bg-surface rounded-t-3xl w-full max-w-[420px] max-h-[85vh] overflow-y-auto animate-slide-up"
+            style={{ padding: "16px 16px 40px" }}
           >
-            <div
-              style={{
-                width: 40,
-                height: 4,
-                background: color.faint,
-                borderRadius: 2,
-                margin: "0 auto 12px",
-              }}
-            />
+            <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-3" />
             <EventCard
               event={selectedEvent}
               userId={userId}
@@ -733,20 +556,12 @@ const CalendarView = ({
           onTouchStart={(e) => e.stopPropagation()}
           onTouchMove={(e) => e.stopPropagation()}
           onTouchEnd={(e) => e.stopPropagation()}
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 9999,
-            display: "flex",
-            alignItems: "flex-end",
-            justifyContent: "center",
-          }}
+          className="fixed inset-0 z-[9999] flex items-end justify-center"
         >
           <div
             onClick={closeSyncModal}
+            className="absolute inset-0"
             style={{
-              position: "absolute",
-              inset: 0,
               background: "rgba(0,0,0,0.7)",
               backdropFilter: syncClosing ? "blur(0px)" : "blur(8px)",
               WebkitBackdropFilter: syncClosing ? "blur(0px)" : "blur(8px)",
@@ -755,15 +570,8 @@ const CalendarView = ({
             }}
           />
           <div
+            className="relative bg-surface rounded-t-3xl max-w-[420px] w-full max-h-[75vh] flex flex-col"
             style={{
-              position: "relative",
-              background: color.surface,
-              borderRadius: "24px 24px 0 0",
-              maxWidth: 420,
-              width: "100%",
-              maxHeight: "75vh",
-              display: "flex",
-              flexDirection: "column",
               animation: syncClosing ? undefined : "slideUp 0.3s ease-out",
               transform: syncClosing ? "translateY(100%)" : `translateY(${syncDragOffset}px)`,
               transition: syncClosing ? "transform 0.2s ease-in" : (syncDragOffset === 0 ? "transform 0.2s ease-out" : "none"),
@@ -774,33 +582,29 @@ const CalendarView = ({
               onTouchStart={syncHandleSwipeStart}
               onTouchMove={syncHandleSwipeMove}
               onTouchEnd={syncHandleSwipeEnd}
-              style={{ touchAction: "none", padding: "16px 20px 0" }}
+              className="touch-none"
+              style={{ padding: "16px 20px 0" }}
             >
-              <div style={{ display: "flex", justifyContent: "center", marginBottom: 12 }}>
-                <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2 }} />
+              <div className="flex justify-center mb-3">
+                <div className="w-10 h-1 bg-faint rounded-sm" />
               </div>
-              <h3 style={{ fontFamily: font.serif, fontSize: 18, color: color.text, margin: "0 0 12px", fontWeight: 400 }}>
+              <h3 className="font-serif text-lg text-primary font-normal mb-3" style={{ margin: "0 0 12px" }}>
                 Sync to Calendar
               </h3>
 
               {/* Tabs */}
-              <div style={{ display: "flex", gap: 0, marginBottom: 12, borderBottom: `1px solid ${color.border}` }}>
+              <div className="flex gap-0 mb-3 border-b border-border">
                 {(["export", "subscribe"] as const).map((tab) => (
                   <button
                     key={tab}
                     onClick={() => setSyncTab(tab)}
+                    className={cn(
+                      "flex-1 py-2 bg-transparent border-none font-mono text-xs cursor-pointer uppercase",
+                      syncTab === tab ? "font-bold text-dt" : "font-normal text-dim",
+                    )}
                     style={{
-                      flex: 1,
-                      padding: "8px 0",
-                      background: "transparent",
-                      border: "none",
-                      borderBottom: syncTab === tab ? `2px solid ${color.accent}` : "2px solid transparent",
-                      fontFamily: font.mono,
+                      borderBottom: syncTab === tab ? "2px solid #e8ff5a" : "2px solid transparent",
                       fontSize: 11,
-                      fontWeight: syncTab === tab ? 700 : 400,
-                      color: syncTab === tab ? color.accent : color.dim,
-                      cursor: "pointer",
-                      textTransform: "uppercase",
                       letterSpacing: "0.08em",
                     }}
                   >
@@ -814,8 +618,8 @@ const CalendarView = ({
             {syncTab === "export" ? (
               <>
                 {/* Select all / count */}
-                <div style={{ padding: "0 20px", display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }}>
-                  <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>
+                <div className="flex items-center justify-between mb-2" style={{ padding: "0 20px" }}>
+                  <span className="font-mono text-tiny text-dim">
                     {syncSelected.size} of {allExportable.length} selected
                   </span>
                   <button
@@ -823,17 +627,8 @@ const CalendarView = ({
                       if (syncSelected.size === allExportable.length) setSyncSelected(new Set());
                       else setSyncSelected(new Set(allExportable.map((e) => e.id)));
                     }}
-                    style={{
-                      background: "transparent",
-                      border: "none",
-                      fontFamily: font.mono,
-                      fontSize: 10,
-                      color: color.accent,
-                      cursor: "pointer",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      padding: "4px 0",
-                    }}
+                    className="bg-transparent border-none font-mono text-tiny text-dt cursor-pointer uppercase py-1"
+                    style={{ letterSpacing: "0.08em", padding: "4px 0" }}
                   >
                     {syncSelected.size === allExportable.length ? "Deselect All" : "Select All"}
                   </button>
@@ -845,7 +640,8 @@ const CalendarView = ({
                   onTouchStart={syncHandleScrollTouchStart}
                   onTouchMove={syncHandleScrollTouchMove}
                   onTouchEnd={syncHandleScrollTouchEnd}
-                  style={{ flex: 1, overflowY: "auto", padding: "0 20px", overscrollBehavior: "contain" }}
+                  className="flex-1 overflow-y-auto overscroll-contain"
+                  style={{ padding: "0 20px" }}
                 >
                   {allExportable.map((item) => {
                     const selected = syncSelected.has(item.id);
@@ -853,41 +649,26 @@ const CalendarView = ({
                       <div
                         key={item.id}
                         onClick={() => toggleSyncItem(item.id)}
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: 12,
-                          padding: "10px 0",
-                          borderBottom: `1px solid ${color.border}`,
-                          cursor: "pointer",
-                        }}
+                        className="flex items-center gap-3 cursor-pointer border-b border-border"
+                        style={{ padding: "10px 0" }}
                       >
-                        <div style={{
-                          width: 20,
-                          height: 20,
-                          borderRadius: 6,
-                          border: `2px solid ${selected ? color.accent : color.borderMid}`,
-                          background: selected ? color.accent : "transparent",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          flexShrink: 0,
-                          transition: "all 0.15s",
-                        }}>
-                          {selected && <span style={{ color: "#000", fontSize: 12, lineHeight: 1 }}>✓</span>}
+                        <div
+                          className={cn(
+                            "w-5 h-5 rounded-md flex items-center justify-center shrink-0 transition-all duration-150",
+                            selected ? "bg-dt border-2 border-dt" : "bg-transparent border-2 border-border-mid",
+                          )}
+                          style={{ borderRadius: 6 }}
+                        >
+                          {selected && <span className="text-black text-xs leading-none" style={{ fontSize: 12 }}>✓</span>}
                         </div>
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                          <div style={{
-                            fontFamily: font.mono,
-                            fontSize: 12,
-                            color: selected ? color.text : color.muted,
-                            whiteSpace: "nowrap",
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                          }}>
+                        <div className="flex-1 min-w-0">
+                          <div className={cn(
+                            "font-mono text-xs whitespace-nowrap overflow-hidden text-ellipsis",
+                            selected ? "text-primary" : "text-muted",
+                          )} style={{ fontSize: 12 }}>
                             {item.label}
                           </div>
-                          <div style={{ fontFamily: font.mono, fontSize: 10, color: color.faint }}>
+                          <div className="font-mono text-tiny text-faint">
                             {item.sub}
                           </div>
                         </div>
@@ -897,44 +678,26 @@ const CalendarView = ({
                 </div>
 
                 {/* Export action buttons */}
-                <div style={{ padding: "16px 20px calc(16px + env(safe-area-inset-bottom, 0px))", display: "flex", gap: 8 }}>
+                <div className="flex gap-2" style={{ padding: "16px 20px calc(16px + env(safe-area-inset-bottom, 0px))" }}>
                   <button
                     onClick={() => handleSync("google")}
                     disabled={syncSelected.size === 0}
-                    style={{
-                      flex: 1,
-                      padding: "12px 0",
-                      background: "transparent",
-                      border: `1px solid ${syncSelected.size > 0 ? color.borderMid : color.border}`,
-                      borderRadius: 12,
-                      color: syncSelected.size > 0 ? color.text : color.faint,
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                      fontWeight: 700,
-                      cursor: syncSelected.size > 0 ? "pointer" : "default",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                    }}
+                    className={cn(
+                      "flex-1 py-3 bg-transparent rounded-xl font-mono text-xs font-bold uppercase",
+                      syncSelected.size > 0 ? "text-primary cursor-pointer border border-border-mid" : "text-faint cursor-default border border-border",
+                    )}
+                    style={{ fontSize: 12, letterSpacing: "0.08em" }}
                   >
                     Google Cal
                   </button>
                   <button
                     onClick={() => handleSync("ics")}
                     disabled={syncSelected.size === 0}
-                    style={{
-                      flex: 1,
-                      padding: "12px 0",
-                      background: syncSelected.size > 0 ? color.accent : color.border,
-                      border: "none",
-                      borderRadius: 12,
-                      color: syncSelected.size > 0 ? "#000" : color.faint,
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                      fontWeight: 700,
-                      cursor: syncSelected.size > 0 ? "pointer" : "default",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                    }}
+                    className={cn(
+                      "flex-1 py-3 border-none rounded-xl font-mono text-xs font-bold uppercase",
+                      syncSelected.size > 0 ? "bg-dt text-black cursor-pointer" : "bg-border text-faint cursor-default",
+                    )}
+                    style={{ fontSize: 12, letterSpacing: "0.08em" }}
                   >
                     Download .ics
                   </button>
@@ -943,81 +706,51 @@ const CalendarView = ({
             ) : (
               /* Subscribe tab */
               <div style={{ padding: "0 20px calc(20px + env(safe-area-inset-bottom, 0px))" }}>
-                <p style={{ fontFamily: font.mono, fontSize: 11, color: color.muted, lineHeight: 1.6, marginBottom: 16 }}>
+                <p className="font-mono text-xs text-muted mb-4" style={{ fontSize: 11, lineHeight: 1.6 }}>
                   Subscribe once and your calendar app will automatically stay in sync. New events you save will appear automatically — no duplicates.
                 </p>
 
                 {tokenLoading ? (
-                  <div style={{ fontFamily: font.mono, fontSize: 11, color: color.faint, textAlign: "center", padding: 20 }}>
+                  <div className="font-mono text-xs text-faint text-center p-5" style={{ fontSize: 11 }}>
                     Loading...
                   </div>
                 ) : webcalUrl ? (
                   <>
                     {/* URL display */}
-                    <div style={{
-                      background: color.deep,
-                      border: `1px solid ${color.border}`,
-                      borderRadius: 10,
-                      padding: "10px 12px",
-                      marginBottom: 12,
-                      fontFamily: font.mono,
-                      fontSize: 10,
-                      color: color.dim,
-                      wordBreak: "break-all",
-                      lineHeight: 1.5,
-                    }}>
+                    <div
+                      className="bg-deep border border-border rounded-lg font-mono text-tiny text-dim mb-3 break-all"
+                      style={{ padding: "10px 12px", lineHeight: 1.5 }}
+                    >
                       {webcalUrl}
                     </div>
 
                     {/* Actions */}
-                    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    <div className="flex flex-col gap-2">
                       <a
                         href={webcalUrl}
-                        style={{
-                          display: "block",
-                          padding: "12px 0",
-                          background: color.accent,
-                          border: "none",
-                          borderRadius: 12,
-                          color: "#000",
-                          fontFamily: font.mono,
-                          fontSize: 12,
-                          fontWeight: 700,
-                          cursor: "pointer",
-                          textTransform: "uppercase",
-                          letterSpacing: "0.08em",
-                          textAlign: "center",
-                          textDecoration: "none",
-                        }}
+                        className="block py-3 bg-dt border-none rounded-xl text-black font-mono text-xs font-bold cursor-pointer uppercase text-center no-underline"
+                        style={{ fontSize: 12, letterSpacing: "0.08em" }}
                       >
                         Subscribe in Calendar App
                       </a>
                       <button
                         onClick={copySubscribeUrl}
-                        style={{
-                          padding: "12px 0",
-                          background: "transparent",
-                          border: `1px solid ${color.borderMid}`,
-                          borderRadius: 12,
-                          color: copied ? color.accent : color.text,
-                          fontFamily: font.mono,
-                          fontSize: 12,
-                          fontWeight: 700,
-                          cursor: "pointer",
-                          textTransform: "uppercase",
-                          letterSpacing: "0.08em",
-                        }}
+                        className={cn(
+                          "py-3 bg-transparent border border-border-mid rounded-xl font-mono text-xs font-bold cursor-pointer uppercase",
+                          copied ? "text-dt" : "text-primary",
+                        )}
+                        style={{ fontSize: 12, letterSpacing: "0.08em" }}
                       >
                         {copied ? "Copied!" : "Copy URL"}
                       </button>
                     </div>
 
-                    <p style={{ fontFamily: font.mono, fontSize: 9, color: color.faint, lineHeight: 1.5, marginTop: 14, textAlign: "center" }}>
+                    <p className="font-mono text-faint text-center mt-3.5" style={{ fontSize: 9, lineHeight: 1.5 }}>
                       Works with Apple Calendar, Google Calendar, Outlook, and any app that supports webcal subscriptions. Your calendar will refresh automatically.
                     </p>
                   </>
                 ) : (
-                  <div style={{ fontFamily: font.mono, fontSize: 11, color: color.faint, textAlign: "center", padding: 20 }}>
+                  <div className="font-mono text-xs text-faint text-center p-5" style={{ fontSize: 11 }}>
                     Could not load subscription URL.
                   </div>
                 )}

--- a/src/features/friends/components/FriendsModal.tsx
+++ b/src/features/friends/components/FriendsModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { font, color } from "@/lib/styles";
+import cn from "@/lib/tailwindMerge";
 import type { Friend } from "@/lib/ui-types";
 import * as db from "@/lib/db";
 import { logError } from "@/lib/logger";
@@ -146,40 +146,28 @@ const FriendsModal = ({
   if (!visible) return null;
 
   return (
-    <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 100,
-        display: "flex",
-        alignItems: "flex-end",
-        justifyContent: "center",
-      }}
-    >
+    <div className="fixed inset-0 z-100 flex items-end justify-center">
       <div
         onClick={preventClose ? undefined : close}
+        className={cn(
+          "absolute inset-0 transition-all duration-300 ease-in-out",
+          (entering || closing) ? "opacity-0" : "opacity-100"
+        )}
         style={{
-          position: "absolute",
-          inset: 0,
           background: "rgba(0,0,0,0.7)",
           backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
           WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
-          transition: "opacity 0.3s ease, backdrop-filter 0.3s ease, -webkit-backdrop-filter 0.3s ease",
         }}
       />
       <div
+        className={cn(
+          "relative bg-surface w-full max-w-[420px] flex flex-col",
+          !closing && "animate-slide-up"
+        )}
         style={{
-          position: "relative",
-          background: color.surface,
           borderRadius: "24px 24px 0 0",
-          width: "100%",
-          maxWidth: 420,
           padding: "32px 24px 0",
           maxHeight: "85vh",
-          display: "flex",
-          flexDirection: "column",
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
           transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
           transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
         }}
@@ -188,85 +176,44 @@ const FriendsModal = ({
           onTouchStart={handleSwipeStart}
           onTouchMove={handleSwipeMove}
           onTouchEnd={finishSwipe}
-          style={{ touchAction: "none" }}
+          className="touch-none"
         >
-          <div
-            style={{
-              width: 40,
-              height: 4,
-              background: color.faint,
-              borderRadius: 2,
-              margin: "0 auto 24px",
-            }}
-          />
+          <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-6" />
         </div>
 
         {preventClose && (
-          <div
-            style={{
-              fontFamily: font.mono,
-              fontSize: 13,
-              color: color.text,
-              textAlign: "center",
-              marginBottom: 16,
-            }}
-          >
+          <div className="font-mono text-sm text-primary text-center mb-4">
             add at least one friend to get started
           </div>
         )}
 
         {/* Tabs */}
-        <div style={{ display: "flex", gap: 8, marginBottom: 20 }}>
+        <div className="flex gap-2 mb-5">
           <button
             onClick={() => setTab("friends")}
-            style={{
-              flex: 1,
-              background: tab === "friends" ? color.accent : "transparent",
-              color: tab === "friends" ? "#000" : color.dim,
-              border: tab === "friends" ? "none" : `1px solid ${color.borderMid}`,
-              borderRadius: 10,
-              padding: "10px",
-              fontFamily: font.mono,
-              fontSize: 11,
-              fontWeight: tab === "friends" ? 700 : 400,
-              cursor: "pointer",
-              textTransform: "uppercase",
-              letterSpacing: "0.08em",
-            }}
+            className={cn(
+              "flex-1 rounded-lg p-2.5 font-mono text-xs cursor-pointer uppercase",
+              tab === "friends"
+                ? "bg-dt text-black font-bold border-none"
+                : "bg-transparent text-dim border border-border-mid font-normal"
+            )}
+            style={{ letterSpacing: "0.08em" }}
           >
             Friends ({friends.length})
           </button>
           <button
             onClick={() => setTab("add")}
-            style={{
-              flex: 1,
-              background: tab === "add" ? color.accent : "transparent",
-              color: tab === "add" ? "#000" : color.dim,
-              border: tab === "add" ? "none" : `1px solid ${color.borderMid}`,
-              borderRadius: 10,
-              padding: "10px",
-              fontFamily: font.mono,
-              fontSize: 11,
-              fontWeight: tab === "add" ? 700 : 400,
-              cursor: "pointer",
-              textTransform: "uppercase",
-              letterSpacing: "0.08em",
-              position: "relative",
-            }}
+            className={cn(
+              "flex-1 rounded-lg p-2.5 font-mono text-xs cursor-pointer uppercase relative",
+              tab === "add"
+                ? "bg-dt text-black font-bold border-none"
+                : "bg-transparent text-dim border border-border-mid font-normal"
+            )}
+            style={{ letterSpacing: "0.08em" }}
           >
             Add
             {incomingRequests.length > 0 && (
-              <span
-                style={{
-                  position: "absolute",
-                  top: 6,
-                  right: 6,
-                  width: 8,
-                  height: 8,
-                  borderRadius: "50%",
-                  background: "#ff6b6b",
-                }}
-              />
+              <span className="absolute top-1.5 right-1.5 w-2 h-2 rounded-full bg-danger" />
             )}
           </button>
         </div>
@@ -277,18 +224,7 @@ const FriendsModal = ({
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder={tab === "add" ? "Search users by name or @username..." : "Filter friends..."}
-          style={{
-            width: "100%",
-            background: color.deep,
-            border: `1px solid ${color.borderMid}`,
-            borderRadius: 12,
-            padding: "12px 16px",
-            color: color.text,
-            fontFamily: font.mono,
-            fontSize: 13,
-            outline: "none",
-            marginBottom: 20,
-          }}
+          className="w-full bg-deep border border-border-mid rounded-xl py-3 px-4 text-primary font-mono text-sm outline-none mb-5"
         />
 
         <div
@@ -296,25 +232,12 @@ const FriendsModal = ({
           onTouchStart={handleScrollTouchStart}
           onTouchMove={handleScrollTouchMove}
           onTouchEnd={handleScrollTouchEnd}
-          style={{
-            overflowY: "auto",
-            overflowX: "hidden",
-            flex: 1,
-            paddingBottom: 40,
-          }}
+          className="overflow-y-auto overflow-x-hidden flex-1 pb-10"
         >
         {tab === "friends" ? (
           <>
             {filteredFriends.length === 0 ? (
-              <p
-                style={{
-                  textAlign: "center",
-                  color: color.faint,
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  padding: "40px 0",
-                }}
-              >
+              <p className="text-center text-faint font-mono text-xs py-10">
                 {search ? "No friends found" : "No friends yet"}
               </p>
             ) : (
@@ -322,65 +245,27 @@ const FriendsModal = ({
                 <div
                   key={f.id}
                   onClick={() => onViewProfile ? onViewProfile(f.id) : setSelectedFriend(f)}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    padding: "12px 0",
-                    borderBottom: `1px solid ${color.border}`,
-                    cursor: "pointer",
-                  }}
+                  className="flex items-center py-3 border-b border-border cursor-pointer"
                 >
-                  <div
-                    style={{
-                      width: 40,
-                      height: 40,
-                      borderRadius: "50%",
-                      background: color.accent,
-                      color: "#000",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      fontFamily: font.mono,
-                      fontSize: 16,
-                      fontWeight: 700,
-                      marginRight: 12,
-                    }}
-                  >
+                  <div className="w-10 h-10 rounded-full bg-dt text-black flex items-center justify-center font-mono text-base font-bold mr-3">
                     {f.avatar}
                   </div>
-                  <div style={{ flex: 1 }}>
-                    <div
-                      style={{
-                        fontFamily: font.mono,
-                        fontSize: 13,
-                        color: color.text,
-                      }}
-                    >
+                  <div className="flex-1">
+                    <div className="font-mono text-sm text-primary">
                       {f.name}
                     </div>
-                    <div
-                      style={{
-                        fontFamily: font.mono,
-                        fontSize: 11,
-                        color: color.dim,
-                      }}
-                    >
+                    <div className="font-mono text-xs text-dim">
                       @{f.username}
                     </div>
                   </div>
                   {f.availability && (
-                    <span
-                      style={{
-                        fontSize: 12,
-                        opacity: 0.8,
-                      }}
-                    >
-                      {f.availability === "open" && "✨"}
-                      {f.availability === "awkward" && "👀"}
-                      {f.availability === "not-available" && "🌙"}
+                    <span className="text-xs opacity-80">
+                      {f.availability === "open" && "\u2728"}
+                      {f.availability === "awkward" && "\uD83D\uDC40"}
+                      {f.availability === "not-available" && "\uD83C\uDF19"}
                     </span>
                   )}
-                  <span style={{ color: color.faint, fontSize: 16, marginLeft: 8 }}>›</span>
+                  <span className="text-faint text-base ml-2">&rsaquo;</span>
                 </div>
               ))
             )}
@@ -401,21 +286,8 @@ const FriendsModal = ({
                   }
                 } catch { /* cancelled or error */ }
               }}
-              style={{
-                width: "100%",
-                padding: "12px 0",
-                background: "transparent",
-                border: `1px dashed ${color.borderMid}`,
-                borderRadius: 12,
-                color: color.accent,
-                fontFamily: font.mono,
-                fontSize: 12,
-                fontWeight: 700,
-                cursor: "pointer",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-                marginBottom: 16,
-              }}
+              className="w-full py-3 bg-transparent border border-dashed border-border-mid rounded-xl text-dt font-mono text-xs font-bold cursor-pointer uppercase mb-4"
+              style={{ letterSpacing: "0.08em" }}
             >
               Share invite link
             </button>
@@ -424,141 +296,72 @@ const FriendsModal = ({
             {incomingRequests.length > 0 && (
               <>
                 <div
-                  style={{
-                    fontFamily: font.mono,
-                    fontSize: 10,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.15em",
-                    color: color.accent,
-                    marginBottom: 12,
-                  }}
+                  className="font-mono text-tiny uppercase text-dt mb-3"
+                  style={{ letterSpacing: "0.15em" }}
                 >
                   Friend Requests ({incomingRequests.length})
                 </div>
                 {incomingRequests.map((f) => (
                   <div
                     key={f.id}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      padding: "12px 0",
-                      borderBottom: `1px solid ${color.border}`,
-                    }}
+                    className="flex items-center py-3 border-b border-border"
                   >
-                    <div
-                      style={{
-                        width: 40,
-                        height: 40,
-                        borderRadius: "50%",
-                        background: color.borderLight,
-                        color: color.dim,
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        fontFamily: font.mono,
-                        fontSize: 16,
-                        fontWeight: 700,
-                        marginRight: 12,
-                      }}
-                    >
+                    <div className="w-10 h-10 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-base font-bold mr-3">
                       {f.avatar}
                     </div>
-                    <div style={{ flex: 1 }}>
-                      <div
-                        style={{
-                          fontFamily: font.mono,
-                          fontSize: 13,
-                          color: color.text,
-                        }}
-                      >
+                    <div className="flex-1">
+                      <div className="font-mono text-sm text-primary">
                         {f.name}
                       </div>
-                      <div
-                        style={{
-                          fontFamily: font.mono,
-                          fontSize: 11,
-                          color: color.dim,
-                        }}
-                      >
+                      <div className="font-mono text-xs text-dim">
                         @{f.username}
                       </div>
                     </div>
-                    <div style={{ display: "flex", gap: 6 }}>
+                    <div className="flex gap-1.5">
                       {onRemoveFriend && (
                         <button
                           onClick={() => onRemoveFriend(f.id)}
-                          style={{
-                            background: "transparent",
-                            color: color.dim,
-                            border: `1px solid ${color.borderMid}`,
-                            borderRadius: 8,
-                            padding: "8px 12px",
-                            fontFamily: font.mono,
-                            fontSize: 11,
-                            fontWeight: 700,
-                            cursor: "pointer",
-                          }}
+                          className="bg-transparent text-dim border border-border-mid rounded-lg py-2 px-3 font-mono text-xs font-bold cursor-pointer"
                         >
                           Decline
                         </button>
                       )}
                       <button
                         onClick={() => onAcceptRequest(f.id)}
-                        style={{
-                          background: color.accent,
-                          color: "#000",
-                          border: "none",
-                          borderRadius: 8,
-                          padding: "8px 14px",
-                          fontFamily: font.mono,
-                          fontSize: 11,
-                          fontWeight: 700,
-                          cursor: "pointer",
-                        }}
+                        className="bg-dt text-black border-none rounded-lg py-2 px-3.5 font-mono text-xs font-bold cursor-pointer"
                       >
                         Accept
                       </button>
                     </div>
                   </div>
                 ))}
-                <div style={{ height: 20 }} />
+                <div className="h-5" />
               </>
             )}
 
             {/* Requested (outgoing pending) */}
             {filteredOutgoing.length > 0 && (
-              <div style={{ marginBottom: 20 }}>
+              <div className="mb-5">
                 <div
                   onClick={() => setRequestedState((s) => s === "collapsed" ? "preview" : "collapsed")}
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    cursor: "pointer",
-                    paddingBottom: requestedState !== "collapsed" ? 8 : 0,
-                  }}
+                  className={cn(
+                    "flex items-center justify-between cursor-pointer",
+                    requestedState !== "collapsed" ? "pb-2" : "pb-0"
+                  )}
                 >
                   <div
-                    style={{
-                      fontFamily: font.mono,
-                      fontSize: 10,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.15em",
-                      color: color.dim,
-                    }}
+                    className="font-mono text-tiny uppercase text-dim"
+                    style={{ letterSpacing: "0.15em" }}
                   >
                     Requested ({filteredOutgoing.length})
                   </div>
                   <span
+                    className="font-mono text-xs text-faint transition-transform duration-200"
                     style={{
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                      color: color.faint,
-                      transition: "transform 0.2s",
                       transform: requestedState === "collapsed" ? "rotate(0deg)" : "rotate(90deg)",
                     }}
                   >
-                    ›
+                    &rsaquo;
                   </span>
                 </div>
                 {requestedState !== "collapsed" && (
@@ -566,42 +369,25 @@ const FriendsModal = ({
                     {(requestedState === "preview" ? filteredOutgoing.slice(0, 3) : filteredOutgoing).map((f) => (
                       <div
                         key={f.id}
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          padding: "10px 0",
-                          borderBottom: `1px solid ${color.border}`,
-                        }}
+                        className="flex items-center py-2.5 border-b border-border"
                       >
-                        <div
-                          style={{
-                            width: 36,
-                            height: 36,
-                            borderRadius: "50%",
-                            background: color.borderLight,
-                            color: color.dim,
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            fontFamily: font.mono,
-                            fontSize: 14,
-                            fontWeight: 700,
-                            marginRight: 12,
-                          }}
-                        >
+                        <div className="w-9 h-9 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-sm font-bold mr-3">
                           {f.avatar}
                         </div>
-                        <div style={{ flex: 1 }}>
-                          <div style={{ fontFamily: font.mono, fontSize: 13, color: color.text }}>
+                        <div className="flex-1">
+                          <div className="font-mono text-sm text-primary">
                             {f.name}
                           </div>
-                          <div style={{ fontFamily: font.mono, fontSize: 11, color: color.dim }}>
+                          <div className="font-mono text-xs text-dim">
                             @{f.username}
                           </div>
                         </div>
                         <span
                           onClick={() => onCancelRequest?.(f.id)}
-                          style={{ fontFamily: font.mono, fontSize: 10, color: color.faint, cursor: onCancelRequest ? "pointer" : undefined, padding: "4px 8px", borderRadius: 6, border: `1px solid ${color.border}` }}
+                          className={cn(
+                            "font-mono text-tiny text-faint py-1 px-2 rounded-md border border-border",
+                            onCancelRequest ? "cursor-pointer" : ""
+                          )}
                         >
                           Pending
                         </span>
@@ -610,14 +396,7 @@ const FriendsModal = ({
                     {requestedState === "preview" && filteredOutgoing.length > 3 && (
                       <div
                         onClick={() => setRequestedState("expanded")}
-                        style={{
-                          fontFamily: font.mono,
-                          fontSize: 11,
-                          color: color.dim,
-                          padding: "10px 0",
-                          cursor: "pointer",
-                          textAlign: "center",
-                        }}
+                        className="font-mono text-xs text-dim py-2.5 cursor-pointer text-center"
                       >
                         Show all ({filteredOutgoing.length})
                       </div>
@@ -631,101 +410,47 @@ const FriendsModal = ({
             {search.length >= 2 ? (
               <>
                 <div
-                  style={{
-                    fontFamily: font.mono,
-                    fontSize: 10,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.15em",
-                    color: color.dim,
-                    marginBottom: 12,
-                  }}
+                  className="font-mono text-tiny uppercase text-dim mb-3"
+                  style={{ letterSpacing: "0.15em" }}
                 >
                   {searching ? "Searching..." : `Results (${searchResults.length})`}
                 </div>
                 {searching ? (
-                  <div
-                    style={{
-                      textAlign: "center",
-                      padding: "32px 0",
-                      color: color.faint,
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                    }}
-                  >
-                    <span style={{ animation: "pulse 1.5s ease-in-out infinite" }}>
+                  <div className="text-center py-8 text-faint font-mono text-xs">
+                    <span className="animate-pulse">
                       Searching users...
                     </span>
                   </div>
                 ) : searchResults.length === 0 ? (
-                  <p
-                    style={{
-                      textAlign: "center",
-                      color: color.faint,
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                      padding: "32px 0",
-                    }}
-                  >
+                  <p className="text-center text-faint font-mono text-xs py-8">
                     No users found
                   </p>
                 ) : (
                   searchResults.map((f) => (
                     <div
                       key={f.id}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        padding: "12px 0",
-                        borderBottom: `1px solid ${color.border}`,
-                      }}
+                      className="flex items-center py-3 border-b border-border"
                     >
                       <div
-                        style={{
-                          width: 40,
-                          height: 40,
-                          borderRadius: "50%",
-                          background: f.status === "friend" ? color.accent : color.borderLight,
-                          color: f.status === "friend" ? "#000" : color.dim,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontFamily: font.mono,
-                          fontSize: 16,
-                          fontWeight: 700,
-                          marginRight: 12,
-                        }}
+                        className={cn(
+                          "w-10 h-10 rounded-full flex items-center justify-center font-mono text-base font-bold mr-3",
+                          f.status === "friend"
+                            ? "bg-dt text-black"
+                            : "bg-border-light text-dim"
+                        )}
                       >
                         {f.avatar}
                       </div>
-                      <div style={{ flex: 1 }}>
-                        <div
-                          style={{
-                            fontFamily: font.mono,
-                            fontSize: 13,
-                            color: color.text,
-                          }}
-                        >
+                      <div className="flex-1">
+                        <div className="font-mono text-sm text-primary">
                           {f.name}
                         </div>
-                        <div
-                          style={{
-                            fontFamily: font.mono,
-                            fontSize: 11,
-                            color: color.dim,
-                          }}
-                        >
+                        <div className="font-mono text-xs text-dim">
                           @{f.username}
                         </div>
                       </div>
                       {f.status === "friend" ? (
-                        <span
-                          style={{
-                            fontFamily: font.mono,
-                            fontSize: 11,
-                            color: color.dim,
-                            padding: "8px 14px",
-                          }}
-                        >
+                        <span className="font-mono text-xs text-dim py-2 px-3.5">
                           Friends
                         </span>
                       ) : (
@@ -744,17 +469,12 @@ const FriendsModal = ({
                               prev.map((r) => r.id === f.id ? { ...r, status: "pending" as const } : r)
                             );
                           }}
-                          style={{
-                            background: f.status === "pending" ? "transparent" : color.accent,
-                            color: f.status === "pending" ? color.dim : "#000",
-                            border: f.status === "pending" ? `1px solid ${color.borderMid}` : "none",
-                            borderRadius: 8,
-                            padding: "8px 14px",
-                            fontFamily: font.mono,
-                            fontSize: 11,
-                            fontWeight: 700,
-                            cursor: "pointer",
-                          }}
+                          className={cn(
+                            "rounded-lg py-2 px-3.5 font-mono text-xs font-bold cursor-pointer",
+                            f.status === "pending"
+                              ? "bg-transparent text-dim border border-border-mid"
+                              : "bg-dt text-black border-none"
+                          )}
                         >
                           {f.status === "pending" ? "Requested" : "Add"}
                         </button>
@@ -766,95 +486,44 @@ const FriendsModal = ({
             ) : (
               <>
                 <div
-                  style={{
-                    fontFamily: font.mono,
-                    fontSize: 10,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.15em",
-                    color: color.dim,
-                    marginBottom: 12,
-                  }}
+                  className="font-mono text-tiny uppercase text-dim mb-3"
+                  style={{ letterSpacing: "0.15em" }}
                 >
                   Suggestions
                 </div>
                 {filteredSuggestions.length === 0 ? (
-                  <p
-                    style={{
-                      textAlign: "center",
-                      color: color.faint,
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                      padding: "32px 0",
-                    }}
-                  >
+                  <p className="text-center text-faint font-mono text-xs py-8">
                     Search for friends by name or username
                   </p>
                 ) : (
                   filteredSuggestions.map((f) => (
                     <div
                       key={f.id}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        padding: "12px 0",
-                        borderBottom: `1px solid ${color.border}`,
-                      }}
+                      className="flex items-center py-3 border-b border-border"
                     >
-                      <div
-                        style={{
-                          width: 40,
-                          height: 40,
-                          borderRadius: "50%",
-                          background: color.borderLight,
-                          color: color.dim,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontFamily: font.mono,
-                          fontSize: 16,
-                          fontWeight: 700,
-                          marginRight: 12,
-                        }}
-                      >
+                      <div className="w-10 h-10 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-base font-bold mr-3">
                         {f.avatar}
                       </div>
-                      <div style={{ flex: 1 }}>
-                        <div
-                          style={{
-                            fontFamily: font.mono,
-                            fontSize: 13,
-                            color: color.text,
-                          }}
-                        >
+                      <div className="flex-1">
+                        <div className="font-mono text-sm text-primary">
                           {f.name}
                         </div>
-                        <div
-                          style={{
-                            fontFamily: font.mono,
-                            fontSize: 11,
-                            color: color.dim,
-                          }}
-                        >
+                        <div className="font-mono text-xs text-dim">
                           @{f.username}
                           {f.mutualFriendName && (
-                            <span style={{ color: color.accent, marginLeft: 6 }}>via {f.mutualFriendName}</span>
+                            <span className="text-dt ml-1.5">via {f.mutualFriendName}</span>
                           )}
                         </div>
                       </div>
                       <button
                         onClick={() => f.status === "none" && onAddFriend(f.id)}
                         disabled={f.status === "pending"}
-                        style={{
-                          background: f.status === "pending" ? "transparent" : color.accent,
-                          color: f.status === "pending" ? color.dim : "#000",
-                          border: f.status === "pending" ? `1px solid ${color.borderMid}` : "none",
-                          borderRadius: 8,
-                          padding: "8px 14px",
-                          fontFamily: font.mono,
-                          fontSize: 11,
-                          fontWeight: 700,
-                          cursor: f.status === "pending" ? "default" : "pointer",
-                        }}
+                        className={cn(
+                          "rounded-lg py-2 px-3.5 font-mono text-xs font-bold",
+                          f.status === "pending"
+                            ? "bg-transparent text-dim border border-border-mid cursor-default"
+                            : "bg-dt text-black border-none cursor-pointer"
+                        )}
                       >
                         {f.status === "pending" ? "Requested" : "Add"}
                       </button>
@@ -868,24 +537,13 @@ const FriendsModal = ({
         </div>
 
         {preventClose && hasAddedFriend && (
-          <div style={{ padding: "12px 0 24px", flexShrink: 0 }}>
+          <div className="py-3 pb-6 shrink-0">
             <button
               onClick={onClose}
-              style={{
-                width: "100%",
-                background: color.accent,
-                color: "#000",
-                border: "none",
-                borderRadius: 12,
-                padding: "14px",
-                fontFamily: font.mono,
-                fontSize: 13,
-                fontWeight: 700,
-                cursor: "pointer",
-                letterSpacing: "0.02em",
-              }}
+              className="w-full bg-dt text-black border-none rounded-xl py-3.5 font-mono text-sm font-bold cursor-pointer"
+              style={{ letterSpacing: "0.02em" }}
             >
-              Continue →
+              Continue &rarr;
             </button>
           </div>
         )}
@@ -894,91 +552,36 @@ const FriendsModal = ({
       {/* Friend Profile Detail */}
       {selectedFriend && (
         <div
+          className="absolute inset-0 bg-surface z-10 flex flex-col items-center animate-slide-up"
           style={{
-            position: "absolute",
-            inset: 0,
-            background: color.surface,
             borderRadius: "24px 24px 0 0",
             padding: "32px 24px 40px",
-            zIndex: 10,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            animation: "slideUp 0.2s ease-out",
           }}
         >
           <button
             onClick={() => setSelectedFriend(null)}
-            style={{
-              alignSelf: "flex-start",
-              background: "transparent",
-              border: "none",
-              color: color.dim,
-              fontFamily: font.mono,
-              fontSize: 13,
-              cursor: "pointer",
-              padding: "0 0 20px",
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-            }}
+            className="self-start bg-transparent border-none text-dim font-mono text-sm cursor-pointer pb-5 px-0 flex items-center gap-1.5"
           >
-            ‹ Back
+            &lsaquo; Back
           </button>
 
-          <div
-            style={{
-              width: 72,
-              height: 72,
-              borderRadius: "50%",
-              background: color.accent,
-              color: "#000",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontFamily: font.mono,
-              fontSize: 28,
-              fontWeight: 700,
-              marginBottom: 16,
-            }}
-          >
+          <div className="w-[72px] h-[72px] rounded-full bg-dt text-black flex items-center justify-center font-mono text-[28px] font-bold mb-4">
             {selectedFriend.avatar}
           </div>
 
-          <div
-            style={{
-              fontFamily: font.serif,
-              fontSize: 22,
-              color: color.text,
-              marginBottom: 4,
-            }}
-          >
+          <div className="font-serif text-2xl text-primary mb-1">
             {selectedFriend.name}
           </div>
 
-          <div
-            style={{
-              fontFamily: font.mono,
-              fontSize: 13,
-              color: color.dim,
-              marginBottom: 8,
-            }}
-          >
+          <div className="font-mono text-sm text-dim mb-2">
             @{selectedFriend.username}
           </div>
 
           {selectedFriend.availability && (
-            <div
-              style={{
-                fontFamily: font.mono,
-                fontSize: 12,
-                color: color.faint,
-                marginBottom: 32,
-              }}
-            >
-              {selectedFriend.availability === "open" && "✨ open to friends!"}
-              {selectedFriend.availability === "awkward" && "👀 awkward timing"}
-              {selectedFriend.availability === "not-available" && "🌙 not available"}
+            <div className="font-mono text-xs text-faint mb-8">
+              {selectedFriend.availability === "open" && "\u2728 open to friends!"}
+              {selectedFriend.availability === "awkward" && "\uD83D\uDC40 awkward timing"}
+              {selectedFriend.availability === "not-available" && "\uD83C\uDF19 not available"}
             </div>
           )}
 
@@ -988,17 +591,9 @@ const FriendsModal = ({
                 onRemoveFriend(selectedFriend.id);
                 setSelectedFriend(null);
               }}
+              className="mt-auto bg-transparent rounded-lg py-3 px-6 font-mono text-xs text-danger cursor-pointer uppercase"
               style={{
-                marginTop: "auto",
-                background: "transparent",
-                border: `1px solid rgba(255,107,107,0.3)`,
-                borderRadius: 10,
-                padding: "12px 24px",
-                fontFamily: font.mono,
-                fontSize: 12,
-                color: "#ff6b6b",
-                cursor: "pointer",
-                textTransform: "uppercase",
+                border: "1px solid rgba(255,107,107,0.3)",
                 letterSpacing: "0.08em",
               }}
             >

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useLayoutEffect, useRef } from "react";
 import * as db from "@/lib/db";
-import { font, color } from "@/lib/styles";
+import cn from "@/lib/tailwindMerge";
 import type { Squad } from "@/lib/ui-types";
 import { logError } from "@/lib/logger";
 import { parseNaturalDate, parseNaturalTime, parseDateToISO, formatTimeAgo } from "@/lib/utils";
@@ -454,25 +454,17 @@ const SquadChat = ({
   return (
     <>
     {/* Full-screen backdrop so iOS keyboard gap shows bg color, not content behind */}
-    <div style={{
-      position: "fixed", inset: 0, background: color.bg, zIndex: 49,
-      transform: (closing || entering) ? "translateX(100%)" : `translateX(${dragX}px)`,
-      transition: closing ? "transform 0.25s ease-in" : (entering || dragX === 0) ? "transform 0.3s ease-out" : "none",
-    }} />
+    <div
+      className="fixed inset-0 bg-bg z-[49]"
+      style={{
+        transform: (closing || entering) ? "translateX(100%)" : `translateX(${dragX}px)`,
+        transition: closing ? "transform 0.25s ease-in" : (entering || dragX === 0) ? "transform 0.3s ease-out" : "none",
+      }}
+    />
     <div
       ref={chatContainerRef}
+      className="flex flex-col fixed top-0 left-0 right-0 h-dvh z-50 bg-bg overflow-hidden overscroll-none"
       style={{
-        display: "flex",
-        flexDirection: "column",
-        position: "fixed",
-        top: 0,
-        left: 0,
-        right: 0,
-        height: "100dvh",
-        zIndex: 50,
-        background: color.bg,
-        overflow: "hidden",
-        overscrollBehavior: "none",
         transform: (closing || entering) ? "translateX(100%)" : `translateX(${dragX}px)`,
         transition: closing ? "transform 0.25s ease-in" : (entering || dragX === 0) ? "transform 0.3s ease-out" : "none",
       }}
@@ -492,49 +484,23 @@ const SquadChat = ({
       {/* Leave squad confirmation */}
       {showLeaveConfirm && (
         <div
-          style={{
-            position: "fixed",
-            top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.7)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 9999,
-          }}
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-[9999]"
           onClick={() => setShowLeaveConfirm(false)}
         >
           <div
-            style={{
-              background: color.deep,
-              border: `1px solid ${color.border}`,
-              borderRadius: 16,
-              padding: "24px 20px",
-              maxWidth: 300,
-              width: "90%",
-              textAlign: "center",
-            }}
+            className="bg-deep border border-border rounded-2xl px-5 py-6 w-[90%] max-w-[300px] text-center"
             onClick={(e) => e.stopPropagation()}
           >
-            <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 6 }}>
+            <p className="font-serif text-lg text-primary mb-1.5" style={{ fontWeight: 400 }}>
               Leave {localSquad.name}?
             </p>
-            <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, marginBottom: 20 }}>
+            <p className="font-mono text-xs text-dim mb-5">
               You won&apos;t see messages from this squad anymore.
             </p>
-            <div style={{ display: "flex", gap: 10 }}>
+            <div className="flex gap-2.5">
               <button
                 onClick={() => setShowLeaveConfirm(false)}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  background: "none",
-                  border: `1px solid ${color.border}`,
-                  borderRadius: 10,
-                  color: color.text,
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  cursor: "pointer",
-                }}
+                className="flex-1 py-2.5 bg-transparent border border-border rounded-lg text-primary font-mono text-xs cursor-pointer"
               >
                 Cancel
               </button>
@@ -551,18 +517,7 @@ const SquadChat = ({
                   }
                   setShowLeaveConfirm(false);
                 }}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  background: "#ff4444",
-                  border: "none",
-                  borderRadius: 10,
-                  color: "#fff",
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  cursor: "pointer",
-                  fontWeight: 700,
-                }}
+                className="flex-1 py-2.5 bg-[#ff4444] border-none rounded-lg text-white font-mono text-xs font-bold cursor-pointer"
               >
                 Leave
               </button>
@@ -574,49 +529,23 @@ const SquadChat = ({
       {/* I'm out confirmation */}
       {showImOutConfirm && (
         <div
-          style={{
-            position: "fixed",
-            top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.7)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 9999,
-          }}
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-[9999]"
           onClick={() => setShowImOutConfirm(false)}
         >
           <div
-            style={{
-              background: color.deep,
-              border: `1px solid ${color.border}`,
-              borderRadius: 16,
-              padding: "24px 20px",
-              maxWidth: 300,
-              width: "90%",
-              textAlign: "center",
-            }}
+            className="bg-deep border border-border rounded-2xl px-5 py-6 w-[90%] max-w-[300px] text-center"
             onClick={(e) => e.stopPropagation()}
           >
-            <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 6 }}>
+            <p className="font-serif text-lg text-primary mb-1.5" style={{ fontWeight: 400 }}>
               Can&apos;t make it?
             </p>
-            <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, marginBottom: 20 }}>
+            <p className="font-mono text-xs text-dim mb-5">
               You&apos;ll be removed from this squad and lose access to the chat.
             </p>
-            <div style={{ display: "flex", gap: 10 }}>
+            <div className="flex gap-2.5">
               <button
                 onClick={() => setShowImOutConfirm(false)}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  background: "none",
-                  border: `1px solid ${color.border}`,
-                  borderRadius: 10,
-                  color: color.text,
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  cursor: "pointer",
-                }}
+                className="flex-1 py-2.5 bg-transparent border border-border rounded-lg text-primary font-mono text-xs cursor-pointer"
               >
                 Cancel
               </button>
@@ -638,18 +567,7 @@ const SquadChat = ({
                   }
                   setShowImOutConfirm(false);
                 }}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  background: "#ff4444",
-                  border: "none",
-                  borderRadius: 10,
-                  color: "#fff",
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  cursor: "pointer",
-                  fontWeight: 700,
-                }}
+                className="flex-1 py-2.5 bg-[#ff4444] border-none rounded-lg text-white font-mono text-xs font-bold cursor-pointer"
               >
                 I&apos;m out
               </button>
@@ -661,49 +579,23 @@ const SquadChat = ({
       {/* Kick member confirmation */}
       {kickTarget && localSquad && (
         <div
-          style={{
-            position: "fixed",
-            top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.7)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 9999,
-          }}
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-[9999]"
           onClick={() => setKickTarget(null)}
         >
           <div
-            style={{
-              background: color.deep,
-              border: `1px solid ${color.border}`,
-              borderRadius: 16,
-              padding: "24px 20px",
-              maxWidth: 300,
-              width: "90%",
-              textAlign: "center",
-            }}
+            className="bg-deep border border-border rounded-2xl px-5 py-6 w-[90%] max-w-[300px] text-center"
             onClick={(e) => e.stopPropagation()}
           >
-            <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 6 }}>
+            <p className="font-serif text-lg text-primary mb-1.5" style={{ fontWeight: 400 }}>
               Kick {kickTarget.name}?
             </p>
-            <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, marginBottom: 20 }}>
+            <p className="font-mono text-xs text-dim mb-5">
               they&apos;ll be removed from the squad. no take-backs (jk you can re-add them)
             </p>
-            <div style={{ display: "flex", gap: 10 }}>
+            <div className="flex gap-2.5">
               <button
                 onClick={() => setKickTarget(null)}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  background: "none",
-                  border: `1px solid ${color.border}`,
-                  borderRadius: 10,
-                  color: color.text,
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  cursor: "pointer",
-                }}
+                className="flex-1 py-2.5 bg-transparent border border-border rounded-lg text-primary font-mono text-xs cursor-pointer"
               >
                 Nah
               </button>
@@ -728,18 +620,7 @@ const SquadChat = ({
                     setKickTarget(null);
                   }
                 }}
-                style={{
-                  flex: 1,
-                  padding: "10px 0",
-                  background: "#ff4444",
-                  border: "none",
-                  borderRadius: 10,
-                  color: "#fff",
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  cursor: "pointer",
-                  fontWeight: 700,
-                }}
+                className="flex-1 py-2.5 bg-[#ff4444] border-none rounded-lg text-white font-mono text-xs font-bold cursor-pointer"
               >
                 Yeet 🥾
               </button>
@@ -795,136 +676,69 @@ const SquadChat = ({
         };
 
         return (
-          <div
-            style={{
-              position: "fixed",
-              inset: 0,
-              zIndex: 9999,
-              display: "flex",
-              alignItems: "flex-end",
-              justifyContent: "center",
-            }}
-          >
+          <div className="fixed inset-0 z-[9999] flex items-end justify-center">
             <div
               onClick={() => setShowEditEvent(false)}
-              style={{
-                position: "absolute",
-                inset: 0,
-                background: "rgba(0,0,0,0.7)",
-                backdropFilter: "blur(8px)",
-                WebkitBackdropFilter: "blur(8px)",
-              }}
+              className="absolute inset-0 bg-black/70 backdrop-blur-[8px]"
+              style={{ WebkitBackdropFilter: "blur(8px)" }}
             />
             <div
-              style={{
-                position: "relative",
-                background: color.surface,
-                borderRadius: "24px 24px 0 0",
-                width: "100%",
-                maxWidth: 420,
-                padding: "20px 24px 0",
-                maxHeight: "80vh",
-                display: "flex",
-                flexDirection: "column",
-                animation: "slideUp 0.3s ease-out",
-              }}
+              className="relative bg-surface rounded-t-3xl w-full max-w-[420px] px-6 pt-5 pb-0 max-h-[80vh] flex flex-col animate-slide-up"
             >
               {/* Drag handle */}
-              <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2, margin: "0 auto 20px" }} />
+              <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-5" />
 
-              <div style={{ overflowY: "auto", overflowX: "hidden", flex: 1, paddingBottom: 24 }}>
+              <div className="overflow-y-auto overflow-x-hidden flex-1 pb-6">
                 {/* Title */}
-                <h2 style={{ fontFamily: font.serif, fontSize: 18, color: color.text, margin: "0 0 20px", fontWeight: 400 }}>
+                <h2 className="font-serif text-lg text-primary m-0 mb-5" style={{ fontWeight: 400 }}>
                   Edit event
                 </h2>
 
                 {/* Event title textarea */}
-                <div style={{ marginBottom: 16 }}>
+                <div className="mb-4">
                   <textarea
                     value={editEventTitle}
                     onChange={(e) => setEditEventTitle(e.target.value.slice(0, 280))}
                     placeholder="What's the plan?"
                     autoFocus
                     rows={3}
-                    style={{
-                      width: "100%",
-                      background: color.deep,
-                      border: `1px solid ${color.borderMid}`,
-                      borderRadius: 12,
-                      padding: "14px 16px",
-                      color: color.text,
-                      fontFamily: font.mono,
-                      fontSize: 13,
-                      outline: "none",
-                      resize: "none",
-                      lineHeight: 1.5,
-                      boxSizing: "border-box",
-                    }}
+                    className="w-full bg-deep border border-border-mid rounded-xl p-3.5 px-4 text-primary font-mono text-sm outline-none resize-none leading-relaxed box-border"
+                    style={{ fontSize: 13 }}
                   />
                 </div>
 
                 {/* When / Where inputs */}
-                <div style={{ display: "flex", gap: 8, marginBottom: 4 }}>
+                <div className="flex gap-2 mb-1">
                   <input
                     type="text"
                     placeholder="tmr 7pm"
                     value={editWhenInput}
                     onChange={(e) => setEditWhenInput(e.target.value)}
-                    style={{
-                      flex: 1,
-                      minWidth: 0,
-                      padding: "10px 12px",
-                      background: color.deep,
-                      border: `1px solid ${color.borderMid}`,
-                      borderRadius: 10,
-                      fontFamily: font.mono,
-                      fontSize: 11,
-                      color: color.text,
-                      outline: "none",
-                      boxSizing: "border-box",
-                    }}
+                    className="flex-1 min-w-0 py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
                   />
                   <input
                     type="text"
                     placeholder="where?"
                     value={editWhereInput}
                     onChange={(e) => setEditWhereInput(e.target.value)}
-                    style={{
-                      flex: 0.6,
-                      minWidth: 0,
-                      padding: "10px 12px",
-                      background: color.deep,
-                      border: `1px solid ${color.borderMid}`,
-                      borderRadius: 10,
-                      fontFamily: font.mono,
-                      fontSize: 11,
-                      color: color.text,
-                      outline: "none",
-                      boxSizing: "border-box",
-                    }}
+                    className="min-w-0 py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
+                    style={{ flex: 0.6 }}
                   />
                 </div>
               </div>
 
               {/* Save button */}
-              <div style={{ padding: "12px 0 24px", flexShrink: 0 }}>
+              <div className="py-3 pb-6 shrink-0">
                 <button
                   onClick={handleSaveEvent}
                   disabled={savingEvent}
-                  style={{
-                    width: "100%",
-                    background: !savingEvent ? color.accent : color.borderMid,
-                    color: !savingEvent ? "#000" : color.dim,
-                    border: "none",
-                    borderRadius: 12,
-                    padding: "14px",
-                    fontFamily: font.mono,
-                    fontSize: 12,
-                    fontWeight: 700,
-                    cursor: !savingEvent ? "pointer" : "default",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.08em",
-                  }}
+                  className={cn(
+                    "w-full border-none rounded-xl p-3.5 font-mono text-xs font-bold uppercase",
+                    savingEvent
+                      ? "bg-border-mid text-dim cursor-default"
+                      : "bg-dt text-black cursor-pointer"
+                  )}
+                  style={{ letterSpacing: "0.08em" }}
                 >
                   {savingEvent ? "Saving..." : "Save"}
                 </button>
@@ -935,27 +749,16 @@ const SquadChat = ({
       })()}
 
       {/* Messages + Input blur wrapper */}
-      <div style={{
-        flex: 1,
-        display: "flex",
-        flexDirection: "column",
-        filter: (showSquadPopup || showEditEvent) ? 'blur(4px)' : 'none',
-        opacity: (showSquadPopup || showEditEvent) ? 0.3 : 1,
-        pointerEvents: (showSquadPopup || showEditEvent) ? 'none' : 'auto',
-        transition: 'filter 0.2s, opacity 0.2s',
-        minHeight: 0,
-      }}>
+      <div
+        className={cn(
+          "flex-1 flex flex-col min-h-0 transition-[filter,opacity] duration-200",
+          (showSquadPopup || showEditEvent) && "blur-[4px] opacity-30 pointer-events-none"
+        )}
+      >
       {/* Messages */}
       <div
-        style={{
-          flex: 1,
-          overflowY: dragX > 0 ? "hidden" : "auto",
-          overscrollBehavior: "contain",
-          padding: "12px 20px",
-          display: "flex",
-          flexDirection: "column",
-          gap: 2,
-        }}
+        className="flex-1 overscroll-contain px-5 py-3 flex flex-col gap-0.5"
+        style={{ overflowY: dragX > 0 ? "hidden" : "auto" }}
       >
         {(() => {
           const lastConfirmIdx = messages.reduce((acc, m, idx) => m.messageType === 'date_confirm' ? idx : acc, -1);
@@ -988,34 +791,20 @@ const SquadChat = ({
 
       {/* Input — hidden for waitlisted users */}
       {localSquad.isWaitlisted ? (
-        <div
-          style={{
-            padding: "12px 20px calc(12px + env(safe-area-inset-bottom, 0px))",
-            borderTop: `1px solid ${color.border}`,
-            textAlign: "center",
-          }}
-        >
-          <span style={{ fontFamily: font.mono, fontSize: 11, color: color.faint }}>
+        <div className="px-5 py-3 border-t border-border text-center" style={{ paddingBottom: "calc(12px + env(safe-area-inset-bottom, 0px))" }}>
+          <span className="font-mono text-xs text-faint">
             You&apos;re on the waitlist — read only
           </span>
         </div>
       ) : (
-      <div style={{ borderTop: `1px solid ${color.border}` }}>
+      <div className="border-t border-border">
         {/* Sticky date confirm bar */}
         {(dateConfirmStatus === 'pending' || (dateConfirmStatus === 'loading' && localSquad.dateStatus === 'proposed')) && !confirmLoading && (
-          <div style={{
-            borderTop: `1px solid ${color.border}`,
-            padding: '12px 20px',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            gap: 10,
-            background: color.card,
-          }}>
-            <span style={{ fontFamily: font.mono, fontSize: 10, color: color.dim }}>
+          <div className="border-t border-border px-5 py-3 flex flex-col items-center gap-2.5 bg-card">
+            <span className="font-mono text-tiny text-dim">
               are you still down?
             </span>
-            <div style={{ display: 'flex', gap: 8 }}>
+            <div className="flex gap-2">
               <button
                 onClick={async () => {
                   if (!localSquad?.id || confirmLoading) return;
@@ -1030,33 +819,13 @@ const SquadChat = ({
                     setConfirmLoading(false);
                   }
                 }}
-                style={{
-                  background: color.accent,
-                  color: '#000',
-                  border: 'none',
-                  borderRadius: 10,
-                  padding: '6px 16px',
-                  fontFamily: font.mono,
-                  fontSize: 11,
-                  fontWeight: 700,
-                  cursor: 'pointer',
-                }}
+                className="bg-dt text-black border-none rounded-lg px-4 py-1.5 font-mono text-xs font-bold cursor-pointer"
               >
                 STILL DOWN
               </button>
               <button
                 onClick={() => setShowImOutConfirm(true)}
-                style={{
-                  background: 'transparent',
-                  color: color.text,
-                  border: `1px solid ${color.borderMid}`,
-                  borderRadius: 10,
-                  padding: '6px 16px',
-                  fontFamily: font.mono,
-                  fontSize: 11,
-                  fontWeight: 700,
-                  cursor: 'pointer',
-                }}
+                className="bg-transparent text-primary border border-border-mid rounded-lg px-4 py-1.5 font-mono text-xs font-bold cursor-pointer"
               >
                 I&apos;M OUT
               </button>
@@ -1067,36 +836,16 @@ const SquadChat = ({
         {activePoll?.status === 'active' && (
           <div
             onClick={() => pollMessageRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })}
-            style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '6px 20px', cursor: 'pointer' }}
+            className="flex items-center gap-1.5 px-5 py-1.5 cursor-pointer"
           >
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              background: color.card,
-              border: `1px solid ${color.accent}`,
-              borderRadius: 20,
-              padding: '6px 12px',
-              flex: 1,
-              minWidth: 0,
-            }}>
-              <span style={{ fontSize: 12, flexShrink: 0 }}>📊</span>
-              <span style={{
-                fontFamily: font.mono,
-                fontSize: 11,
-                color: color.text,
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                flex: 1,
-              }}>{activePoll.question}</span>
-              <span style={{
-                fontFamily: font.mono,
-                fontSize: 10,
-                fontWeight: 700,
-                color: color.accent,
-                flexShrink: 0,
-              }}>{new Set(pollVotes.map((v) => v.userId)).size}</span>
+            <div className="flex items-center gap-1.5 bg-card border border-dt rounded-2xl px-3 py-1.5 flex-1 min-w-0">
+              <span className="text-xs shrink-0">📊</span>
+              <span className="font-mono text-xs text-primary overflow-hidden text-ellipsis whitespace-nowrap flex-1">
+                {activePoll.question}
+              </span>
+              <span className="font-mono text-tiny font-bold text-dt shrink-0">
+                {new Set(pollVotes.map((v) => v.userId)).size}
+              </span>
             </div>
           </div>
         )}
@@ -1106,45 +855,25 @@ const SquadChat = ({
           .map((r) => (
             <div
               key={r.userId}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 10,
-                padding: "10px 20px",
-                borderTop: `1px solid ${color.border}`,
-              }}
+              className="flex items-center gap-2.5 px-5 py-2.5 border-t border-border"
             >
-              <div style={{
-                width: 24, height: 24, borderRadius: "50%",
-                background: color.borderLight, color: color.dim,
-                display: "flex", alignItems: "center", justifyContent: "center",
-                fontFamily: font.mono, fontSize: 10, fontWeight: 700, flexShrink: 0,
-              }}>
+              <div className="w-6 h-6 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-tiny font-bold shrink-0">
                 {r.avatar}
               </div>
-              <span style={{ fontFamily: font.mono, fontSize: 11, color: color.accent, flex: 1, minWidth: 0 }}>
+              <span className="font-mono text-xs text-dt flex-1 min-w-0">
                 {r.name} wants to join
               </span>
               <button
                 onClick={() => onRespondToJoinRequest(r.squadId, r.userId, true)}
-                style={{
-                  background: color.accent, color: "#000", border: "none",
-                  borderRadius: 8, padding: "6px 12px",
-                  fontFamily: font.mono, fontSize: 10, fontWeight: 700,
-                  textTransform: "uppercase", letterSpacing: "0.08em", cursor: "pointer",
-                }}
+                className="bg-dt text-black border-none rounded-lg px-3 py-1.5 font-mono text-tiny font-bold uppercase cursor-pointer"
+                style={{ letterSpacing: "0.08em" }}
               >
                 Accept
               </button>
               <button
                 onClick={() => onRespondToJoinRequest(r.squadId, r.userId, false)}
-                style={{
-                  background: "transparent", color: color.dim,
-                  border: `1px solid ${color.borderMid}`,
-                  borderRadius: 8, padding: "6px 12px",
-                  fontFamily: font.mono, fontSize: 10, fontWeight: 700,
-                  textTransform: "uppercase", letterSpacing: "0.08em", cursor: "pointer",
-                }}
+                className="bg-transparent text-dim border border-border-mid rounded-lg px-3 py-1.5 font-mono text-tiny font-bold uppercase cursor-pointer"
+                style={{ letterSpacing: "0.08em" }}
               >
                 Decline
               </button>
@@ -1194,37 +923,25 @@ const SquadChat = ({
       {showPollCreator && (
         <div
           onClick={() => { setShowPollCreator(false); setPollQuestion(""); setPollOptions(["", ""]); setPollMultiSelect(true); }}
-          style={{
-            position: "fixed", top: 0, left: 0, right: 0, bottom: 0,
-            background: "rgba(0,0,0,0.7)",
-            display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9999,
-          }}
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-[9999]"
         >
           <div
             onClick={(e) => e.stopPropagation()}
-            style={{
-              background: color.deep, border: `1px solid ${color.border}`,
-              borderRadius: 16, padding: "24px 20px", maxWidth: 340, width: "90%",
-            }}
+            className="bg-deep border border-border rounded-2xl px-5 py-6 w-[90%] max-w-[340px]"
           >
-            <h3 style={{ fontFamily: font.serif, fontSize: 18, color: color.text, marginBottom: 16, textAlign: 'center' }}>
+            <h3 className="font-serif text-lg text-primary mb-4 text-center">
               Create a poll
             </h3>
             <input
               value={pollQuestion}
               onChange={(e) => setPollQuestion(e.target.value)}
               placeholder="What's the question?"
-              style={{
-                width: '100%', background: color.card,
-                border: `1px solid ${color.borderMid}`, borderRadius: 10,
-                padding: '10px 12px', color: color.text,
-                fontFamily: font.mono, fontSize: 13, outline: 'none',
-                marginBottom: 12, boxSizing: 'border-box',
-              }}
+              className="w-full bg-card border border-border-mid rounded-lg py-2.5 px-3 text-primary font-mono outline-none mb-3 box-border"
+              style={{ fontSize: 13 }}
             />
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 12 }}>
+            <div className="flex flex-col gap-2 mb-3">
               {pollOptions.map((opt, i) => (
-                <div key={i} style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                <div key={i} className="flex gap-1.5 items-center">
                   <input
                     value={opt}
                     onChange={(e) => {
@@ -1233,20 +950,12 @@ const SquadChat = ({
                       setPollOptions(next);
                     }}
                     placeholder={`Option ${i + 1}`}
-                    style={{
-                      flex: 1, background: color.card,
-                      border: `1px solid ${color.borderMid}`, borderRadius: 10,
-                      padding: '8px 12px', color: color.text,
-                      fontFamily: font.mono, fontSize: 12, outline: 'none',
-                    }}
+                    className="flex-1 bg-card border border-border-mid rounded-lg py-2 px-3 text-primary font-mono text-xs outline-none"
                   />
                   {pollOptions.length > 2 && (
                     <button
                       onClick={() => setPollOptions(pollOptions.filter((_, j) => j !== i))}
-                      style={{
-                        background: 'none', border: 'none', color: color.faint,
-                        fontFamily: font.mono, fontSize: 16, cursor: 'pointer', padding: '0 4px',
-                      }}
+                      className="bg-transparent border-none text-faint font-mono text-base cursor-pointer px-1"
                     >
                       ×
                     </button>
@@ -1257,44 +966,31 @@ const SquadChat = ({
             {pollOptions.length < 10 && (
               <button
                 onClick={() => setPollOptions([...pollOptions, ""])}
-                style={{
-                  background: 'none', border: `1px solid ${color.borderMid}`,
-                  borderRadius: 10, padding: '6px 12px', color: color.dim,
-                  fontFamily: font.mono, fontSize: 11, cursor: 'pointer',
-                  width: '100%', marginBottom: 16,
-                }}
+                className="bg-transparent border border-border-mid rounded-lg px-3 py-1.5 text-dim font-mono text-xs cursor-pointer w-full mb-4"
               >
                 + Add option
               </button>
             )}
             <div
               onClick={() => setPollMultiSelect(!pollMultiSelect)}
-              style={{
-                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                padding: '10px 0', marginBottom: 12, cursor: 'pointer',
-              }}
+              className="flex items-center justify-between py-2.5 mb-3 cursor-pointer"
             >
-              <span style={{ fontFamily: font.mono, fontSize: 11, color: color.dim }}>Allow multiple selections</span>
-              <div style={{
-                width: 36, height: 20, borderRadius: 10,
-                background: pollMultiSelect ? color.accent : color.borderMid,
-                position: 'relative', transition: 'background 0.2s',
-              }}>
-                <div style={{
-                  width: 16, height: 16, borderRadius: '50%', background: '#fff',
-                  position: 'absolute', top: 2, left: pollMultiSelect ? 18 : 2, transition: 'left 0.2s',
-                }} />
+              <span className="font-mono text-xs text-dim">Allow multiple selections</span>
+              <div
+                className="w-9 h-5 rounded-lg relative transition-colors duration-200"
+                style={{ background: pollMultiSelect ? '#e8ff5a' : '#333' }}
+              >
+                <div
+                  className="w-4 h-4 rounded-full bg-white absolute top-0.5 transition-[left] duration-200"
+                  style={{ left: pollMultiSelect ? 18 : 2 }}
+                />
               </div>
             </div>
-            <div style={{ display: 'flex', gap: 10 }}>
+            <div className="flex gap-2.5">
               <button
                 onClick={() => { setShowPollCreator(false); setPollQuestion(""); setPollOptions(["", ""]); setPollMultiSelect(true); }}
-                style={{
-                  flex: 1, background: 'transparent', color: color.text,
-                  border: `1px solid ${color.borderMid}`, borderRadius: 12, padding: '12px',
-                  fontFamily: font.mono, fontSize: 12, fontWeight: 700,
-                  cursor: 'pointer', textTransform: 'uppercase', letterSpacing: '0.08em',
-                }}
+                className="flex-1 bg-transparent text-primary border border-border-mid rounded-xl p-3 font-mono text-xs font-bold cursor-pointer uppercase"
+                style={{ letterSpacing: '0.08em' }}
               >
                 Cancel
               </button>
@@ -1317,15 +1013,13 @@ const SquadChat = ({
                     setPollCreating(false);
                   }
                 }}
-                style={{
-                  flex: 1,
-                  background: (!pollQuestion.trim() || pollOptions.filter((o) => o.trim()).length < 2) ? color.borderMid : color.accent,
-                  color: (!pollQuestion.trim() || pollOptions.filter((o) => o.trim()).length < 2) ? color.dim : '#000',
-                  border: 'none', borderRadius: 12, padding: '12px',
-                  fontFamily: font.mono, fontSize: 12, fontWeight: 700,
-                  cursor: (!pollQuestion.trim() || pollOptions.filter((o) => o.trim()).length < 2) ? 'default' : 'pointer',
-                  textTransform: 'uppercase', letterSpacing: '0.08em',
-                }}
+                className={cn(
+                  "flex-1 border-none rounded-xl p-3 font-mono text-xs font-bold uppercase",
+                  (!pollQuestion.trim() || pollOptions.filter((o) => o.trim()).length < 2)
+                    ? "bg-border-mid text-dim cursor-default"
+                    : "bg-dt text-black cursor-pointer"
+                )}
+                style={{ letterSpacing: '0.08em' }}
               >
                 {pollCreating ? '...' : 'Create'}
               </button>


### PR DESCRIPTION
## Summary
Batch 3 of inline styles → Tailwind migration. Converts 3 files (~214 inline styles total):

- **SquadChat.tsx** — 72 inline styles → Tailwind (420 lines removed)
- **FriendsModal.tsx** — 71 inline styles → Tailwind (532 lines removed)
- **CalendarView.tsx** — 71 inline styles → Tailwind (394 lines removed)

All three remove `font`/`color` imports from `styles.ts`.

## Running total
| Batch | Files | Inline styles converted | Lines removed |
|-------|-------|------------------------|---------------|
| 1 (#300) | CreateModal | 102 | 812 |
| 2 (#301) | ProfileView, EventCard, admin | 231 | 794 |
| 3 (this) | SquadChat, FriendsModal, CalendarView | 214 | 1,346 |
| **Total** | **7 files** | **547 / ~970 (56%)** | **~2,952** |

## Test plan
- [ ] Squad chat renders correctly (messages, confirm bar, input, settings)
- [ ] Friends modal renders correctly (tabs, search, friend cards, profile detail)
- [ ] Calendar view renders correctly (month grid, event dots, saved events list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)