### PR TITLE
refactor: convert all remaining files to Tailwind (batch 5 — final)

### DIFF
--- a/src/app/check/[id]/cta.tsx
+++ b/src/app/check/[id]/cta.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { API_BASE } from "@/lib/db";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 
 type State = "loading" | "logged-out" | "ready" | "submitting" | "done";
 
@@ -40,28 +40,13 @@ export default function CheckPreviewCTA({ checkId }: { checkId: string }) {
 
   if (state === "loading") return null;
 
-  const buttonStyle = {
-    display: "block",
-    width: "100%",
-    textAlign: "center" as const,
-    background: color.accent,
-    color: "#000",
-    borderRadius: 12,
-    padding: 14,
-    fontFamily: font.mono,
-    fontSize: 12,
-    fontWeight: 700,
-    textTransform: "uppercase" as const,
-    letterSpacing: "0.08em",
-    textDecoration: "none",
-    border: "none",
-    cursor: "pointer",
-  };
+  const baseClasses = "block w-full text-center bg-dt text-black rounded-xl font-mono text-xs font-bold uppercase no-underline border-none cursor-pointer";
+  const baseStyle = { padding: 14, letterSpacing: "0.08em" };
 
   // Not logged in — send through auth flow with pending check
   if (state === "logged-out") {
     return (
-      <a href={`/?pendingCheck=${checkId}`} style={buttonStyle}>
+      <a href={`/?pendingCheck=${checkId}`} className={baseClasses} style={baseStyle}>
         Join to respond
       </a>
     );
@@ -70,19 +55,14 @@ export default function CheckPreviewCTA({ checkId }: { checkId: string }) {
   // Already responded
   if (state === "done") {
     return (
-      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div className="flex flex-col gap-2.5">
         <div
-          style={{
-            ...buttonStyle,
-            background: "transparent",
-            color: color.accent,
-            border: `1px solid ${color.borderMid}`,
-            cursor: "default",
-          }}
+          className={`${baseClasses} !bg-transparent !text-dt !cursor-default`}
+          style={{ ...baseStyle, border: `1px solid ${color.borderMid}` }}
         >
           {"You're down \u{1F919}"}
         </div>
-        <a href={`/?tab=feed&checkId=${checkId}`} style={{ ...buttonStyle, background: color.card, color: color.text }}>
+        <a href={`/?tab=feed&checkId=${checkId}`} className={`${baseClasses} !bg-card !text-primary`} style={baseStyle}>
           Open downto
         </a>
       </div>
@@ -94,8 +74,9 @@ export default function CheckPreviewCTA({ checkId }: { checkId: string }) {
     <button
       onClick={handleRespond}
       disabled={state === "submitting"}
+      className={baseClasses}
       style={{
-        ...buttonStyle,
+        ...baseStyle,
         opacity: state === "submitting" ? 0.6 : 1,
       }}
     >

--- a/src/app/check/[id]/page.tsx
+++ b/src/app/check/[id]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getServiceClient } from "@/lib/supabase-admin";
-import { font, color } from "@/lib/styles";
 import CheckPreviewCTA from "./cta";
 
 interface CheckData {
@@ -82,86 +81,38 @@ export default async function CheckPreviewPage({ params }: { params: Promise<{ i
   const whenLine = dateParts.length > 0 ? dateParts.join(" · ") : null;
 
   return (
-    <div
-      style={{
-        minHeight: "100dvh",
-        background: color.bg,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        padding: "24px 20px",
-      }}
-    >
-      <div style={{ width: "100%", maxWidth: 380 }}>
-        <p style={{
-          fontFamily: font.serif,
-          fontSize: 22,
-          color: color.text,
-          textAlign: "center",
-          marginBottom: 20,
-          fontWeight: 400,
-        }}>
+    <div className="min-h-dvh bg-bg flex flex-col items-center justify-center py-6 px-5">
+      <div className="w-full max-w-[380px]">
+        <p className="font-serif text-2xl text-primary text-center mb-5 font-normal">
           are you down?
         </p>
         {/* Card */}
-        <div
-          style={{
-            background: color.card,
-            borderRadius: 14,
-            border: `1px solid ${color.border}`,
-            padding: 20,
-            marginBottom: 24,
-          }}
-        >
+        <div className="bg-card rounded-xl border border-border p-5 mb-6">
           {/* Author */}
-          <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}>
-            <div
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: "50%",
-                background: color.borderLight,
-                color: color.dim,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontFamily: font.mono,
-                fontSize: 13,
-                fontWeight: 700,
-              }}
-            >
+          <div className="flex items-center gap-2.5 mb-3.5">
+            <div className="w-8 h-8 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-sm font-bold">
               {check.author.avatar_letter}
             </div>
-            <span style={{ fontFamily: font.mono, fontSize: 12, color: color.muted }}>
+            <span className="font-mono text-xs text-muted">
               {check.author.display_name}
             </span>
           </div>
 
           {/* Check text */}
-          <p
-            style={{
-              fontFamily: font.serif,
-              fontSize: 20,
-              color: color.text,
-              lineHeight: 1.4,
-              margin: "0 0 14px",
-              fontWeight: 400,
-            }}
-          >
+          <p className="font-serif text-xl text-primary leading-[1.4] mb-3.5 font-normal" style={{ margin: "0 0 14px" }}>
             {check.text}
           </p>
 
           {/* When / Where */}
           {(whenLine || check.location) && (
-            <div style={{ display: "flex", flexDirection: "column", gap: 4, marginBottom: 14 }}>
+            <div className="flex flex-col gap-1 mb-3.5">
               {whenLine && (
-                <span style={{ fontFamily: font.mono, fontSize: 11, color: color.faint }}>
+                <span className="font-mono text-xs text-faint">
                   {whenLine}
                 </span>
               )}
               {check.location && (
-                <span style={{ fontFamily: font.mono, fontSize: 11, color: color.faint }}>
+                <span className="font-mono text-xs text-faint">
                   {check.location}
                 </span>
               )}
@@ -170,7 +121,7 @@ export default async function CheckPreviewPage({ params }: { params: Promise<{ i
 
           {/* Response count */}
           {check.responseCount > 0 && (
-            <span style={{ fontFamily: font.mono, fontSize: 11, color: color.dim }}>
+            <span className="font-mono text-xs text-dim">
               {check.responseCount} {check.responseCount === 1 ? "person" : "people"} responded
             </span>
           )}
@@ -180,15 +131,7 @@ export default async function CheckPreviewPage({ params }: { params: Promise<{ i
         <CheckPreviewCTA checkId={check.id} />
 
         {/* Branding */}
-        <p
-          style={{
-            textAlign: "center",
-            fontFamily: font.serif,
-            fontSize: 14,
-            color: color.faint,
-            marginTop: 20,
-          }}
-        >
+        <p className="text-center font-serif text-sm text-faint mt-5">
           down to
         </p>
       </div>

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useEffect, useState } from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import type { Tab } from "@/lib/ui-types";
 import { TABS } from "@/lib/ui-types";
 
@@ -65,38 +65,18 @@ const BottomNav = ({
   const idx = TABS.indexOf(tab);
 
   return (
-    <div
-      style={{
-        flexShrink: 0,
-        padding: "0px 16px 16px",
-        background: color.bg,
-      }}
-    >
+    <div className="shrink-0 px-4 pb-4 bg-bg">
       <div
-        style={{
-          display: "flex",
-          gap: 0,
-          background: color.card,
-          borderRadius: 18,
-          padding: "4px",
-          border: `1px solid ${color.border}`,
-          position: "relative",
-          height: 60,
-          alignItems: "stretch",
-        }}
+        className="flex bg-card rounded-[18px] p-1 border border-border relative items-stretch"
+        style={{ height: 60 }}
       >
         {/* Sliding highlight */}
         <div
           ref={highlightRef}
+          className="absolute top-1 bottom-1 bg-border-light rounded-xl opacity-30"
           style={{
-            position: "absolute",
-            top: 4,
-            bottom: 4,
             left: `calc(${idx} * (100% - 8px) / 4 + 4px)`,
             width: "calc((100% - 8px) / 4)",
-            background: color.borderLight,
-            borderRadius: 14,
-            opacity: 0.3,
             ...(settled ? { transition: "none" } : {}),
           }}
         />
@@ -104,31 +84,15 @@ const BottomNav = ({
           <button
             key={t}
             onClick={() => onTabChange(t)}
-            style={{
-              flex: 1,
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              padding: "8px 0",
-              position: "relative",
-              zIndex: 1,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              justifyContent: "center",
-              gap: 2,
-            }}
+            className="flex-1 bg-none border-none cursor-pointer py-2 relative z-[1] flex flex-col items-center justify-center gap-0.5"
           >
-            <span style={{ fontSize: 13, lineHeight: 1 }}>
+            <span className="text-sm leading-none">
               {tabIcons[t]}
             </span>
             <span
+              className="font-mono leading-none mt-[5px] uppercase"
               style={{
-                fontFamily: font.mono,
                 fontSize: 9,
-                lineHeight: 1,
-                marginTop: 5,
-                textTransform: "uppercase",
                 letterSpacing: "0.08em",
                 color: tab === t ? color.accent : color.faint,
                 fontWeight: tab === t ? 700 : 400,
@@ -139,15 +103,7 @@ const BottomNav = ({
             {t === "groups" && hasGroupsUnread && (
               <div
                 data-testid="squads-unread-dot"
-                style={{
-                  position: "absolute",
-                  top: 4,
-                  right: 8,
-                  width: 7,
-                  height: 7,
-                  borderRadius: "50%",
-                  background: "#ff3b30",
-                }}
+                className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
               />
             )}
           </button>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 
 const Header = ({
   unreadCount,
@@ -13,41 +13,18 @@ const Header = ({
   onOpenAdd: () => void;
   glowAdd?: boolean;
 }) => (
-  <div
-    style={{
-      padding: "16px 20px 4px",
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-      flexShrink: 0,
-      background: color.bg,
-    }}
-  >
+  <div className="pt-4 px-5 pb-1 flex justify-between items-center shrink-0 bg-bg">
     <h1
-      style={{
-        fontFamily: font.serif,
-        fontSize: 28,
-        color: color.text,
-        fontWeight: 400,
-        letterSpacing: "-0.02em",
-      }}
+      className="font-serif text-primary font-normal"
+      style={{ fontSize: 28, letterSpacing: "-0.02em" }}
     >
       down to
     </h1>
-    <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+    <div className="flex items-center gap-2.5">
       {/* Bell icon */}
       <button
         onClick={onOpenNotifications}
-        style={{
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          position: "relative",
-          padding: 8,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
+        className="bg-none border-none cursor-pointer relative p-2 flex items-center justify-center"
       >
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke={color.muted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
@@ -55,60 +32,28 @@ const Header = ({
         </svg>
         {unreadCount > 0 && (
           <div
-            style={{
-              position: "absolute",
-              top: 4,
-              right: 4,
-              width: unreadCount > 9 ? 18 : 16,
-              height: 16,
-              borderRadius: 8,
-              background: "#ff3b30",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 9,
-              fontWeight: 700,
-              fontFamily: font.mono,
-              color: "#fff",
-            }}
+            className="absolute top-1 right-1 h-4 rounded-lg bg-[#ff3b30] flex items-center justify-center font-mono text-white font-bold"
+            style={{ width: unreadCount > 9 ? 18 : 16, fontSize: 9 }}
           >
             {unreadCount > 99 ? "99+" : unreadCount}
           </div>
         )}
       </button>
       {/* Add event button */}
-      <div style={{ position: "relative" }}>
+      <div className="relative">
         {glowAdd && (
           <div
-            style={{
-              position: "absolute",
-              bottom: -28,
-              right: 0,
-              whiteSpace: "nowrap",
-              fontFamily: font.mono,
-              fontSize: 10,
-              color: color.accent,
-              letterSpacing: "0.02em",
-            }}
+            className="absolute right-0 whitespace-nowrap font-mono text-tiny text-dt"
+            style={{ bottom: -28, letterSpacing: "0.02em" }}
           >
             drop your first idea
           </div>
         )}
         <button
           onClick={onOpenAdd}
+          className="bg-dt text-black border-none w-10 h-10 rounded-full cursor-pointer flex items-center justify-center font-bold"
           style={{
-            background: color.accent,
-            color: "#000",
-            border: "none",
-            width: 40,
-            height: 40,
-            borderRadius: "50%",
             fontSize: 22,
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            fontWeight: 700,
             animation: glowAdd ? "addButtonGlow 2s ease-in-out infinite" : undefined,
           }}
         >

--- a/src/app/components/IOSInstallBanner.tsx
+++ b/src/app/components/IOSInstallBanner.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { font, color } from "@/lib/styles";
 import { isIOSNotStandalone } from "@/lib/pushNotifications";
 
 const DISMISSED_KEY = "pwa-install-banner-dismissed";
@@ -19,45 +18,19 @@ const IOSInstallBanner = () => {
 
   return (
     <div
+      className="fixed bottom-20 left-3 right-3 max-w-[396px] mx-auto bg-surface border border-border-light rounded-xl z-[200] flex items-start gap-3"
       style={{
-        position: "fixed",
-        bottom: 80,
-        left: 12,
-        right: 12,
-        maxWidth: 396,
-        margin: "0 auto",
-        background: color.surface,
-        border: `1px solid ${color.borderLight}`,
-        borderRadius: 14,
         padding: "14px 16px",
-        zIndex: 200,
         animation: "slideUp 0.3s ease",
-        display: "flex",
-        alignItems: "flex-start",
-        gap: 12,
       }}
     >
-      <div style={{ flex: 1 }}>
-        <p
-          style={{
-            fontFamily: font.serif,
-            fontSize: 16,
-            color: color.text,
-            marginBottom: 6,
-          }}
-        >
+      <div className="flex-1">
+        <p className="font-serif text-base text-primary mb-1.5">
           install down to
         </p>
-        <p
-          style={{
-            fontFamily: font.mono,
-            fontSize: 11,
-            color: color.dim,
-            lineHeight: 1.5,
-          }}
-        >
+        <p className="font-mono text-xs text-dim leading-relaxed">
           tap{" "}
-          <span style={{ fontSize: 14, verticalAlign: "middle" }}>
+          <span className="text-sm align-middle">
             {"\u{1F4E4}"}
           </span>{" "}
           then &quot;Add to Home Screen&quot; for notifications &amp; faster access
@@ -68,17 +41,7 @@ const IOSInstallBanner = () => {
           localStorage.setItem(DISMISSED_KEY, "1");
           setVisible(false);
         }}
-        style={{
-          background: "transparent",
-          border: "none",
-          color: color.dim,
-          fontFamily: font.mono,
-          fontSize: 18,
-          cursor: "pointer",
-          padding: "0 4px",
-          lineHeight: 1,
-          flexShrink: 0,
-        }}
+        className="bg-transparent border-none text-dim font-mono text-lg cursor-pointer px-1 leading-none shrink-0"
         aria-label="Dismiss"
       >
         x

--- a/src/app/components/UpdateBanner.tsx
+++ b/src/app/components/UpdateBanner.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { logVersionPing, API_BASE } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 
 const CLIENT_BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? "";
 const MIN_BACKGROUND_MS = 5 * 60 * 1000; // 5 minutes
@@ -86,30 +86,18 @@ export default function UpdateBanner() {
   if (reloading) {
     return (
       <div
-        style={{
-          position: "fixed",
-          inset: 0,
-          zIndex: 9999,
-          background: color.bg,
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: 12,
-          animation: "fadeIn 0.3s ease-out",
-        }}
+        className="fixed inset-0 z-[9999] bg-bg flex flex-col items-center justify-center gap-3"
+        style={{ animation: "fadeIn 0.3s ease-out" }}
       >
         <div
+          className="w-6 h-6 rounded-full"
           style={{
-            width: 24,
-            height: 24,
             border: `2px solid ${color.borderMid}`,
             borderTopColor: color.accent,
-            borderRadius: "50%",
             animation: "spin 0.8s linear infinite",
           }}
         />
-        <p style={{ fontFamily: font.mono, fontSize: 12, color: color.dim }}>
+        <p className="font-mono text-xs text-dim">
           updating...
         </p>
       </div>
@@ -126,23 +114,11 @@ export default function UpdateBanner() {
           await new Promise((r) => setTimeout(r, 400));
           await clearCachesAndReload();
         }}
+        className="fixed bottom-20 left-1/2 -translate-x-1/2 z-[9999] bg-dt text-black rounded-xl font-mono text-xs font-bold cursor-pointer whitespace-nowrap"
         style={{
-          position: "fixed",
-          bottom: 80,
-          left: "50%",
-          transform: "translateX(-50%)",
-          zIndex: 9999,
-          background: color.accent,
-          color: "#000",
-          borderRadius: 12,
           padding: "10px 20px",
-          fontFamily: font.mono,
-          fontSize: 12,
-          fontWeight: 700,
-          cursor: "pointer",
           animation: "slideUp 0.3s ease-out",
           boxShadow: "0 4px 20px rgba(0,0,0,0.4)",
-          whiteSpace: "nowrap",
         }}
       >
         Update available — tap to refresh

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -17,55 +17,20 @@ export default function Error({
   }, [error]);
 
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        background: "#0a0a0a",
-        padding: 24,
-        textAlign: "center",
-      }}
-    >
-      <div
-        style={{
-          fontFamily: "'Instrument Serif', serif",
-          fontSize: 48,
-          color: "#E8FF5A",
-          marginBottom: 12,
-        }}
-      >
+    <div className="min-h-screen flex flex-col items-center justify-center bg-bg p-6 text-center">
+      <div className="font-serif text-dt mb-3" style={{ fontSize: 48 }}>
         oops
       </div>
       <p
-        style={{
-          fontFamily: "'Space Mono', monospace",
-          fontSize: 13,
-          color: "#999",
-          marginBottom: 24,
-          maxWidth: 300,
-          lineHeight: 1.6,
-        }}
+        className="font-mono text-sm text-muted mb-6 max-w-[300px]"
+        style={{ lineHeight: 1.6 }}
       >
         something broke — sorry about that
       </p>
       <button
         onClick={reset}
-        style={{
-          background: "#E8FF5A",
-          color: "#000",
-          border: "none",
-          borderRadius: 12,
-          padding: "14px 32px",
-          fontFamily: "'Space Mono', monospace",
-          fontSize: 12,
-          fontWeight: 700,
-          cursor: "pointer",
-          textTransform: "uppercase",
-          letterSpacing: "0.1em",
-        }}
+        className="bg-dt text-black border-none rounded-xl font-mono text-xs font-bold cursor-pointer uppercase"
+        style={{ padding: "14px 32px", letterSpacing: "0.1em" }}
       >
         Try Again
       </button>

--- a/src/app/friend/page.tsx
+++ b/src/app/friend/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import Grain from "@/app/components/Grain";
 
 /**
@@ -10,7 +10,7 @@ import Grain from "@/app/components/Grain";
  *
  * Landing page for one-time instant friendship links.
  * - If logged in: redeems immediately
- * - If not logged in: shows creator info + "Join to connect" → stores token, redirects to auth
+ * - If not logged in: shows creator info + "Join to connect" -> stores token, redirects to auth
  *
  * Security:
  * - UUID v4 token (128-bit, unguessable)
@@ -88,60 +88,30 @@ export default function FriendLinkPage() {
   }, []);
 
   return (
-    <div style={{
-      maxWidth: 420,
-      margin: "0 auto",
-      minHeight: "100vh",
-      background: color.bg,
-      padding: "80px 24px",
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "center",
-      textAlign: "center",
-    }}>
+    <div className="max-w-[420px] mx-auto min-h-screen bg-bg py-20 px-6 flex flex-col items-center text-center">
       <Grain />
 
       {status === "loading" && (
-        <p style={{ fontFamily: font.mono, fontSize: 12, color: color.dim }}>Loading...</p>
+        <p className="font-mono text-xs text-dim">Loading...</p>
       )}
 
       {status === "redeemed" && (
         <>
           {creatorAvatar && (
-            <div style={{
-              width: 64, height: 64, borderRadius: "50%",
-              background: color.accent, color: "#000",
-              display: "flex", alignItems: "center", justifyContent: "center",
-              fontFamily: font.mono, fontSize: 24, fontWeight: 700,
-              marginBottom: 20,
-            }}>
+            <div className="w-16 h-16 rounded-full bg-dt text-black flex items-center justify-center font-mono text-2xl font-bold mb-5">
               {creatorAvatar}
             </div>
           )}
-          <h1 style={{ fontFamily: font.serif, fontSize: 32, color: color.text, fontWeight: 400, marginBottom: 8 }}>
+          <h1 className="font-serif text-[32px] text-primary font-normal mb-2">
             you&apos;re connected!
           </h1>
-          <p style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 32, lineHeight: 1.6 }}>
+          <p className="font-mono text-sm text-dim mb-8" style={{ lineHeight: 1.6 }}>
             you and {creatorName ?? "your friend"} are now friends on down to
           </p>
           <a
             href="/"
-            style={{
-              display: "block",
-              width: "100%",
-              padding: 16,
-              background: color.accent,
-              color: "#000",
-              border: "none",
-              borderRadius: 12,
-              fontFamily: font.mono,
-              fontSize: 14,
-              fontWeight: 700,
-              textAlign: "center",
-              textDecoration: "none",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-            }}
+            className="block w-full p-4 bg-dt text-black border-none rounded-xl font-mono text-sm font-bold text-center no-underline uppercase"
+            style={{ letterSpacing: "0.1em" }}
           >
             Open App
           </a>
@@ -150,30 +120,16 @@ export default function FriendLinkPage() {
 
       {status === "login-needed" && (
         <>
-          <h1 style={{ fontFamily: font.serif, fontSize: 32, color: color.text, fontWeight: 400, marginBottom: 8 }}>
+          <h1 className="font-serif text-[32px] text-primary font-normal mb-2">
             you&apos;ve been invited
           </h1>
-          <p style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 32, lineHeight: 1.6 }}>
+          <p className="font-mono text-sm text-dim mb-8" style={{ lineHeight: 1.6 }}>
             someone wants to connect with you on down to. sign up or log in to accept.
           </p>
           <a
             href="/?pendingFriend=1"
-            style={{
-              display: "block",
-              width: "100%",
-              padding: 16,
-              background: color.accent,
-              color: "#000",
-              border: "none",
-              borderRadius: 12,
-              fontFamily: font.mono,
-              fontSize: 14,
-              fontWeight: 700,
-              textAlign: "center",
-              textDecoration: "none",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-            }}
+            className="block w-full p-4 bg-dt text-black border-none rounded-xl font-mono text-sm font-bold text-center no-underline uppercase"
+            style={{ letterSpacing: "0.1em" }}
           >
             Join to Connect
           </a>
@@ -182,28 +138,17 @@ export default function FriendLinkPage() {
 
       {status === "error" && (
         <>
-          <h1 style={{ fontFamily: font.serif, fontSize: 32, color: color.text, fontWeight: 400, marginBottom: 8 }}>
+          <h1 className="font-serif text-[32px] text-primary font-normal mb-2">
             link expired
           </h1>
-          <p style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 32, lineHeight: 1.6 }}>
+          <p className="font-mono text-sm text-dim mb-8" style={{ lineHeight: 1.6 }}>
             {errorMsg || "This friend link is no longer valid. Ask your friend to send a new one."}
           </p>
           <a
             href="/"
+            className="block w-full p-4 bg-transparent text-primary rounded-xl font-mono text-sm font-bold text-center no-underline uppercase"
             style={{
-              display: "block",
-              width: "100%",
-              padding: 16,
-              background: "transparent",
-              color: color.text,
               border: `1px solid ${color.borderMid}`,
-              borderRadius: 12,
-              fontFamily: font.mono,
-              fontSize: 14,
-              fontWeight: 700,
-              textAlign: "center",
-              textDecoration: "none",
-              textTransform: "uppercase",
               letterSpacing: "0.1em",
             }}
           >

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import * as Sentry from "@sentry/nextjs";
 import { logError } from "@/lib/logger";
+import "./global.css";
 
 export default function GlobalError({
   error,
@@ -24,62 +25,21 @@ export default function GlobalError({
           rel="stylesheet"
         />
       </head>
-      <body
-        style={{
-          margin: 0,
-          padding: 0,
-          background: "#0a0a0a",
-          minHeight: "100vh",
-        }}
-      >
-        <div
-          style={{
-            minHeight: "100vh",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: 24,
-            textAlign: "center",
-          }}
-        >
-          <div
-            style={{
-              fontFamily: "'Instrument Serif', serif",
-              fontSize: 48,
-              color: "#E8FF5A",
-              marginBottom: 12,
-            }}
-          >
+      <body className="m-0 p-0 bg-bg min-h-screen">
+        <div className="min-h-screen flex flex-col items-center justify-center p-6 text-center">
+          <div className="font-serif text-dt mb-3" style={{ fontSize: 48 }}>
             oops
           </div>
           <p
-            style={{
-              fontFamily: "'Space Mono', monospace",
-              fontSize: 13,
-              color: "#999",
-              marginBottom: 24,
-              maxWidth: 300,
-              lineHeight: 1.6,
-            }}
+            className="font-mono text-sm text-muted mb-6 max-w-[300px]"
+            style={{ lineHeight: 1.6 }}
           >
             something broke — sorry about that
           </p>
           <button
             onClick={reset}
-            style={{
-              background: "#E8FF5A",
-              color: "#000",
-              border: "none",
-              borderRadius: 12,
-              padding: "14px 32px",
-              fontFamily: "'Space Mono', monospace",
-              fontSize: 12,
-              fontWeight: 700,
-              cursor: "pointer",
-              textTransform: "uppercase",
-              letterSpacing: "0.1em",
-            }}
+            className="bg-dt text-black border-none rounded-xl font-mono text-xs font-bold cursor-pointer uppercase"
+            style={{ padding: "14px 32px", letterSpacing: "0.1em" }}
           >
             Try Again
           </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,7 @@ import { useEvents } from "@/features/events/hooks/useEvents";
 import { supabase } from "@/lib/supabase";
 import * as db from "@/lib/db";
 import { API_BASE } from "@/lib/db";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import { sanitize, sanitizeVibes, parseDateToISO, toLocalISODate } from "@/lib/utils";
 import type { Profile } from "@/lib/types";
 import type { Person, Event, Tab, ScrapedEvent, Squad } from "@/lib/ui-types";
@@ -688,7 +688,7 @@ export default function Home() {
       toggleSave: eventsHook.toggleSave,
       toggleDown: eventsHook.toggleDown,
     }}>
-    <div style={{ display: "flex", flexDirection: "column", height: "100dvh" }}>
+    <div className="flex flex-col h-dvh">
       <div>
         <Header
           unreadCount={notificationsHook.unreadCount}
@@ -708,28 +708,28 @@ export default function Home() {
       </div>
 
       {/* Scroll area with fade edges */}
-      <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
+      <div className="flex-1 relative overflow-hidden">
         {/* Top fade — visible when scrolled */}
-        <div style={{
-          position: "absolute", top: 0, left: 0, right: 0, height: 15,
-          background: `linear-gradient(${color.bg}, transparent)`,
-          zIndex: 10, pointerEvents: "none",
-          opacity: scrolledDown ? 1 : 0,
-          transition: "opacity 0.5s ease",
-        }} />
+        <div
+          className="absolute top-0 left-0 right-0 z-10 pointer-events-none transition-opacity duration-500"
+          style={{
+            height: 15,
+            background: `linear-gradient(${color.bg}, transparent)`,
+            opacity: scrolledDown ? 1 : 0,
+          }}
+        />
         {/* Bottom fade */}
-        <div style={{
-          position: "absolute", bottom: 0, left: 0, right: 0, height: 15,
-          background: `linear-gradient(transparent, ${color.bg})`,
-          zIndex: 10, pointerEvents: "none",
-        }} />
+        <div
+          className="absolute bottom-0 left-0 right-0 z-10 pointer-events-none"
+          style={{
+            height: 15,
+            background: `linear-gradient(transparent, ${color.bg})`,
+          }}
+        />
         {/* Scroll container */}
         <div
           ref={scrollRef}
-          style={{
-            height: "100%",
-            overflowY: "auto",
-          }}
+          className="h-full overflow-y-auto"
           onScroll={() => {
             const scrolled = (scrollRef.current?.scrollTop ?? 0) > 0;
             if (scrolled !== scrolledDown) setScrolledDown(scrolled);
@@ -739,50 +739,34 @@ export default function Home() {
           onTouchEnd={handlePullEnd}
         >
         {/* Inner wrapper — translated by pull-to-refresh */}
-        <div ref={innerRef} style={{ position: "relative" }}>
+        <div ref={innerRef} className="relative">
         {/* Pull-to-refresh spinner */}
         <div
           ref={spinnerWrapRef}
-          style={{
-            position: "absolute",
-            top: -50,
-            left: 0,
-            right: 0,
-            display: "flex",
-            justifyContent: "center",
-            willChange: "transform, opacity",
-          }}
+          className="absolute left-0 right-0 flex justify-center"
+          style={{ top: -50, willChange: "transform, opacity" }}
         >
           <div
             ref={spinnerRef}
+            className="w-[22px] h-[22px] rounded-full"
             style={{
-              width: 22,
-              height: 22,
               border: `2px solid ${color.borderMid}`,
               borderTopColor: color.accent,
-              borderRadius: "50%",
               willChange: "transform",
             }}
           />
         </div>
         {!feedLoaded && (
-          <div style={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "80px 20px",
-            gap: 12,
-          }}>
-            <div style={{
-              width: 24,
-              height: 24,
-              border: `2px solid ${color.borderMid}`,
-              borderTopColor: color.accent,
-              borderRadius: "50%",
-              animation: "spin 0.8s linear infinite",
-            }} />
-            <p style={{ fontFamily: font.mono, fontSize: 12, color: color.dim }}>
+          <div className="flex flex-col items-center justify-center px-5 gap-3" style={{ paddingTop: 80, paddingBottom: 80 }}>
+            <div
+              className="w-6 h-6 rounded-full"
+              style={{
+                border: `2px solid ${color.borderMid}`,
+                borderTopColor: color.accent,
+                animation: "spin 0.8s linear infinite",
+              }}
+            />
+            <p className="font-mono text-xs text-dim">
               loading your feed...
             </p>
           </div>

--- a/src/features/auth/components/AuthScreen.tsx
+++ b/src/features/auth/components/AuthScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import Grain from "@/app/components/Grain";
 
 const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
@@ -60,76 +60,43 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
   };
 
   return (
-    <div
-      style={{
-        padding: "60px 24px",
-        display: "flex",
-        flexDirection: "column",
-      }}
-    >
+    <div className="flex flex-col" style={{ padding: "60px 24px" }}>
       <Grain />
 
-      <h1
-        style={{
-          fontFamily: font.serif,
-          fontSize: 48,
-          color: color.text,
-          fontWeight: 400,
-          marginBottom: 8,
-        }}
-      >
+      <h1 className="font-serif text-5xl text-primary font-normal mb-2">
         down to
       </h1>
       <p
-        style={{
-          fontFamily: font.mono,
-          fontSize: 13,
-          color: color.dim,
-          marginBottom: pendingAddUser ? 12 : 48,
-        }}
+        className="font-mono text-sm text-dim"
+        style={{ marginBottom: pendingAddUser ? 12 : 48 }}
       >
         from idea to squad in 10 seconds
       </p>
       {pendingCheck && !pendingAddUser && (
         <div
+          className="rounded-xl mb-8"
           style={{
             background: "rgba(232,255,90,0.08)",
             border: `1px solid rgba(232,255,90,0.2)`,
-            borderRadius: 12,
             padding: "12px 16px",
-            marginBottom: 32,
           }}
         >
-          <p style={{ fontFamily: font.mono, fontSize: 12, color: color.accent, margin: 0, lineHeight: 1.5 }}>
+          <p className="font-mono text-xs text-dt m-0 leading-normal">
             sign up or log in to respond to this check
           </p>
-          <p style={{ fontFamily: font.mono, fontSize: 10, color: color.dim, margin: "4px 0 0" }}>
+          <p className="font-mono text-tiny text-dim" style={{ margin: "4px 0 0" }}>
             quick setup, then you&apos;re in
           </p>
         </div>
       )}
       {pendingAddUser && (
-        <p
-          style={{
-            fontFamily: font.mono,
-            fontSize: 12,
-            color: color.accent,
-            marginBottom: 36,
-          }}
-        >
+        <p className="font-mono text-xs text-dt mb-9">
           log in or create a profile to add @{pendingAddUser}
         </p>
       )}
 
       {error && (
-        <p
-          style={{
-            fontFamily: font.mono,
-            fontSize: 12,
-            color: "#ff6b6b",
-            marginBottom: 16,
-          }}
-        >
+        <p className="font-mono text-xs text-danger mb-4">
           {error}
         </p>
       )}
@@ -137,14 +104,8 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
       {step === "email" ? (
         <>
           <label
-            style={{
-              fontFamily: font.mono,
-              fontSize: 10,
-              textTransform: "uppercase",
-              letterSpacing: "0.15em",
-              color: color.dim,
-              marginBottom: 8,
-            }}
+            className="font-mono text-tiny uppercase text-dim mb-2"
+            style={{ letterSpacing: "0.15em" }}
           >
             Email
           </label>
@@ -154,32 +115,16 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
             onChange={(e) => setEmail(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleSendCode()}
             placeholder="you@email.com"
-            style={{
-              background: color.card,
-              border: `1px solid ${color.borderMid}`,
-              borderRadius: 12,
-              padding: "16px",
-              color: color.text,
-              fontFamily: font.mono,
-              fontSize: 18,
-              outline: "none",
-              marginBottom: 16,
-            }}
+            className="bg-card border border-border-mid rounded-xl p-4 text-primary font-mono text-lg outline-none mb-4"
           />
           <button
             onClick={handleSendCode}
             disabled={!email.includes("@") || loading}
+            className="border-none rounded-xl p-4 font-mono text-sm font-bold uppercase"
             style={{
               background: email.includes("@") ? color.accent : color.borderMid,
               color: email.includes("@") ? "#000" : color.dim,
-              border: "none",
-              borderRadius: 12,
-              padding: "16px",
-              fontFamily: font.mono,
-              fontSize: 14,
-              fontWeight: 700,
               cursor: email.includes("@") ? "pointer" : "not-allowed",
-              textTransform: "uppercase",
               letterSpacing: "0.1em",
             }}
           >
@@ -188,26 +133,13 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
         </>
       ) : (
         <>
-          <p
-            style={{
-              fontFamily: font.mono,
-              fontSize: 12,
-              color: color.dim,
-              marginBottom: 20,
-            }}
-          >
+          <p className="font-mono text-xs text-dim mb-5">
             We sent a code to<br />
-            <span style={{ color: color.accent }}>{email}</span>
+            <span className="text-dt">{email}</span>
           </p>
           <label
-            style={{
-              fontFamily: font.mono,
-              fontSize: 10,
-              textTransform: "uppercase",
-              letterSpacing: "0.15em",
-              color: color.dim,
-              marginBottom: 8,
-            }}
+            className="font-mono text-tiny uppercase text-dim mb-2"
+            style={{ letterSpacing: "0.15em" }}
           >
             Code
           </label>
@@ -220,66 +152,32 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
             onKeyDown={(e) => e.key === "Enter" && handleVerifyCode()}
             placeholder="00000000"
             autoFocus
-            style={{
-              background: color.card,
-              border: `1px solid ${color.borderMid}`,
-              borderRadius: 12,
-              padding: "16px",
-              color: color.text,
-              fontFamily: font.mono,
-              fontSize: 24,
-              letterSpacing: "0.3em",
-              textAlign: "center",
-              outline: "none",
-              marginBottom: 16,
-            }}
+            className="bg-card border border-border-mid rounded-xl p-4 text-primary font-mono text-2xl text-center outline-none mb-4"
+            style={{ letterSpacing: "0.3em" }}
           />
           <button
             onClick={handleVerifyCode}
             disabled={otp.length !== 8 || loading}
+            className="border-none rounded-xl p-4 font-mono text-sm font-bold uppercase mb-3"
             style={{
               background: otp.length === 8 ? color.accent : color.borderMid,
               color: otp.length === 8 ? "#000" : color.dim,
-              border: "none",
-              borderRadius: 12,
-              padding: "16px",
-              fontFamily: font.mono,
-              fontSize: 14,
-              fontWeight: 700,
               cursor: otp.length === 8 ? "pointer" : "not-allowed",
-              textTransform: "uppercase",
               letterSpacing: "0.1em",
-              marginBottom: 12,
             }}
           >
             {loading ? "Verifying..." : "Verify"}
           </button>
-          <div style={{ display: "flex", justifyContent: "center", gap: 16 }}>
+          <div className="flex justify-center gap-4">
             <button
               onClick={() => { setStep("email"); setOtp(""); setError(null); }}
-              style={{
-                background: "transparent",
-                border: "none",
-                color: color.dim,
-                fontFamily: font.mono,
-                fontSize: 11,
-                cursor: "pointer",
-                textDecoration: "underline",
-              }}
+              className="bg-transparent border-none text-dim font-mono text-xs cursor-pointer underline"
             >
               Different email
             </button>
             <button
               onClick={() => { setOtp(""); setError(null); handleSendCode(); }}
-              style={{
-                background: "transparent",
-                border: "none",
-                color: color.dim,
-                fontFamily: font.mono,
-                fontSize: 11,
-                cursor: "pointer",
-                textDecoration: "underline",
-              }}
+              className="bg-transparent border-none text-dim font-mono text-xs cursor-pointer underline"
             >
               Resend code
             </button>

--- a/src/features/auth/components/EnableNotificationsScreen.tsx
+++ b/src/features/auth/components/EnableNotificationsScreen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import {
   isPushSupported,
   isIOSNotStandalone,
@@ -11,76 +11,30 @@ import {
 import Grain from "@/app/components/Grain";
 
 const IOSInstallScreen = ({ onComplete }: { onComplete: (enabled: boolean) => void }) => (
-  <div
-    style={{
-      maxWidth: 420,
-      margin: "0 auto",
-      minHeight: "100vh",
-      background: color.bg,
-      padding: "60px 24px",
-      display: "flex",
-      flexDirection: "column",
-    }}
-  >
+  <div className="max-w-[420px] mx-auto min-h-screen bg-bg flex flex-col" style={{ padding: "60px 24px" }}>
     <Grain />
 
-    <h1
-      style={{
-        fontFamily: font.serif,
-        fontSize: 48,
-        color: color.text,
-        fontWeight: 400,
-        marginBottom: 8,
-        lineHeight: 1.1,
-      }}
-    >
+    <h1 className="font-serif text-5xl text-primary font-normal mb-2 leading-tight">
       install the app
     </h1>
-    <p
-      style={{
-        fontFamily: font.mono,
-        fontSize: 12,
-        color: color.dim,
-        marginBottom: 40,
-        lineHeight: 1.6,
-      }}
-    >
+    <p className="font-mono text-xs text-dim mb-10 leading-relaxed">
       get push notifications, faster loading, and easy access from your home screen
     </p>
 
-    <div style={{ display: "flex", flexDirection: "column", gap: 20, marginBottom: 40 }}>
+    <div className="flex flex-col gap-5 mb-10">
       {[
         { step: "1", text: <>tap the share button <span style={{ fontSize: 18, verticalAlign: "middle" }}>&#xFE0E;{"\u{1F4E4}"}</span> in Safari</> },
-        { step: "2", text: <>scroll down and tap <strong style={{ color: color.text }}>&quot;Add to Home Screen&quot;</strong></> },
-        { step: "3", text: <>open <strong style={{ color: color.accent }}>down to</strong> from your home screen</> },
+        { step: "2", text: <>scroll down and tap <strong className="text-primary">&quot;Add to Home Screen&quot;</strong></> },
+        { step: "3", text: <>open <strong className="text-dt">down to</strong> from your home screen</> },
       ].map(({ step, text }) => (
-        <div key={step} style={{ display: "flex", alignItems: "flex-start", gap: 14 }}>
+        <div key={step} className="flex items-start gap-3.5">
           <div
-            style={{
-              width: 28,
-              height: 28,
-              borderRadius: "50%",
-              border: `1.5px solid ${color.borderMid}`,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontFamily: font.mono,
-              fontSize: 13,
-              color: color.accent,
-              flexShrink: 0,
-            }}
+            className="w-7 h-7 rounded-full flex items-center justify-center font-mono text-sm text-dt shrink-0"
+            style={{ border: `1.5px solid ${color.borderMid}` }}
           >
             {step}
           </div>
-          <p
-            style={{
-              fontFamily: font.mono,
-              fontSize: 13,
-              color: color.muted,
-              lineHeight: 1.6,
-              paddingTop: 4,
-            }}
-          >
+          <p className="font-mono text-sm text-muted leading-relaxed pt-1">
             {text}
           </p>
         </div>
@@ -89,34 +43,14 @@ const IOSInstallScreen = ({ onComplete }: { onComplete: (enabled: boolean) => vo
 
     <button
       disabled
-      style={{
-        width: "100%",
-        padding: "16px",
-        background: color.borderMid,
-        border: "none",
-        borderRadius: 12,
-        color: color.dim,
-        fontFamily: font.mono,
-        fontSize: 14,
-        fontWeight: 700,
-        cursor: "default",
-        marginBottom: 16,
-      }}
+      className="w-full p-4 bg-border-mid border-none rounded-xl text-dim font-mono text-sm font-bold cursor-default mb-4"
     >
       waiting for install...
     </button>
 
     <button
       onClick={() => onComplete(false)}
-      style={{
-        background: "transparent",
-        border: "none",
-        color: color.dim,
-        fontFamily: font.mono,
-        fontSize: 12,
-        cursor: "pointer",
-        alignSelf: "center",
-      }}
+      className="bg-transparent border-none text-dim font-mono text-xs cursor-pointer self-center"
     >
       skip for now
     </button>
@@ -143,58 +77,24 @@ const NotificationsScreen = ({ onComplete }: { onComplete: (enabled: boolean) =>
   };
 
   return (
-    <div
-      style={{
-        maxWidth: 420,
-        margin: "0 auto",
-        minHeight: "100vh",
-        background: color.bg,
-        padding: "60px 24px",
-        display: "flex",
-        flexDirection: "column",
-      }}
-    >
+    <div className="max-w-[420px] mx-auto min-h-screen bg-bg flex flex-col" style={{ padding: "60px 24px" }}>
       <Grain />
 
-      <h1
-        style={{
-          fontFamily: font.serif,
-          fontSize: 48,
-          color: color.text,
-          fontWeight: 400,
-          marginBottom: 8,
-          lineHeight: 1.1,
-        }}
-      >
+      <h1 className="font-serif text-5xl text-primary font-normal mb-2 leading-tight">
         stay in the loop
       </h1>
-      <p
-        style={{
-          fontFamily: font.mono,
-          fontSize: 12,
-          color: color.dim,
-          marginBottom: 40,
-          lineHeight: 1.6,
-        }}
-      >
+      <p className="font-mono text-xs text-dim mb-10 leading-relaxed">
         get notified when friends send you a check, accept your request, or when your squad is formed
       </p>
 
       <button
         onClick={handleEnable}
         disabled={loading || !supported}
+        className="w-full p-4 border-none rounded-xl font-mono text-sm font-bold mb-4"
         style={{
-          width: "100%",
-          padding: "16px",
           background: supported ? color.accent : color.borderMid,
-          border: "none",
-          borderRadius: 12,
           color: supported ? color.bg : color.dim,
-          fontFamily: font.mono,
-          fontSize: 14,
-          fontWeight: 700,
           cursor: supported ? "pointer" : "default",
-          marginBottom: 16,
           opacity: loading ? 0.6 : 1,
         }}
       >
@@ -207,15 +107,7 @@ const NotificationsScreen = ({ onComplete }: { onComplete: (enabled: boolean) =>
 
       <button
         onClick={() => onComplete(false)}
-        style={{
-          background: "transparent",
-          border: "none",
-          color: color.dim,
-          fontFamily: font.mono,
-          fontSize: 12,
-          cursor: "pointer",
-          alignSelf: "center",
-        }}
+        className="bg-transparent border-none text-dim font-mono text-xs cursor-pointer self-center"
       >
         skip for now
       </button>

--- a/src/features/auth/hooks/useOnboarding.tsx
+++ b/src/features/auth/hooks/useOnboarding.tsx
@@ -291,7 +291,7 @@ export function useOnboarding({
 
   const computeOnboardingScreen = (): ReactNode | null => {
     if (isLoading) {
-      return <div style={{ minHeight: "100vh", background: "#111" }} />;
+      return <div className="min-h-screen bg-card" />;
     }
 
     // Eagerly persist pendingCheck from URL to localStorage (before any gate checks)
@@ -377,7 +377,7 @@ export function useOnboarding({
       }
 
       // Wait for feed data before setting up friend gate
-      if (!feedLoaded) return <div style={{ minHeight: "100vh", background: "#111" }} />;
+      if (!feedLoaded) return <div className="min-h-screen bg-card" />;
 
       // Set up friend gate with check author suggestion
       if (!friendGateInitRef.current) {
@@ -410,7 +410,7 @@ export function useOnboarding({
         })();
       }
       // Block rendering until friend gate is ready
-      return <div style={{ minHeight: "100vh", background: "#111" }} />;
+      return <div className="min-h-screen bg-card" />;
     }
 
     if (showFirstCheck) {

--- a/src/features/checks/components/CheckActionsSheet.tsx
+++ b/src/features/checks/components/CheckActionsSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 
 export default function CheckActionsSheet({
   open,
@@ -67,23 +67,14 @@ export default function CheckActionsSheet({
   const actionRow = (label: string, icon: string, onClick: () => void, destructive?: boolean) => (
     <button
       onClick={onClick}
+      className="flex items-center gap-3 w-full bg-transparent border-none border-b border-border font-mono text-sm cursor-pointer text-left"
       style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        width: "100%",
         padding: "14px 0",
-        background: "transparent",
-        border: "none",
-        borderBottom: `1px solid ${color.border}`,
-        fontFamily: font.mono,
-        fontSize: 13,
         color: destructive ? "#ff4444" : color.text,
-        cursor: "pointer",
-        textAlign: "left",
+        borderBottom: `1px solid ${color.border}`,
       }}
     >
-      <span style={{ fontSize: 16, width: 24, textAlign: "center" }}>{icon}</span>
+      <span className="text-base w-6 text-center">{icon}</span>
       {label}
     </button>
   );
@@ -93,13 +84,11 @@ export default function CheckActionsSheet({
       {/* Backdrop */}
       <div
         onClick={dismiss}
+        className="fixed inset-0 z-[100]"
         style={{
-          position: "fixed",
-          inset: 0,
           background: "rgba(0,0,0,0.7)",
           backdropFilter: "blur(8px)",
           WebkitBackdropFilter: "blur(8px)",
-          zIndex: 100,
         }}
       />
 
@@ -108,16 +97,9 @@ export default function CheckActionsSheet({
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        className="fixed bottom-0 left-0 right-0 bg-surface max-w-[420px] mx-auto z-[101]"
         style={{
-          position: "fixed",
-          bottom: 0,
-          left: 0,
-          right: 0,
-          background: color.surface,
           borderRadius: "24px 24px 0 0",
-          maxWidth: 420,
-          margin: "0 auto",
-          zIndex: 101,
           animation: closing ? undefined : "slideUp 0.3s ease-out",
           transform: closing ? "translateY(100%)" : dragOffset > 0 ? `translateY(${dragOffset}px)` : undefined,
           transition: closing ? "transform 0.25s ease-in" : dragOffset > 0 ? undefined : "transform 0.25s ease-out",
@@ -125,18 +107,12 @@ export default function CheckActionsSheet({
         }}
       >
         {/* Drag handle */}
-        <div style={{ display: "flex", justifyContent: "center", padding: "12px 0 8px" }}>
-          <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2 }} />
+        <div className="flex justify-center pt-3 pb-2">
+          <div className="w-10 h-1 bg-faint rounded-sm" />
         </div>
 
-        <div style={{ padding: "0 20px 20px" }}>
-          <p style={{
-            fontFamily: font.serif,
-            fontSize: 18,
-            color: color.text,
-            margin: "0 0 8px",
-            fontWeight: 400,
-          }}>
+        <div className="px-5 pb-5">
+          <p className="font-serif text-lg text-primary font-normal mb-2 mt-0">
             Check actions
           </p>
 
@@ -151,61 +127,25 @@ export default function CheckActionsSheet({
       {confirmDelete && (
         <div
           onClick={() => setConfirmDelete(false)}
-          style={{
-            position: "fixed",
-            inset: 0,
-            background: "rgba(0,0,0,0.7)",
-            zIndex: 9999,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
+          className="fixed inset-0 z-[9999] flex items-center justify-center"
+          style={{ background: "rgba(0,0,0,0.7)" }}
         >
           <div
             onClick={(e) => e.stopPropagation()}
-            style={{
-              background: color.deep,
-              border: `1px solid ${color.border}`,
-              borderRadius: 16,
-              maxWidth: 300,
-              padding: "24px 20px",
-            }}
+            className="bg-deep border border-border rounded-2xl max-w-[300px]"
+            style={{ padding: "24px 20px" }}
           >
-            <p style={{
-              fontFamily: font.serif,
-              fontSize: 18,
-              color: color.text,
-              margin: "0 0 8px",
-              fontWeight: 400,
-            }}>
+            <p className="font-serif text-lg text-primary font-normal mb-2 mt-0">
               Delete check?
             </p>
-            <p style={{
-              fontFamily: font.mono,
-              fontSize: 11,
-              color: color.dim,
-              margin: "0 0 16px",
-              lineHeight: 1.5,
-            }}>
+            <p className="font-mono text-xs text-dim mb-4 mt-0 leading-normal">
               This will permanently remove the check and all responses. This can&apos;t be undone.
             </p>
-            <div style={{ display: "flex", gap: 10 }}>
+            <div className="flex gap-2.5">
               <button
                 onClick={() => setConfirmDelete(false)}
-                style={{
-                  flex: 1,
-                  padding: 12,
-                  background: "transparent",
-                  border: `1px solid ${color.borderMid}`,
-                  borderRadius: 12,
-                  color: color.text,
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  fontWeight: 700,
-                  cursor: "pointer",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.08em",
-                }}
+                className="flex-1 p-3 bg-transparent border border-border-mid rounded-xl text-primary font-mono text-xs font-bold cursor-pointer uppercase"
+                style={{ letterSpacing: "0.08em" }}
               >
                 Cancel
               </button>
@@ -215,20 +155,8 @@ export default function CheckActionsSheet({
                   onClose();
                   onDelete();
                 }}
-                style={{
-                  flex: 1,
-                  padding: 12,
-                  background: "#ff4444",
-                  border: "none",
-                  borderRadius: 10,
-                  color: "#fff",
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  fontWeight: 700,
-                  cursor: "pointer",
-                  textTransform: "uppercase",
-                  letterSpacing: "0.08em",
-                }}
+                className="flex-1 p-3 bg-[#ff4444] border-none rounded-lg text-white font-mono text-xs font-bold cursor-pointer uppercase"
+                style={{ letterSpacing: "0.08em" }}
               >
                 Delete
               </button>

--- a/src/features/events/components/EditEventModal.tsx
+++ b/src/features/events/components/EditEventModal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef, CSSProperties } from "react";
-import { font, color } from "@/lib/styles";
+import { useState, useEffect, useRef } from "react";
+import { color } from "@/lib/styles";
 import { parseNaturalDate, parseNaturalTime, parseDateToISO } from "@/lib/utils";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import cn from "@/lib/tailwindMerge";
 import type { Event } from "@/lib/ui-types";
 
 const EditEventModal = ({
@@ -87,44 +88,12 @@ const EditEventModal = ({
     || event.date;
   const resolvedTime = parsedTime ?? event.time;
 
-  const inputStyle: CSSProperties = {
-    background: color.deep,
-    border: `1px solid ${color.borderMid}`,
-    borderRadius: 10,
-    padding: "12px 14px",
-    color: color.text,
-    fontFamily: font.mono,
-    fontSize: 13,
-    outline: "none",
-    width: "100%",
-    boxSizing: "border-box",
-  };
-
-  const labelStyle: CSSProperties = {
-    fontFamily: font.mono,
-    fontSize: 10,
-    textTransform: "uppercase",
-    letterSpacing: "0.15em",
-    color: color.dim,
-    marginBottom: 6,
-  };
-
   return (
-    <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 100,
-        display: "flex",
-        alignItems: "flex-end",
-        justifyContent: "center",
-      }}
-    >
+    <div className="fixed inset-0 z-[100] flex items-end justify-center">
       <div
         onClick={close}
+        className="absolute inset-0"
         style={{
-          position: "absolute",
-          inset: 0,
           background: "rgba(0,0,0,0.7)",
           backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
           WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
@@ -133,16 +102,8 @@ const EditEventModal = ({
         }}
       />
       <div
+        className="relative bg-surface rounded-t-3xl w-full max-w-[420px] px-6 pt-5 pb-0 max-h-[80vh] flex flex-col"
         style={{
-          position: "relative",
-          background: color.surface,
-          borderRadius: "24px 24px 0 0",
-          width: "100%",
-          maxWidth: 420,
-          padding: "20px 24px 0",
-          maxHeight: "80vh",
-          display: "flex",
-          flexDirection: "column",
           animation: closing ? undefined : "slideUp 0.3s ease-out",
           transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
           transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
@@ -155,7 +116,7 @@ const EditEventModal = ({
           onTouchEnd={finishSwipe}
           style={{ touchAction: "none" }}
         >
-          <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2, margin: "0 auto 20px" }} />
+          <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-5" />
         </div>
 
         <div
@@ -163,115 +124,93 @@ const EditEventModal = ({
           onTouchStart={handleScrollTouchStart}
           onTouchMove={handleScrollTouchMove}
           onTouchEnd={handleScrollTouchEnd}
-          style={{ overflowY: "auto", overflowX: "hidden", flex: 1, paddingBottom: 24 }}
+          className="overflow-y-auto overflow-x-hidden flex-1 pb-6"
         >
-          <h3
-            style={{
-              fontFamily: font.serif,
-              fontSize: 22,
-              color: color.text,
-              marginBottom: 20,
-              fontWeight: 400,
-            }}
-          >
+          <h3 className="font-serif text-2xl text-primary mb-5 font-normal">
             Edit event
           </h3>
 
-          <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div className="flex flex-col gap-3.5">
             <div>
-              <div style={labelStyle}>Title</div>
+              <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>Title</div>
               <input
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 placeholder="Event name"
-                style={inputStyle}
+                className="bg-deep border border-border-mid rounded-lg py-3 px-3.5 text-primary font-mono text-sm outline-none w-full box-border"
               />
             </div>
 
             {/* When / Where — matching creation flow */}
-            <div style={{ display: "flex", gap: 8 }}>
-              <div style={{ flex: 1 }}>
-                <div style={labelStyle}>When</div>
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>When</div>
                 <input
                   type="text"
                   placeholder="e.g. fri 9pm"
                   value={whenInput}
                   onChange={(e) => setWhenInput(e.target.value)}
-                  style={inputStyle}
+                  className="bg-deep border border-border-mid rounded-lg py-3 px-3.5 text-primary font-mono text-sm outline-none w-full box-border"
                 />
               </div>
               <div style={{ flex: 0.6 }}>
-                <div style={labelStyle}>Where</div>
+                <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>Where</div>
                 <input
                   type="text"
                   value={venue}
                   onChange={(e) => setVenue(e.target.value)}
                   placeholder="Venue"
-                  style={inputStyle}
+                  className="bg-deep border border-border-mid rounded-lg py-3 px-3.5 text-primary font-mono text-sm outline-none w-full box-border"
                 />
               </div>
             </div>
             {whenPreview && (
-              <div style={{
-                fontFamily: font.mono,
-                fontSize: 10,
-                color: color.dim,
-                marginTop: -8,
-                paddingLeft: 2,
-              }}>
+              <div className="font-mono text-tiny text-dim -mt-2 pl-0.5">
                 {whenPreview}
               </div>
             )}
 
             <div>
-              <div style={labelStyle}>Vibes (comma-separated)</div>
+              <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>Vibes (comma-separated)</div>
               <input
                 type="text"
                 value={vibeText}
                 onChange={(e) => setVibeText(e.target.value)}
                 placeholder="e.g. techno, late night"
-                style={inputStyle}
+                className="bg-deep border border-border-mid rounded-lg py-3 px-3.5 text-primary font-mono text-sm outline-none w-full box-border"
               />
             </div>
             {event?.isPublic && (
               <div>
-                <div style={labelStyle}>Note</div>
+                <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>Note</div>
                 <input
                   type="text"
                   value={note}
                   onChange={(e) => setNote(e.target.value)}
                   placeholder="e.g. DJ set starts at midnight"
                   maxLength={200}
-                  style={inputStyle}
+                  className="bg-deep border border-border-mid rounded-lg py-3 px-3.5 text-primary font-mono text-sm outline-none w-full box-border"
                 />
               </div>
             )}
           </div>
 
           {/* Save button */}
-          <div style={{ padding: "20px 0 0", flexShrink: 0 }}>
+          <div className="pt-5 shrink-0">
             <button
               onClick={() => {
                 const vibes = vibeText.split(",").map((v) => v.trim()).filter(Boolean);
                 onSave({ title, venue, date: resolvedDate, time: resolvedTime, vibe: vibes, note: note.trim() });
               }}
               disabled={!title.trim()}
-              style={{
-                width: "100%",
-                background: title.trim() ? color.accent : color.borderMid,
-                color: title.trim() ? "#000" : color.dim,
-                border: "none",
-                borderRadius: 12,
-                padding: "14px",
-                fontFamily: font.mono,
-                fontSize: 12,
-                fontWeight: 700,
-                cursor: title.trim() ? "pointer" : "not-allowed",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-                opacity: title.trim() ? 1 : 0.5,
-              }}
+              className={cn(
+                "w-full border-none rounded-xl py-3.5 font-mono text-xs font-bold uppercase",
+                title.trim()
+                  ? "bg-dt text-black cursor-pointer opacity-100"
+                  : "bg-border-mid text-dim cursor-not-allowed opacity-50"
+              )}
+              style={{ letterSpacing: "0.08em" }}
             >
               Save Changes
             </button>

--- a/src/features/events/components/EventActionsSheet.tsx
+++ b/src/features/events/components/EventActionsSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 
 export default function EventActionsSheet({
   open,
@@ -51,23 +51,9 @@ export default function EventActionsSheet({
   const actionRow = (label: string, icon: string, onClick: () => void) => (
     <button
       onClick={onClick}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 12,
-        width: "100%",
-        padding: "14px 0",
-        background: "transparent",
-        border: "none",
-        borderBottom: `1px solid ${color.border}`,
-        fontFamily: font.mono,
-        fontSize: 13,
-        color: color.text,
-        cursor: "pointer",
-        textAlign: "left",
-      }}
+      className="flex items-center gap-3 w-full py-3.5 bg-transparent border-none border-b border-border font-mono text-sm text-primary cursor-pointer text-left"
     >
-      <span style={{ fontSize: 16, width: 24, textAlign: "center" }}>{icon}</span>
+      <span className="text-base w-6 text-center">{icon}</span>
       {label}
     </button>
   );
@@ -79,40 +65,31 @@ export default function EventActionsSheet({
         onTouchStart={(e) => e.stopPropagation()}
         onTouchMove={(e) => e.stopPropagation()}
         onTouchEnd={(e) => e.stopPropagation()}
+        className="fixed inset-0 z-[100]"
         style={{
-          position: "fixed",
-          inset: 0,
           background: "rgba(0,0,0,0.7)",
           backdropFilter: "blur(8px)",
           WebkitBackdropFilter: "blur(8px)",
-          zIndex: 100,
         }}
       />
       <div
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
+        className="fixed bottom-0 left-0 right-0 bg-surface max-w-[420px] mx-auto z-[101]"
         style={{
-          position: "fixed",
-          bottom: 0,
-          left: 0,
-          right: 0,
-          background: color.surface,
           borderRadius: "24px 24px 0 0",
-          maxWidth: 420,
-          margin: "0 auto",
-          zIndex: 101,
           animation: closing ? undefined : "slideUp 0.3s ease-out",
           transform: closing ? "translateY(100%)" : dragOffset > 0 ? `translateY(${dragOffset}px)` : undefined,
           transition: closing ? "transform 0.25s ease-in" : dragOffset > 0 ? undefined : "transform 0.25s ease-out",
           paddingBottom: "env(safe-area-inset-bottom, 20px)",
         }}
       >
-        <div style={{ display: "flex", justifyContent: "center", padding: "12px 0 8px" }}>
-          <div style={{ width: 40, height: 4, background: color.faint, borderRadius: 2 }} />
+        <div className="flex justify-center pt-3 pb-2">
+          <div className="w-10 h-1 bg-faint rounded-sm" />
         </div>
-        <div style={{ padding: "0 20px 20px" }}>
-          <p style={{ fontFamily: font.serif, fontSize: 18, color: color.text, margin: "0 0 8px", fontWeight: 400 }}>
+        <div className="px-5 pb-5">
+          <p className="font-serif text-lg text-primary mb-2 font-normal">
             Event actions
           </p>
           {onShare && actionRow("Share event", "🔗", () => { dismiss(); onShare(); })}

--- a/src/features/friends/components/UserProfileOverlay.tsx
+++ b/src/features/friends/components/UserProfileOverlay.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import type { Profile } from "@/lib/types";
 import * as db from "@/lib/db";
 import { logError } from "@/lib/logger";
+import cn from "@/lib/tailwindMerge";
 
 const UserProfileOverlay = ({
   targetUserId,
@@ -87,110 +88,62 @@ const UserProfileOverlay = ({
     : "Add Friend";
 
   const actionDisabled = acting;
-  const actionColor =
-    friendStatus === "accepted" ? "#ff6b6b"
-    : friendStatus === "pending" && isRequester ? color.dim
-    : color.accent;
-  const actionBg =
-    friendStatus === "accepted" ? "transparent"
-    : friendStatus === "pending" && isRequester ? "transparent"
-    : color.accent;
   const actionTextColor =
     friendStatus === "accepted" ? "#ff6b6b"
     : friendStatus === "pending" && isRequester ? color.faint
     : "#000";
+  const actionBg =
+    friendStatus === "accepted" ? "transparent"
+    : friendStatus === "pending" && isRequester ? "transparent"
+    : color.accent;
 
   return (
-    <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 9999,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center">
       <div
         onClick={onClose}
+        className="absolute inset-0"
         style={{
-          position: "absolute",
-          inset: 0,
           background: "rgba(0,0,0,0.8)",
           backdropFilter: "blur(12px)",
           WebkitBackdropFilter: "blur(12px)",
         }}
       />
-      <div
-        style={{
-          position: "relative",
-          background: color.surface,
-          borderRadius: 24,
-          width: "90%",
-          maxWidth: 340,
-          padding: "40px 24px 32px",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          animation: "slideUp 0.2s ease-out",
-        }}
-      >
+      <div className="relative bg-surface rounded-3xl w-[90%] max-w-[340px] pt-10 px-6 pb-8 flex flex-col items-center animate-slide-up">
         {/* Close button */}
         <button
           onClick={onClose}
-          style={{
-            position: "absolute",
-            top: 14,
-            right: 14,
-            background: "none",
-            border: "none",
-            color: color.dim,
-            fontSize: 18,
-            cursor: "pointer",
-            padding: 4,
-            lineHeight: 1,
-          }}
+          className="absolute top-3.5 right-3.5 bg-transparent border-none text-dim text-lg cursor-pointer p-1 leading-none"
         >
           ✕
         </button>
 
         {loading ? (
-          <div style={{ padding: "40px 0", color: color.faint, fontFamily: font.mono, fontSize: 12 }}>
+          <div className="py-10 text-faint font-mono text-xs">
             <span style={{ animation: "pulse 1.5s ease-in-out infinite" }}>Loading...</span>
           </div>
         ) : !profileData ? (
-          <div style={{ padding: "40px 0", color: color.faint, fontFamily: font.mono, fontSize: 12 }}>
+          <div className="py-10 text-faint font-mono text-xs">
             User not found
           </div>
         ) : (
           <>
             {/* Avatar */}
             <div
-              style={{
-                width: 72,
-                height: 72,
-                borderRadius: "50%",
-                background: isSelf ? color.accent : friendStatus === "accepted" ? color.accent : color.borderLight,
-                color: isSelf || friendStatus === "accepted" ? "#000" : color.dim,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontFamily: font.mono,
-                fontSize: 28,
-                fontWeight: 700,
-                marginBottom: 16,
-              }}
+              className={cn(
+                "w-[72px] h-[72px] rounded-full flex items-center justify-center font-mono text-[28px] font-bold mb-4",
+                (isSelf || friendStatus === "accepted") ? "bg-dt text-black" : "bg-border-light text-dim"
+              )}
             >
               {profileData.avatar_letter}
             </div>
 
             {/* Name */}
-            <div style={{ fontFamily: font.serif, fontSize: 22, color: color.text, marginBottom: 4 }}>
+            <div className="font-serif text-2xl text-primary mb-1">
               {profileData.display_name}
             </div>
 
             {/* Username */}
-            <div style={{ fontFamily: font.mono, fontSize: 13, color: color.dim, marginBottom: 4 }}>
+            <div className="font-mono text-sm text-dim mb-1">
               @{profileData.username}
             </div>
 
@@ -200,14 +153,14 @@ const UserProfileOverlay = ({
                 href={`https://instagram.com/${profileData.ig_handle}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                style={{ fontFamily: font.mono, fontSize: 11, color: color.faint, marginBottom: 8, textDecoration: "none" }}
+                className="font-mono text-xs text-faint mb-2 no-underline"
               >
                 ig: @{profileData.ig_handle}
               </a>
             )}
 
             {/* Availability */}
-            <div style={{ fontFamily: font.mono, fontSize: 12, color: color.faint, marginBottom: 32 }}>
+            <div className="font-mono text-xs text-faint mb-8">
               {profileData.availability === "open" && "✨ open to friends!"}
               {profileData.availability === "awkward" && "👀 awkward timing"}
               {profileData.availability === "not-available" && "🌙 not available"}
@@ -218,8 +171,11 @@ const UserProfileOverlay = ({
               <button
                 onClick={handleAction}
                 disabled={actionDisabled}
+                className={cn(
+                  "w-full rounded-xl py-3.5 px-6 font-mono text-xs font-bold uppercase",
+                  actionDisabled ? "cursor-default opacity-60" : "cursor-pointer opacity-100"
+                )}
                 style={{
-                  width: "100%",
                   background: actionBg,
                   color: actionTextColor,
                   border: friendStatus === "accepted"
@@ -227,15 +183,7 @@ const UserProfileOverlay = ({
                     : friendStatus === "pending" && isRequester
                       ? `1px solid ${color.borderMid}`
                       : "none",
-                  borderRadius: 12,
-                  padding: "14px 24px",
-                  fontFamily: font.mono,
-                  fontSize: 12,
-                  fontWeight: 700,
-                  cursor: actionDisabled ? "default" : "pointer",
-                  textTransform: "uppercase",
                   letterSpacing: "0.08em",
-                  opacity: actionDisabled ? 0.6 : 1,
                 }}
               >
                 {acting ? "..." : actionLabel}

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -2,9 +2,10 @@
 
 import { useRef, useState, useEffect } from "react";
 import * as db from "@/lib/db";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import { formatTimeAgo } from "@/lib/utils";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import cn from "@/lib/tailwindMerge";
 import type { Tab } from "@/lib/ui-types";
 
 interface Notification {
@@ -96,21 +97,11 @@ const NotificationsPanel = ({
   if (!visible) return null;
 
   return (
-    <div
-      style={{
-        position: "fixed",
-        inset: 0,
-        zIndex: 100,
-        display: "flex",
-        alignItems: "flex-end",
-        justifyContent: "center",
-      }}
-    >
+    <div className="fixed inset-0 z-[100] flex items-end justify-center">
       <div
         onClick={close}
+        className="absolute inset-0"
         style={{
-          position: "absolute",
-          inset: 0,
           background: "rgba(0,0,0,0.7)",
           backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
           WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
@@ -120,58 +111,30 @@ const NotificationsPanel = ({
       />
       <div
         ref={panelRef}
+        className="relative bg-surface w-full max-w-[420px] flex flex-col pt-6"
         style={{
-          position: "relative",
-          background: color.surface,
           borderRadius: "24px 24px 0 0",
-          width: "100%",
-          maxWidth: 420,
           maxHeight: "80vh",
-          padding: "24px 0 0",
           animation: closing ? undefined : "slideUp 0.3s ease-out",
           transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
           transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
-          display: "flex",
-          flexDirection: "column",
         }}
       >
         <div
           onTouchStart={handleSwipeStart}
           onTouchMove={handleSwipeMove}
           onTouchEnd={handleSwipeEnd}
-          style={{ touchAction: "none" }}
+          className="touch-none"
         >
-          <div
-            style={{
-              width: 40,
-              height: 4,
-              background: color.faint,
-              borderRadius: 2,
-              margin: "0 auto 16px",
-            }}
-          />
+          <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-4" />
         </div>
         <div
           onTouchStart={handleSwipeStart}
           onTouchMove={handleSwipeMove}
           onTouchEnd={handleSwipeEnd}
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-            padding: "0 20px 16px",
-            borderBottom: `1px solid ${color.border}`,
-            touchAction: "none",
-          }}
+          className="flex justify-between items-center px-5 pb-4 border-b border-border touch-none"
         >
-          <h2
-            style={{
-              fontFamily: font.serif,
-              fontSize: 22,
-              color: color.text,
-              fontWeight: 400,
-            }}
-          >
+          <h2 className="font-serif text-2xl text-primary font-normal">
             Notifications
           </h2>
           {notifications.some((n) => !n.is_read) && (
@@ -189,16 +152,8 @@ const NotificationsPanel = ({
                 setNotifications((prev) => prev.map((n) => pendingFriendRequestIds.has(n.id) ? n : { ...n, is_read: true }));
                 setUnreadCount(pendingFriendRequestIds.size);
               }}
-              style={{
-                background: "none",
-                border: "none",
-                color: color.accent,
-                fontFamily: font.mono,
-                fontSize: 11,
-                cursor: "pointer",
-                textTransform: "uppercase",
-                letterSpacing: "0.08em",
-              }}
+              className="bg-transparent border-none text-dt font-mono text-xs cursor-pointer uppercase"
+              style={{ letterSpacing: "0.08em" }}
             >
               Mark all read
             </button>
@@ -209,37 +164,14 @@ const NotificationsPanel = ({
           onTouchStart={handleScrollTouchStart}
           onTouchMove={handleScrollTouchMove}
           onTouchEnd={handleScrollTouchEnd}
-          style={{
-            overflowY: isDragging.current ? "hidden" : "auto",
-            overflowX: "hidden",
-            flex: 1,
-            padding: "0 0 32px",
-          }}
+          className={cn("overflow-x-hidden flex-1 pb-8", isDragging.current ? "overflow-y-hidden" : "overflow-y-auto")}
         >
           {notifications.length === 0 ? (
-            <div
-              style={{
-                padding: "40px 20px",
-                textAlign: "center",
-              }}
-            >
-              <div
-                style={{
-                  fontFamily: font.serif,
-                  fontSize: 18,
-                  color: color.muted,
-                  marginBottom: 8,
-                }}
-              >
+            <div className="py-10 px-5 text-center">
+              <div className="font-serif text-lg text-muted mb-2">
                 No notifications yet
               </div>
-              <p
-                style={{
-                  fontFamily: font.mono,
-                  fontSize: 11,
-                  color: color.faint,
-                }}
-              >
+              <p className="font-mono text-xs text-faint">
                 You&apos;ll see friend requests, check responses, and squad invites here
               </p>
             </div>
@@ -327,23 +259,15 @@ const NotificationsPanel = ({
                     onNavigate({ type: "feed", checkId: n.related_check_id ?? undefined });
                   }
                 }}
-                style={{
-                  display: "flex",
-                  gap: 12,
-                  padding: "14px 20px",
-                  background: n.is_read ? "transparent" : "rgba(232, 255, 90, 0.04)",
-                  border: "none",
-                  borderBottom: `1px solid ${color.border}`,
-                  cursor: "pointer",
-                  width: "100%",
-                  textAlign: "left",
-                }}
+                className={cn(
+                  "flex gap-3 w-full border-none border-b border-border cursor-pointer text-left",
+                  n.is_read ? "bg-transparent" : "bg-[rgba(232,255,90,0.04)]"
+                )}
+                style={{ padding: "14px 20px", borderBottom: `1px solid ${color.border}` }}
               >
                 <div
+                  className="w-9 h-9 rounded-full flex items-center justify-center text-base shrink-0"
                   style={{
-                    width: 36,
-                    height: 36,
-                    borderRadius: "50%",
                     background: n.type === "friend_request" ? "#E8FF5A22"
                       : n.type === "friend_accepted" ? "#34C75922"
                       : n.type === "check_response" ? "#FF9F0A22"
@@ -354,11 +278,6 @@ const NotificationsPanel = ({
                       : n.type === "event_down" ? "#E8FF5A22"
                       : n.type === "friend_event" ? "#E8FF5A22"
                       : "#5856D622",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    fontSize: 16,
-                    flexShrink: 0,
                   }}
                 >
                   {n.type === "friend_request" ? "👋"
@@ -372,58 +291,28 @@ const NotificationsPanel = ({
                     : n.type === "friend_event" ? "🎉"
                     : "💬"}
                 </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
+                <div className="flex-1 min-w-0">
                   <div
-                    style={{
-                      fontFamily: font.mono,
-                      fontSize: 12,
-                      color: n.is_read ? color.muted : color.text,
-                      fontWeight: n.is_read ? 400 : 700,
-                      marginBottom: 2,
-                    }}
+                    className={cn(
+                      "font-mono text-xs mb-0.5",
+                      n.is_read ? "text-muted font-normal" : "text-primary font-bold"
+                    )}
                   >
                     {n.title}
                   </div>
                   {n.body && (
                     <div
-                      style={{
-                        fontFamily: font.mono,
-                        fontSize: 11,
-                        color: color.dim,
-                        lineHeight: 1.4,
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        display: "-webkit-box",
-                        WebkitLineClamp: 2,
-                        WebkitBoxOrient: "vertical",
-                        wordBreak: "break-all",
-                      }}
+                      className="font-mono text-xs text-dim leading-relaxed overflow-hidden break-all line-clamp-2"
                     >
                       {n.body}
                     </div>
                   )}
-                  <div
-                    style={{
-                      fontFamily: font.mono,
-                      fontSize: 10,
-                      color: color.faint,
-                      marginTop: 4,
-                    }}
-                  >
+                  <div className="font-mono text-tiny text-faint mt-1">
                     {formatTimeAgo(new Date(n.created_at))}
                   </div>
                 </div>
                 {!n.is_read && (
-                  <div
-                    style={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: "50%",
-                      background: color.accent,
-                      flexShrink: 0,
-                      alignSelf: "center",
-                    }}
-                  />
+                  <div className="w-2 h-2 rounded-full bg-dt shrink-0 self-center" />
                 )}
               </button>
             ))

--- a/src/features/squads/components/GroupsView.tsx
+++ b/src/features/squads/components/GroupsView.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import * as db from "@/lib/db";
-import { font, color } from "@/lib/styles";
+import cn from "@/lib/tailwindMerge";
 import type { Squad } from "@/lib/ui-types";
 
 const formatExpiryShort = (expiresAt?: string): string | null => {
@@ -23,32 +23,16 @@ const GroupsView = ({
   onSelectSquad: (squad: Squad) => void;
 }) => {
   return (
-    <div style={{ padding: "0 20px" }}>
-      <h2
-        style={{
-          fontFamily: font.serif,
-          fontSize: 28,
-          color: color.text,
-          marginBottom: 4,
-          fontWeight: 400,
-        }}
-      >
+    <div className="px-5">
+      <h2 className="font-serif text-[28px] text-primary mb-1 font-normal">
         Your Squads
       </h2>
-      <p style={{ fontFamily: font.mono, fontSize: 11, color: color.dim, marginBottom: 24 }}>
+      <p className="font-mono text-xs text-dim mb-6">
         Groups formed around events
       </p>
 
       {squads.length === 0 ? (
-        <div
-          style={{
-            textAlign: "center",
-            padding: "60px 20px",
-            color: color.faint,
-            fontFamily: font.mono,
-            fontSize: 12,
-          }}
-        >
+        <div className="text-center py-[60px] px-5 text-faint font-mono text-xs">
           No squads yet.<br />
           Say you&apos;re down on a friend&apos;s check and a squad forms automatically.
         </div>
@@ -57,35 +41,21 @@ const GroupsView = ({
           <div
             key={g.id}
             onClick={() => onSelectSquad({ ...g, hasUnread: false })}
-            style={{
-              background: color.card,
-              borderRadius: 16,
-              padding: 16,
-              marginBottom: 8,
-              border: `1px solid ${color.border}`,
-              cursor: "pointer",
-            }}
+            className="bg-card rounded-2xl p-4 mb-2 border border-border cursor-pointer"
           >
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "flex-start",
-                marginBottom: 8,
-              }}
-            >
-              <div style={{ display: "flex", alignItems: "flex-start", gap: 8 }}>
-                <span style={{ fontFamily: font.serif, fontSize: 17, color: color.text, fontWeight: 400 }}>
+            <div className="flex justify-between items-start mb-2">
+              <div className="flex items-start gap-2">
+                <span className="font-serif text-[17px] text-primary font-normal">
                   {g.name}
                   {g.hasUnread && (
-                    <span data-testid={`squad-unread-dot-${g.id}`} style={{ display: "inline-block", width: 8, height: 8, borderRadius: "50%", background: "#ff3b30", marginLeft: 6, verticalAlign: "middle" }} />
+                    <span data-testid={`squad-unread-dot-${g.id}`} className="inline-block w-2 h-2 rounded-full bg-[#ff3b30] ml-1.5 align-middle" />
                   )}
                 </span>
                 {g.isWaitlisted && (
-                  <span style={{ fontFamily: font.mono, fontSize: 9, color: color.faint, border: `1px solid ${color.border}`, borderRadius: 4, padding: "1px 5px", flexShrink: 0, marginTop: 5 }}>waitlist</span>
+                  <span className="font-mono text-[9px] text-faint border border-border rounded px-[5px] py-px shrink-0 mt-[5px]">waitlist</span>
                 )}
               </div>
-              <span style={{ fontFamily: font.mono, fontSize: 10, color: color.faint, flexShrink: 0 }}>
+              <span className="font-mono text-tiny text-faint shrink-0">
                 {g.time}
                 {(() => {
                   const exp = formatExpiryShort(g.expiresAt);
@@ -93,40 +63,21 @@ const GroupsView = ({
                   const msLeft = g.expiresAt ? new Date(g.expiresAt).getTime() - Date.now() : Infinity;
                   const isUrgent = msLeft < 24 * 60 * 60 * 1000;
                   return (
-                    <span style={{ color: isUrgent ? "#ff3b30" : color.faint }}>
+                    <span className={isUrgent ? "text-[#ff3b30]" : "text-faint"}>
                       {" · "}expires {exp}
                     </span>
                   );
                 })()}
               </span>
             </div>
-            <div
-              style={{
-                fontFamily: font.mono,
-                fontSize: 12,
-                color: color.muted,
-                marginBottom: 8,
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-              }}
-            >
+            <div className="font-mono text-xs text-muted mb-2 overflow-hidden text-ellipsis whitespace-nowrap">
               {g.lastMsg}
             </div>
           </div>
         ))
       )}
 
-      <div
-        style={{
-          textAlign: "center",
-          padding: "32px 20px",
-          color: color.borderMid,
-          fontFamily: font.mono,
-          fontSize: 11,
-          lineHeight: 1.8,
-        }}
-      >
+      <div className="text-center py-8 px-5 text-border-mid font-mono text-xs" style={{ lineHeight: 1.8 }}>
         squads dissolve after the event ✶
       </div>
     </div>

--- a/src/features/squads/components/MessageComposer.tsx
+++ b/src/features/squads/components/MessageComposer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useRef } from "react";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 import type { Squad } from "@/lib/ui-types";
 
 interface MessageComposerProps {
@@ -53,11 +53,8 @@ export default function MessageComposer({
         );
         if (filtered.length === 0) return null;
         return (
-          <div style={{ padding: "4px 20px", background: color.surface }}>
-            <div style={{
-              background: color.deep, border: `1px solid ${color.borderMid}`,
-              borderRadius: 10, maxHeight: 120, overflowY: "auto",
-            }}>
+          <div className="px-5 bg-surface">
+            <div className="bg-deep border border-border-mid rounded-lg max-h-[120px] overflow-y-auto">
               {filtered.slice(0, 6).map((m) => (
                 <button
                   key={m.userId}
@@ -70,22 +67,12 @@ export default function MessageComposer({
                     setChatMentionIdx(-1);
                     msgInputRef.current?.focus();
                   }}
-                  style={{
-                    display: "flex", alignItems: "center", gap: 8,
-                    width: "100%", padding: "8px 12px",
-                    background: "transparent", border: "none", cursor: "pointer",
-                    borderBottom: `1px solid ${color.border}`,
-                  }}
+                  className="flex items-center gap-2 w-full px-3 py-2 bg-transparent border-none cursor-pointer border-b border-border"
                 >
-                  <div style={{
-                    width: 24, height: 24, borderRadius: "50%",
-                    background: color.borderLight, color: color.dim,
-                    display: "flex", alignItems: "center", justifyContent: "center",
-                    fontFamily: font.mono, fontSize: 10, fontWeight: 700,
-                  }}>
+                  <div className="w-6 h-6 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-tiny font-bold">
                     {m.avatar}
                   </div>
-                  <span style={{ fontFamily: font.mono, fontSize: 12, color: color.text }}>{m.name}</span>
+                  <span className="font-mono text-xs text-primary">{m.name}</span>
                 </button>
               ))}
             </div>
@@ -94,20 +81,13 @@ export default function MessageComposer({
       })()}
       {/* Input row */}
       <div
-        style={{
-          padding: "12px 20px calc(12px + env(safe-area-inset-bottom, 0px))",
-          display: "flex",
-          gap: 8,
-          alignItems: "flex-end",
-        }}
+        className="flex gap-2 items-end"
+        style={{ padding: "12px 20px calc(12px + env(safe-area-inset-bottom, 0px))" }}
       >
         {(!activePoll || activePoll.status === 'closed') && onOpenPollCreator && (
           <button
             onClick={onOpenPollCreator}
-            style={{
-              background: 'none', border: 'none', padding: 0,
-              fontSize: 20, opacity: 0.6, cursor: 'pointer', lineHeight: 1, marginBottom: 8,
-            }}
+            className="bg-none border-none p-0 text-xl opacity-60 cursor-pointer leading-none mb-2"
           >
             📊
           </button>
@@ -145,36 +125,22 @@ export default function MessageComposer({
           enterKeyHint="send"
           placeholder="Message..."
           rows={1}
+          className="flex-1 bg-card border border-border-mid rounded-[20px] text-primary font-mono outline-none resize-none max-h-[120px] overflow-y-auto"
           style={{
-            flex: 1,
-            background: color.card,
-            border: `1px solid ${color.borderMid}`,
-            borderRadius: 20,
             padding: "10px 16px",
-            color: color.text,
-            fontFamily: font.mono,
             fontSize: 16,
-            outline: "none",
-            resize: "none",
-            maxHeight: 120,
             lineHeight: 1.4,
-            overflowY: "auto",
           }}
         />
         <button
           onMouseDown={(e) => e.preventDefault()}
           onClick={handleSend}
           disabled={!newMsg.trim()}
+          className="border-none rounded-full w-10 h-10 font-bold text-base"
           style={{
             background: newMsg.trim() ? color.accent : color.borderMid,
             color: newMsg.trim() ? "#000" : color.dim,
-            border: "none",
-            borderRadius: "50%",
-            width: 40,
-            height: 40,
             cursor: newMsg.trim() ? "pointer" : "default",
-            fontWeight: 700,
-            fontSize: 16,
           }}
         >
           ↑

--- a/src/features/squads/components/PollMessage.tsx
+++ b/src/features/squads/components/PollMessage.tsx
@@ -2,7 +2,8 @@
 
 import React, { useState, useEffect } from "react";
 import * as db from "@/lib/db";
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
+import cn from "@/lib/tailwindMerge";
 
 interface PollMessageProps {
   poll: {
@@ -55,23 +56,16 @@ export default function PollMessage({
   const isCreator = userId === poll.createdBy;
 
   return (
-    <div ref={pollMessageRef} style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}>
-      <div style={{
-        background: color.card,
-        border: `1px solid ${color.borderMid}`,
-        borderRadius: 14,
-        padding: 16,
-        maxWidth: 300,
-        width: '100%',
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 4 }}>
-          <span style={{ fontSize: 16 }}>📊</span>
-          <span style={{ fontFamily: font.serif, fontSize: 16, color: color.text }}>{poll.question}</span>
+    <div ref={pollMessageRef} className="flex justify-center py-2">
+      <div className="bg-card border border-border-mid rounded-xl p-4 max-w-[300px] w-full">
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className="text-base">📊</span>
+          <span className="font-serif text-base text-primary">{poll.question}</span>
         </div>
-        <div style={{ fontFamily: font.mono, fontSize: 10, color: color.faint, marginBottom: 10 }}>
+        <div className="font-mono text-tiny text-faint mb-2.5">
           {poll.multiSelect ? 'Select all that apply' : 'Pick one'}
         </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div className="flex flex-col gap-1.5">
           {poll.options.map((opt, oi) => {
             const isMyVote = myVotes.has(oi);
             const votersForOption = votes.filter((v) => v.optionIndex === oi);
@@ -82,50 +76,39 @@ export default function PollMessage({
               <div
                 key={oi}
                 onClick={canVote ? () => handleVote(oi) : undefined}
-                style={{
-                  position: 'relative',
-                  border: isMyVote ? 'none' : `1px solid ${color.borderMid}`,
-                  background: isMyVote ? color.accent : 'transparent',
-                  borderRadius: 10,
-                  padding: '8px 12px',
-                  cursor: canVote ? 'pointer' : 'default',
-                  overflow: 'hidden',
-                }}
+                className={cn(
+                  "relative rounded-lg overflow-hidden",
+                  isMyVote ? "bg-dt border-none" : "bg-transparent border border-border-mid",
+                  canVote ? "cursor-pointer" : "cursor-default"
+                )}
+                style={{ padding: '8px 12px' }}
               >
                 {totalVoters > 0 && (
-                  <div style={{
-                    position: 'absolute',
-                    left: 0, top: 0, bottom: 0,
-                    width: `${pct}%`,
-                    background: isMyVote ? 'rgba(0,0,0,0.1)' : `${color.accent}15`,
-                    borderRadius: 10,
-                    transition: 'width 0.3s ease',
-                  }} />
+                  <div
+                    className="absolute left-0 top-0 bottom-0 rounded-lg transition-[width] duration-300 ease-in-out"
+                    style={{
+                      width: `${pct}%`,
+                      background: isMyVote ? 'rgba(0,0,0,0.1)' : `${color.accent}15`,
+                    }}
+                  />
                 )}
-                <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                  <span style={{
-                    fontFamily: font.mono,
-                    fontSize: 12,
-                    color: isMyVote ? '#000' : color.text,
-                    fontWeight: isMyVote ? 700 : 400,
-                  }}>{opt}</span>
+                <div className="relative flex justify-between items-center">
+                  <span className={cn(
+                    "font-mono text-xs",
+                    isMyVote ? "text-black font-bold" : "text-primary font-normal"
+                  )}>{opt}</span>
                   {totalVoters > 0 && (
-                    <span style={{
-                      fontFamily: font.mono,
-                      fontSize: 10,
-                      color: isMyVote ? '#000' : color.dim,
-                      fontWeight: 700,
-                    }}>{pct}%</span>
+                    <span className={cn(
+                      "font-mono text-tiny font-bold",
+                      isMyVote ? "text-black" : "text-dim"
+                    )}>{pct}%</span>
                   )}
                 </div>
                 {count > 0 && (
-                  <div style={{
-                    position: 'relative',
-                    fontFamily: font.mono,
-                    fontSize: 10,
-                    color: isMyVote ? 'rgba(0,0,0,0.6)' : color.faint,
-                    marginTop: 2,
-                  }}>
+                  <div
+                    className="relative font-mono text-tiny mt-0.5"
+                    style={{ color: isMyVote ? 'rgba(0,0,0,0.6)' : color.faint }}
+                  >
                     {votersForOption.map((v) => v.userId === userId ? 'You' : v.displayName).join(', ')}
                   </div>
                 )}
@@ -133,24 +116,15 @@ export default function PollMessage({
             );
           })}
         </div>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 10 }}>
-          <span style={{ fontFamily: font.mono, fontSize: 10, color: color.faint }}>
+        <div className="flex justify-between items-center mt-2.5">
+          <span className="font-mono text-tiny text-faint">
             {totalVoters} vote{totalVoters !== 1 ? 's' : ''}{isClosed ? ' · closed' : ''}
           </span>
           {isCreator && !isClosed && (
             <button
               onClick={handleClose}
-              style={{
-                background: 'transparent',
-                border: `1px solid ${color.borderMid}`,
-                borderRadius: 8,
-                padding: '4px 10px',
-                fontFamily: font.mono,
-                fontSize: 10,
-                fontWeight: 700,
-                color: color.dim,
-                cursor: 'pointer',
-              }}
+              className="bg-transparent border border-border-mid rounded-lg font-mono text-tiny font-bold text-dim cursor-pointer"
+              style={{ padding: '4px 10px' }}
             >
               CLOSE POLL
             </button>

--- a/src/features/squads/components/SquadNotificationBanner.tsx
+++ b/src/features/squads/components/SquadNotificationBanner.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { font, color } from "@/lib/styles";
-
 interface SquadNotificationData {
   squadId: string;
   squadName: string;
@@ -19,90 +17,36 @@ const SquadNotificationBanner = ({
 }) => (
   <div
     onClick={() => onOpen(notification.squadId)}
+    className="fixed top-[60px] left-5 right-5 border-2 border-dt rounded-2xl p-4 z-[250] cursor-pointer"
     style={{
-      position: "fixed",
-      top: 60,
-      left: 20,
-      right: 20,
       background: "linear-gradient(135deg, #1a1a1a 0%, #0d0d0d 100%)",
-      border: `2px solid ${color.accent}`,
-      borderRadius: 16,
-      padding: 16,
-      zIndex: 250,
       animation: "toastIn 0.3s ease",
-      boxShadow: `0 8px 32px rgba(232, 255, 90, 0.2)`,
-      cursor: "pointer",
+      boxShadow: "0 8px 32px rgba(232, 255, 90, 0.2)",
     }}
   >
     <div
-      style={{
-        fontFamily: font.mono,
-        fontSize: 10,
-        color: color.accent,
-        textTransform: "uppercase",
-        letterSpacing: "0.1em",
-        marginBottom: 8,
-      }}
+      className="font-mono text-tiny text-dt uppercase mb-2"
+      style={{ letterSpacing: "0.1em" }}
     >
       🎉 Squad Formed!
     </div>
-    <div
-      style={{
-        fontFamily: font.serif,
-        fontSize: 18,
-        color: color.text,
-        marginBottom: 12,
-      }}
-    >
+    <div className="font-serif text-lg text-primary mb-3">
       {notification.squadName}
     </div>
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: 6,
-      }}
-    >
-      <div
-        style={{
-          fontFamily: font.mono,
-          fontSize: 11,
-          color: color.dim,
-        }}
-      >
-        💡 idea by <span style={{ color: color.text }}>{notification.ideaBy}</span>
+    <div className="flex flex-col gap-1.5">
+      <div className="font-mono text-xs text-dim">
+        💡 idea by <span className="text-primary">{notification.ideaBy}</span>
       </div>
-      <div
-        style={{
-          fontFamily: font.mono,
-          fontSize: 11,
-          color: color.dim,
-        }}
-      >
-        🚀 started by <span style={{ color: color.accent }}>{notification.startedBy}</span>
+      <div className="font-mono text-xs text-dim">
+        🚀 started by <span className="text-dt">{notification.startedBy}</span>
       </div>
       {notification.members.length > 0 && (
-        <div
-          style={{
-            fontFamily: font.mono,
-            fontSize: 11,
-            color: color.dim,
-            marginTop: 4,
-          }}
-        >
+        <div className="font-mono text-xs text-dim mt-1">
           👥 {notification.members.join(", ")} + you
         </div>
       )}
     </div>
-    <div
-      style={{
-        fontFamily: font.mono,
-        fontSize: 10,
-        color: color.accent,
-        marginTop: 10,
-        opacity: 0.7,
-      }}
-    >
+    <div className="font-mono text-tiny text-dt mt-2.5 opacity-70">
       Tap to open chat →
     </div>
   </div>


### PR DESCRIPTION
## Summary
Final batch of inline styles → Tailwind migration. Converts 22 files (~241 inline styles):

**5a:** NotificationsPanel, AuthScreen, EnableNotificationsScreen, PollMessage, CheckActionsSheet (86 styles, 551 lines removed)

**5b:** GroupsView, EditEventModal, UserProfileOverlay, check page, friend page (66 styles, 372 lines removed)

**5c:** page.tsx, SquadNotificationBanner, MessageComposer, EventActionsSheet, Header, BottomNav, IOSInstallBanner, global-error, error, UpdateBanner, check CTA, useOnboarding (89 styles, 508 lines removed)

## Final tally
| Batch | Inline styles converted | Lines removed |
|-------|------------------------|---------------|
| 1 (#300) | 102 | 812 |
| 2 (#301) | 231 | 794 |
| 3 (#302) | 214 | 1,346 |
| 4 (#304) | 182 | 1,132 |
| 5 (this) | 241 | 1,431 |
| **Total** | **~970** | **~5,515** |

## Test plan
- [ ] Full app smoke test — all tabs, modals, sheets render correctly
- [ ] Auth flow renders correctly
- [ ] Notifications panel renders correctly
- [ ] Error pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)