### PR TITLE
feat: add theme switcher to profile page

### DIFF
--- a/src/app/components/ThemeHydrator.tsx
+++ b/src/app/components/ThemeHydrator.tsx
@@ -4,33 +4,49 @@ import { useEffect } from "react";
 import { themes, themeToCSSSVars } from "@/lib/themes";
 import type { ThemeName } from "@/lib/themes";
 
+const THEME_STORAGE_KEY = "downto-theme";
+
+/** Apply a theme by injecting CSS vars, updating meta theme-color, and bg image */
+export function applyTheme(name: ThemeName) {
+  if (!(name in themes)) return;
+  if (name === document.documentElement.dataset.theme) return;
+
+  const cssVars = themeToCSSSVars(themes[name]);
+  document.documentElement.dataset.theme = name;
+
+  let el = document.getElementById("theme-vars");
+  if (!el) {
+    el = document.createElement("style");
+    el.id = "theme-vars";
+    document.head.appendChild(el);
+  }
+  el.textContent = `:root { ${cssVars} }`;
+
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", themes[name].themeColor);
+
+  const t = themes[name];
+  document.body.style.background = t.bgImage
+    ? `var(--t-bg) url(${t.bgImage}) center/cover fixed`
+    : "var(--t-bg)";
+}
+
 export default function ThemeHydrator() {
   useEffect(() => {
+    // Priority: URL param > localStorage > default (no-op)
     const params = new URLSearchParams(window.location.search);
     const qTheme = params.get("theme") as ThemeName | null;
-    if (!qTheme || !(qTheme in themes)) return;
-    if (qTheme === document.documentElement.dataset.theme) return;
 
-    const cssVars = themeToCSSSVars(themes[qTheme]);
-    document.documentElement.dataset.theme = qTheme;
-
-    let el = document.getElementById("theme-vars");
-    if (!el) {
-      el = document.createElement("style");
-      el.id = "theme-vars";
-      document.head.appendChild(el);
+    if (qTheme && qTheme in themes) {
+      applyTheme(qTheme);
+      return;
     }
-    el.textContent = `:root { ${cssVars} }`;
 
-    document
-      .querySelector('meta[name="theme-color"]')
-      ?.setAttribute("content", themes[qTheme].themeColor);
-
-    // Apply or remove background image
-    const t = themes[qTheme];
-    document.body.style.background = t.bgImage
-      ? `var(--t-bg) url(${t.bgImage}) center/cover fixed`
-      : "var(--t-bg)";
+    const stored = localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null;
+    if (stored && stored in themes) {
+      applyTheme(stored);
+    }
   }, []);
 
   return null;

--- a/src/features/profile/components/ProfileView.tsx
+++ b/src/features/profile/components/ProfileView.tsx
@@ -6,6 +6,12 @@ import { API_BASE } from "@/lib/db";
 import cn from "@/lib/tailwindMerge";
 import type { Friend, AvailabilityStatus } from "@/lib/ui-types";
 import { AVAILABILITY_OPTIONS, EXPIRY_OPTIONS } from "@/lib/ui-types";
+import { themes } from "@/lib/themes";
+import type { ThemeName } from "@/lib/themes";
+import { applyTheme } from "@/app/components/ThemeHydrator";
+
+const THEME_STORAGE_KEY = "downto-theme";
+const THEME_NAMES = Object.keys(themes) as ThemeName[];
 
 const ProfileView = ({
   friends,
@@ -62,6 +68,12 @@ const ProfileView = ({
   const [editingIg, setEditingIg] = useState(false);
   const [igInput, setIgInput] = useState("");
   const [showArchived, setShowArchived] = useState(false);
+  const [activeTheme, setActiveTheme] = useState<ThemeName | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null;
+    if (stored && stored in themes) setActiveTheme(stored);
+  }, []);
 
   const handleStatusSelect = (status: AvailabilityStatus) => {
     if (status === "open") {
@@ -234,6 +246,39 @@ const ProfileView = ({
       </div>
       <span className="text-dim text-sm">→</span>
     </button>
+
+    {/* Theme Switcher */}
+    <div className="mt-6 bg-card rounded-2xl p-4 border border-border">
+      <div
+        className="font-mono text-tiny uppercase text-faint mb-3.5"
+        style={{ letterSpacing: "0.15em" }}
+      >
+        Theme
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {THEME_NAMES.map((name) => {
+          const isActive = activeTheme === name;
+          return (
+            <button
+              key={name}
+              onClick={() => {
+                setActiveTheme(name);
+                localStorage.setItem(THEME_STORAGE_KEY, name);
+                applyTheme(name);
+              }}
+              className={cn(
+                "rounded-xl py-2 px-3.5 font-mono text-xs cursor-pointer transition-all duration-200",
+                isActive
+                  ? "bg-dt text-black font-bold border border-transparent"
+                  : "bg-transparent text-muted border border-border-mid"
+              )}
+            >
+              {name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
 
     {/* Availability Meter */}
     <div


### PR DESCRIPTION
## Summary
- Adds theme picker pills (katsu/orlando/justin) to the Profile page
- Persists selection to localStorage, loads on startup
- Extracts `applyTheme()` from ThemeHydrator for reuse
- Priority: URL param > localStorage > default

## Test plan
- [ ] Tap theme pills on profile page — theme switches immediately
- [ ] Refresh app — theme persists from localStorage
- [ ] `?theme=orlando` in URL still overrides localStorage selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)