### PR TITLE
feat: add APNs sending for iOS native push

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/core": "^7.2.0",
         "@capacitor/ios": "^7.2.0",
         "@capacitor/push-notifications": "^7.0.6",
+        "@parse/node-apn": "^8.0.0",
         "@sentry/nextjs": "^10.42.0",
         "@supabase/supabase-js": "^2.95.3",
         "@types/node": "^25.2.3",
@@ -1768,6 +1769,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@parse/node-apn": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@parse/node-apn/-/node-apn-8.0.0.tgz",
+      "integrity": "sha512-blvU/V0FL3j7u2lstso1aInMw7yYrKg/6Ctr3Kc/7kleFatAfZswhzHk9d5lI4DUQBsUBun8nidgZHCY6sft+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.4.3",
+        "jsonwebtoken": "9.0.3",
+        "node-forge": "1.4.0",
+        "verror": "1.10.1"
+      },
+      "engines": {
+        "node": "20 || 22 || 24"
       }
     },
     "node_modules/@playwright/test": {
@@ -3543,6 +3559,15 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3826,6 +3851,12 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4039,6 +4070,15 @@
       "engines": {
         "node": ">=0.8.x"
       }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4423,6 +4463,28 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -4744,6 +4806,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4999,6 +5103,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-releases": {
@@ -5641,7 +5754,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6163,6 +6275,20 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@capacitor/core": "^7.2.0",
     "@capacitor/ios": "^7.2.0",
     "@capacitor/push-notifications": "^7.0.6",
+    "@parse/node-apn": "^8.0.0",
     "@sentry/nextjs": "^10.42.0",
     "@supabase/supabase-js": "^2.95.3",
     "@types/node": "^25.2.3",

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,5 +1,8 @@
 import webpush from 'web-push';
+import apn from '@parse/node-apn';
 import { getServiceClient } from '@/lib/supabase-admin';
+
+// ── Web Push (VAPID) ────────────────────────────────────────────────────────
 
 let vapidInitialized = false;
 
@@ -13,6 +16,40 @@ export function ensureVapid(): boolean {
   return true;
 }
 
+// ── APNs ────────────────────────────────────────────────────────────────────
+
+let apnsProvider: apn.Provider | null = null;
+let apnsInitialized = false;
+
+function ensureApns(): boolean {
+  if (apnsInitialized) return !!apnsProvider;
+  apnsInitialized = true;
+
+  const keyId = process.env.APNS_KEY_ID;
+  const teamId = process.env.APNS_TEAM_ID;
+  const bundleId = process.env.APNS_BUNDLE_ID ?? 'xyz.downto.app';
+  const keyBase64 = process.env.APNS_KEY_BASE64;
+  const keyPath = process.env.APNS_KEY_PATH;
+  const sandbox = process.env.APNS_SANDBOX === 'true';
+
+  if (!keyId || !teamId || (!keyBase64 && !keyPath)) return false;
+
+  const keyOption = keyBase64
+    ? { key: Buffer.from(keyBase64, 'base64').toString('utf-8') }
+    : { key: keyPath! };
+
+  apnsProvider = new apn.Provider({
+    token: { ...keyOption, keyId, teamId },
+    production: !sandbox,
+  });
+
+  // Store bundleId for later use
+  (apnsProvider as unknown as { _bundleId: string })._bundleId = bundleId;
+  return true;
+}
+
+// ── Shared types ────────────────────────────────────────────────────────────
+
 interface NotificationPayload {
   id?: string;
   user_id: string;
@@ -25,54 +62,106 @@ interface NotificationPayload {
   related_event_id?: string | null;
 }
 
-/** Send web-push to all of a user's subscriptions. Returns count sent. */
+// ── Send to all platforms ───────────────────────────────────────────────────
+
+/** Send push to all of a user's subscriptions (web + native). Returns count sent. */
 export async function sendPushToUser(notification: NotificationPayload): Promise<number> {
   const supabase = getServiceClient();
 
-  // Only send to web subscriptions for now — native APNs/FCM sending will be added in #246
   const { data: subscriptions } = await supabase
     .from('push_subscriptions')
     .select('*')
-    .eq('user_id', notification.user_id)
-    .eq('platform', 'web');
+    .eq('user_id', notification.user_id);
 
   if (!subscriptions?.length) return 0;
 
-  const payload = JSON.stringify({
-    title: notification.title,
-    body: notification.body || '',
-    type: notification.type,
-    relatedId: notification.related_squad_id || notification.related_check_id || notification.related_event_id || notification.related_user_id,
-  });
+  const webSubs = subscriptions.filter((s) => s.platform === 'web');
+  const iosSubs = subscriptions.filter((s) => s.platform === 'ios');
 
   const staleEndpoints: string[] = [];
+  const staleDeviceTokens: string[] = [];
   let sent = 0;
 
   const logRows: { notification_id: string | null; user_id: string; endpoint: string; status: string; error: string | null }[] = [];
 
-  await Promise.allSettled(
-    subscriptions.map(async (sub) => {
-      try {
-        await webpush.sendNotification(
-          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-          payload
-        );
-        sent++;
-        logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.endpoint, status: 'sent', error: null });
-      } catch (err: unknown) {
-        const statusCode = (err as { statusCode?: number }).statusCode;
-        if (statusCode === 404 || statusCode === 410) {
-          staleEndpoints.push(sub.endpoint);
-          logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.endpoint, status: 'stale', error: `endpoint returned ${statusCode}` });
-        } else {
-          const message = err instanceof Error ? err.message : String(err);
-          logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.endpoint, status: 'failed', error: message });
-        }
-      }
-    })
-  );
+  const relatedId = notification.related_squad_id || notification.related_check_id || notification.related_event_id || notification.related_user_id;
 
-  // Log delivery attempts — never let logging break push delivery
+  // ── Web push ──────────────────────────────────────────────────────────
+
+  if (webSubs.length > 0 && ensureVapid()) {
+    const payload = JSON.stringify({
+      title: notification.title,
+      body: notification.body || '',
+      type: notification.type,
+      relatedId,
+    });
+
+    await Promise.allSettled(
+      webSubs.map(async (sub) => {
+        try {
+          await webpush.sendNotification(
+            { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+            payload
+          );
+          sent++;
+          logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.endpoint, status: 'sent', error: null });
+        } catch (err: unknown) {
+          const statusCode = (err as { statusCode?: number }).statusCode;
+          if (statusCode === 404 || statusCode === 410) {
+            staleEndpoints.push(sub.endpoint);
+            logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.endpoint, status: 'stale', error: `endpoint returned ${statusCode}` });
+          } else {
+            const message = err instanceof Error ? err.message : String(err);
+            logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.endpoint, status: 'failed', error: message });
+          }
+        }
+      })
+    );
+  }
+
+  // ── APNs (iOS native) ─────────────────────────────────────────────────
+
+  if (iosSubs.length > 0 && ensureApns() && apnsProvider) {
+    const bundleId = (apnsProvider as unknown as { _bundleId: string })._bundleId ?? 'xyz.downto.app';
+
+    await Promise.allSettled(
+      iosSubs.map(async (sub) => {
+        if (!sub.device_token) return;
+        const note = new apn.Notification();
+        note.alert = { title: notification.title, body: notification.body || '' };
+        note.sound = 'default';
+        note.badge = 1;
+        note.topic = bundleId;
+        note.payload = {
+          type: notification.type,
+          relatedId,
+        };
+
+        try {
+          const result = await apnsProvider!.send(note, sub.device_token);
+          if (result.sent.length > 0) {
+            sent++;
+            logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.device_token, status: 'sent', error: null });
+          }
+          for (const failure of result.failed) {
+            const reason = failure.response?.reason ?? 'unknown';
+            if (reason === 'Unregistered' || reason === 'BadDeviceToken') {
+              staleDeviceTokens.push(sub.device_token);
+              logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.device_token, status: 'stale', error: reason });
+            } else {
+              logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.device_token, status: 'failed', error: reason });
+            }
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          logRows.push({ notification_id: notification.id ?? null, user_id: notification.user_id, endpoint: sub.device_token, status: 'failed', error: message });
+        }
+      })
+    );
+  }
+
+  // ── Cleanup ───────────────────────────────────────────────────────────
+
   try {
     if (logRows.length > 0) {
       await supabase.from('push_logs').insert(logRows);
@@ -85,6 +174,14 @@ export async function sendPushToUser(notification: NotificationPayload): Promise
       .delete()
       .eq('user_id', notification.user_id)
       .in('endpoint', staleEndpoints);
+  }
+
+  if (staleDeviceTokens.length > 0) {
+    await supabase
+      .from('push_subscriptions')
+      .delete()
+      .eq('user_id', notification.user_id)
+      .in('device_token', staleDeviceTokens);
   }
 
   return sent;


### PR DESCRIPTION
## Summary
- Sends push notifications via APNs to iOS native app users
- Web push unchanged — dual-path based on `platform` column
- Uses `@parse/node-apn` with token-based auth (.p8 key)
- Stale device tokens auto-cleaned
- Gracefully skips if APNs env vars not configured

## Env vars needed in Vercel
- `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_KEY_BASE64`, `APNS_BUNDLE_ID`, `APNS_SANDBOX`

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)