### PR TITLE
fix: soft 'can't make it' for date confirms

### DIFF
--- a/src/app/api/squads/confirm-date/route.ts
+++ b/src/app/api/squads/confirm-date/route.ts
@@ -62,7 +62,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: true });
   }
 
-  // --- "no" flow ---
+  // --- "no" flow --- user stays in squad but can't make the date
 
   // System message
   await adminClient
@@ -74,46 +74,10 @@ export async function POST(req: NextRequest) {
       is_system: true,
     });
 
-  // Remove from squad
-  await adminClient
-    .from('squad_members')
-    .delete()
-    .eq('squad_id', squadId)
-    .eq('user_id', user.id);
-
-  // Keep confirm row with response='no' so promote_from_waitlist can exclude this user
-
-  // Promote from waitlist if squad has a linked check
-  const { data: squad } = await adminClient
-    .from('squads')
-    .select('check_id')
-    .eq('id', squadId)
-    .single();
-
-  if (squad?.check_id) {
-    // Get the date_confirm message id for the promoted user's confirm row
-    const { data: confirmMsg } = await adminClient
-      .from('messages')
-      .select('id')
-      .eq('squad_id', squadId)
-      .eq('message_type', 'date_confirm')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .single();
-
-    if (confirmMsg) {
-      await adminClient.rpc('promote_from_waitlist', {
-        p_squad_id: squadId,
-        p_check_id: squad.check_id,
-        p_confirm_message_id: confirmMsg.id,
-      });
-    }
-  }
-
-  // Check if remaining members are all confirmed
+  // Check if remaining confirmable members are all in
   await checkAndAutoLock(adminClient, squadId);
 
-  return NextResponse.json({ ok: true, removed: true });
+  return NextResponse.json({ ok: true });
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,9 +101,10 @@ async function checkAndAutoLock(adminClient: any, squadId: string) {
   if (!confirms || confirms.length === 0) return;
 
   const allResponded = confirms.every((c: { response: string | null }) => c.response !== null);
-  const allYes = allResponded && confirms.every((c: { response: string }) => c.response === 'yes');
+  const hasAtLeastOneYes = confirms.some((c: { response: string | null }) => c.response === 'yes');
+  const canLock = allResponded && hasAtLeastOneYes;
 
-  if (allYes) {
+  if (canLock) {
     await adminClient
       .from('squads')
       .update({ date_status: 'locked' })

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -82,6 +82,11 @@ export default function ChatMessage({
               you&apos;re in
             </div>
           )}
+          {dateConfirmStatus === 'no' && !confirmLoading && (
+            <div className="font-mono text-tiny text-faint mt-1.5">
+              can&apos;t make it
+            </div>
+          )}
           {dateConfirmStatus === 'none' && !confirmLoading && (
             <div className="font-mono text-tiny text-neutral-700 mt-1.5">
               waiting for responses


### PR DESCRIPTION
## Summary
- "I'M OUT" → "CAN'T MAKE IT" — no longer removes user from squad
- Responding 'no' records the response but user stays as a member
- Removed confirmation dialog (soft action doesn't need it)
- Shows "can't make it" status in chat and confirm bar
- Auto-lock allows locking when all responded and at least one 'yes'

## Test plan
- [ ] Tap "CAN'T MAKE IT" → stays in squad, shows "can't make it" status
- [ ] "STILL DOWN" still works as before
- [ ] Date auto-locks when all members respond (mix of yes/no)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)