### PR TITLE
fix: iOS safe area, feed spacing, consolidate to 3-tab nav

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -65,7 +65,7 @@ const BottomNav = ({
   const idx = TABS.indexOf(tab);
 
   return (
-    <div className="shrink-0 px-4 pb-2 bg-bg">
+    <div className="shrink-0 px-4 pb-4 bg-bg">
       <div
         className="flex bg-card rounded-[18px] p-1 border border-border relative items-stretch"
         style={{ height: 60 }}
@@ -102,7 +102,7 @@ const BottomNav = ({
             </span>
             {t === "squads" && hasSquadsUnread && (
               <div
-                data-testid="plans-unread-dot"
+                data-testid="squads-unread-dot"
                 className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
               />
             )}

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -65,7 +65,7 @@ const BottomNav = ({
   const idx = TABS.indexOf(tab);
 
   return (
-    <div className="shrink-0 px-4 pb-4 bg-bg">
+    <div className="shrink-0 px-4 pb-2 bg-bg">
       <div
         className="flex bg-card rounded-[18px] p-1 border border-border relative items-stretch"
         style={{ height: 60 }}
@@ -102,7 +102,7 @@ const BottomNav = ({
             </span>
             {t === "squads" && hasSquadsUnread && (
               <div
-                data-testid="squads-unread-dot"
+                data-testid="plans-unread-dot"
                 className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
               />
             )}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -2,6 +2,9 @@
 
 import { color } from "@/lib/styles";
 
+/** Total header height = safe-area-inset-top + this value */
+export const HEADER_HEIGHT_PX = 52;
+
 const Header = ({
   unreadCount,
   onOpenNotifications,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ import OnboardingFriendsPopup from "@/features/friends/components/OnboardingFrie
 import GroupsView from "@/features/squads/components/GroupsView";
 import SquadChat from "@/features/squads/components/SquadChat";
 import ProfileView from "@/features/profile/components/ProfileView";
-import Header from "@/app/components/Header";
+import Header, { HEADER_HEIGHT_PX } from "@/app/components/Header";
 import BottomNav from "@/app/components/BottomNav";
 import Toast from "@/app/components/Toast";
 import NotificationsPanel from "@/features/notifications/components/NotificationsPanel";
@@ -727,7 +727,7 @@ export default function Home() {
         <div
           ref={scrollRef}
           className="h-full overflow-y-auto"
-          style={{ paddingTop: "calc(env(safe-area-inset-top, 16px) + 72px)" }}
+          style={{ paddingTop: `calc(env(safe-area-inset-top, 16px) + ${HEADER_HEIGHT_PX + 4}px)` }}
           onScroll={() => {
             const scrolled = (scrollRef.current?.scrollTop ?? 0) > 0;
             if (scrolled !== scrolledDown) setScrolledDown(scrolled);

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -204,7 +204,7 @@ export default function FeedView({
           onEnableNotifications={onEnableNotifications}
         />
       )}
-      <div className="px-4 pt-2">
+      <div className="px-4">
         {hasContent ? (
           <>
             {/* Pinned: expiring checks */}


### PR DESCRIPTION
## Summary
- Restore `min-h-screen` on body so the app extends into the iOS home indicator safe area (regression from iOS polish commits)
- Consolidate to 3-tab nav (Feed, Squads, You) — removes Calendar tab and CalendarView
- Tighten feed spacing below header using shared `HEADER_HEIGHT_PX` constant

## Test plan
- [ ] Verify app extends to physical bottom of screen on iPhone PWA
- [ ] Verify bottom nav has appropriate padding below the pill
- [ ] Verify feed content starts right below the header with minimal gap
- [ ] Verify 3-tab nav works correctly with sliding highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)