### PR TITLE
fix: show squad button for waitlisted users

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -344,7 +344,7 @@ export default function CheckCard({
                   >
                     {myCheckResponses[check.id] === "down" ? "✓ Down" : myCheckResponses[check.id] === "waitlist" ? "✓ Waitlisted" : "Down"}
                   </button>
-                  {myCheckResponses[check.id] === "down" && (() => {
+                  {(myCheckResponses[check.id] === "down" || myCheckResponses[check.id] === "waitlist") && (() => {
                     const memberCount = check.squadMemberCount ?? 0;
                     const maxSize = check.maxSquadSize;
                     const isUnlimited = maxSize == null;


### PR DESCRIPTION
## Summary
- Squad button block was gated on `myCheckResponses === "down"`, hiding it for waitlisted users
- Now renders for both "down" and "waitlist" so waitlisted users can navigate to squad chat (read-only)
- Also fixed prod data: michelle moved to waitlist, squad size capped at 5

## Test plan
- [ ] When waitlisted on a check with a squad, verify "Waitlisted" button appears
- [ ] Clicking "Waitlisted" navigates to squad chat in read-only mode
- [ ] Squad member count displays correctly (not overflowing max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)