### PR TITLE
fix: squad member count shows 0 for non-members

### DIFF
--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -65,7 +65,12 @@ function transformCheck(c: ActiveCheck, userId: string | null): InterestCheck {
     isYours: c.author_id === userId,
     maxSquadSize: c.max_squad_size,
     squadId: c.squads?.find((s) => !s.archived_at)?.id,
-    squadMemberCount: c.squads?.find((s) => !s.archived_at)?.members?.filter((m) => (m as { role?: string }).role !== 'waitlist')?.length ?? 0,
+    squadMemberCount: (() => {
+      const squad = c.squads?.find((s) => !s.archived_at);
+      const fromMembers = squad?.members?.filter((m) => (m as { role?: string }).role !== 'waitlist')?.length;
+      // Fall back to check_responses count when squad_members is empty due to RLS
+      return (fromMembers && fromMembers > 0) ? fromMembers : c.responses.filter((r) => r.response === 'down').length;
+    })(),
     inSquad: !!userId && !!(c.squads?.find((s) => !s.archived_at)?.members?.some((m) => (m as { user_id?: string }).user_id === userId && (m as { role?: string }).role !== 'waitlist')),
     isWaitlisted: !!userId && !!(c.squads?.find((s) => !s.archived_at)?.members?.some((m) => (m as { user_id?: string }).user_id === userId && (m as { role?: string }).role === 'waitlist')),
     eventDate: c.event_date ?? undefined,


### PR DESCRIPTION
## Summary
- `squad_members` RLS blocks non-members from seeing member rows
- This caused `squadMemberCount` to show `0/5` instead of actual count
- Falls back to counting `check_responses` with status "down" when squad_members is empty

## Test plan
- [ ] View a check with a squad you're NOT in — verify member count is correct (not 0)
- [ ] View a check with a squad you ARE in — verify count still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)