### PR TITLE
fix: close squad chat on un-down

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -414,6 +414,16 @@ export default function Home() {
     }
   }, [squadsHook.autoSelectSquadId, squadsHook.squads]);
 
+  // Close squad chat if user is no longer a member (e.g. after un-downing)
+  useEffect(() => {
+    if (!selectedSquad) return;
+    const stillIn = squadsHook.squads.some(s => s.id === selectedSquad.id);
+    if (!stillIn) {
+      setSelectedSquad(null);
+      setSquadChatOrigin(null);
+    }
+  }, [squadsHook.squads, selectedSquad]);
+
   // ─── Squad API handlers ──────────────────────────────────────────────────
 
   const handleSetSquadDate = async (squadDbId: string, date: string, time?: string | null, locked?: boolean) => {


### PR DESCRIPTION
## Summary
- Squad chat stayed open after un-downing from a check
- DB trigger correctly removes user from squad_members, but frontend didn't react
- Added useEffect that auto-closes squad chat when the squad disappears from user's list

## Test plan
- [ ] Open squad chat from a check, then un-down — verify chat closes
- [ ] Normal squad chat close (X button) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)