### PR TITLE
fix: don't open google maps when tapping event card venue

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -208,15 +208,9 @@ const EventCard = ({
                 {event.time && event.time !== "TBD" && ` ${event.time}`}
               </span>
               {event.venue && event.venue !== "TBD" && (
-                <a
-                  href={`https://maps.google.com/?q=${encodeURIComponent(event.venue)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                  className="font-mono text-xs text-dim mt-0.5 block no-underline"
-                >
+                <span className="font-mono text-xs text-dim mt-0.5 block">
                   {event.venue}
-                </a>
+                </span>
               )}
             </div>
 


### PR DESCRIPTION
## Summary
- Event card venue is now plain text instead of a Google Maps link
- Detail sheet venue link is unchanged

## Test plan
- [ ] Tap on a venue name on an event card — should not open Google Maps
- [ ] Open the event detail sheet — venue should still link out

🤖 Generated with [Claude Code](https://claude.com/claude-code)