### PR TITLE
fix: public events were never merged into feed

### DIFF
--- a/src/features/events/hooks/useEvents.ts
+++ b/src/features/events/hooks/useEvents.ts
@@ -30,6 +30,8 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
 
     setEvents((prev) => {
       const prevPeopleDown = new Map(prev.map((e) => [e.id, e.peopleDown]));
+      // Build a set of event IDs already covered by saved + friends to dedupe public
+      const friendsEventIdSet = new Set(friendsEvents.map((e) => e.id));
       const combined = [
         ...savedEvents.map((se) => ({
           id: se.event!.id,
@@ -82,6 +84,37 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
             note: e.note ?? undefined,
             saved: false,
             isDown: false,
+            visibility: e.visibility ?? 'public',
+            posterName: e.creator?.display_name ?? undefined,
+            posterAvatar: e.creator?.avatar_letter ?? undefined,
+            peopleDown: prevPeopleDown.get(e.id) ?? [],
+            neighborhood: e.neighborhood ?? undefined,
+            rawDate: e.date ?? undefined,
+            createdAt: e.created_at ?? undefined,
+          })),
+        ...publicEvents
+          .filter((e) => !savedEventIdSet.has(e.id) && !friendsEventIdSet.has(e.id))
+          .map((e) => ({
+            id: e.id,
+            createdBy: e.created_by ?? undefined,
+            title: e.title,
+            venue: e.venue ?? "",
+            date: e.date_display ?? "",
+            time: e.time_display ?? "",
+            vibe: e.vibes,
+            image: e.image_url ?? "",
+            igHandle: e.ig_handle ?? "",
+            igUrl: e.ig_url ?? undefined,
+            diceUrl: e.dice_url ?? undefined,
+            letterboxdUrl: e.letterboxd_url ?? undefined,
+            movieTitle: e.movie_metadata?.title,
+            movieYear: e.movie_metadata?.year,
+            movieDirector: e.movie_metadata?.director,
+            movieThumbnail: e.movie_metadata?.thumbnail,
+            note: e.note ?? undefined,
+            saved: false,
+            isDown: false,
+            isPublic: true,
             visibility: e.visibility ?? 'public',
             posterName: e.creator?.display_name ?? undefined,
             posterAvatar: e.creator?.avatar_letter ?? undefined,


### PR DESCRIPTION
## Summary
Public events from non-friend users were not visible in anyone's feed, despite being created with `is_public=true` and `visibility='public'`.

The bug: `useEvents.hydrateEvents()` declared `publicEvents` as a parameter and `page.tsx` fetched them via `db.getPublicEvents()` and passed them in, but the hook only merged `savedEvents` and `friendsEvents` into the array. Public events were silently dropped.

## Fix
Append public events to the merged list, deduped against saved + friends event IDs.

## Test plan
- [ ] Create a public event as user A
- [ ] Log in as unrelated user B (not a friend) — event should appear in feed
- [ ] Verify "Friends" visibility events still only appear for friends/FoF

🤖 Generated with [Claude Code](https://claude.com/claude-code)