### PR TITLE
feat: persistent squad-formed toast with dismiss button

### DIFF
--- a/src/app/components/Toast.tsx
+++ b/src/app/components/Toast.tsx
@@ -6,10 +6,12 @@ const Toast = ({
   message,
   action,
   onDismiss,
+  dismissible,
 }: {
   message: string;
   action?: (() => void) | null;
   onDismiss: () => void;
+  dismissible?: boolean;
 }) => (
   <div
     onClick={action ? () => {
@@ -32,9 +34,28 @@ const Toast = ({
       animation: "toastIn 0.3s ease",
       whiteSpace: "nowrap",
       cursor: action ? "pointer" : "default",
+      display: "flex",
+      alignItems: "center",
+      gap: 10,
     }}
   >
-    {message}{action ? " tap >" : ""}
+    <span>{message}{action ? " tap >" : ""}</span>
+    {dismissible && (
+      <button
+        onClick={(e) => { e.stopPropagation(); onDismiss(); }}
+        style={{
+          background: "transparent",
+          border: "none",
+          color: "#000",
+          cursor: "pointer",
+          padding: 0,
+          fontSize: 14,
+          fontWeight: 700,
+          lineHeight: 1,
+          opacity: 0.6,
+        }}
+      >×</button>
+    )}
   </div>
 );
 

--- a/src/app/hooks/useToast.ts
+++ b/src/app/hooks/useToast.ts
@@ -12,10 +12,12 @@ export function useToast() {
     setTimeout(() => setToastMsg(null), 2000);
   };
 
-  const showToastWithAction = (msg: string, action: () => void) => {
+  const showToastWithAction = (msg: string, action: () => void, persistent = false) => {
     setToastAction(() => action);
     setToastMsg(msg);
-    setTimeout(() => { setToastMsg(null); setToastAction(null); }, 4000);
+    if (!persistent) {
+      setTimeout(() => { setToastMsg(null); setToastAction(null); }, 4000);
+    }
   };
 
   const showToastRef = useRef(showToast);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,8 +130,10 @@ export default function Home() {
     showToast,
     openSquadIdRef: selectedSquadIdRef,
     onSquadCreated: (squadId: string) => {
-      setSquadChatOrigin(tab);
-      squadsHook.setAutoSelectSquadId(squadId);
+      showToastWithAction("squad formed!", () => {
+        setSquadChatOrigin(tab);
+        squadsHook.setAutoSelectSquadId(squadId);
+      }, true);
     },
     onAutoDown: async (eventId: string) => {
       await db.saveEvent(eventId).catch(() => {});
@@ -955,6 +957,7 @@ export default function Home() {
           message={toastMsg}
           action={toastAction}
           onDismiss={() => { setToastMsg(null); setToastAction(null); }}
+          dismissible={!!toastAction}
         />
       )}
 


### PR DESCRIPTION
## Summary
- When a squad auto-forms after responding down, show a persistent toast with tap-to-open and × to dismiss, instead of auto-navigating into the squad chat.
- Adds `dismissible` support to the Toast component and `showToastWithAction` in `useToast`.

## Test plan
- [ ] Respond down to an event that auto-forms a squad — toast appears with dismiss button
- [ ] Tap toast body → opens the squad chat
- [ ] Tap × → dismisses the toast without navigating
- [ ] Regular non-dismissible toasts still auto-hide as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)