### PR TITLE
feat: monochrome theme as default + remove Save to Cal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function Home() {
     newlyAddedId, setNewlyAddedId,
     archivedChecks, setArchivedChecks,
     hydrateEvents, hydrateSocialData,
-    toggleSave, toggleDown, handleEditEvent,
+    toggleDown, handleEditEvent,
   } = eventsHook;
 
   const [addModalOpen, setAddModalOpen] = useState(false);
@@ -698,7 +698,6 @@ export default function Home() {
       redownFromLeft: checksHook.redownFromLeft,
       events: eventsHook.events,
       newlyAddedEventId: eventsHook.newlyAddedId,
-      toggleSave: eventsHook.toggleSave,
       toggleDown: eventsHook.toggleDown,
     }}>
     <div className="flex flex-col h-dvh overflow-x-hidden">

--- a/src/features/checks/context/FeedContext.tsx
+++ b/src/features/checks/context/FeedContext.tsx
@@ -26,7 +26,6 @@ export interface FeedContextValue {
   redownFromLeft: (checkId: string) => void;
 
   // — Event actions —
-  toggleSave: (eventId: string) => void;
   toggleDown: (eventId: string) => Promise<void>;
 }
 

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -10,7 +10,6 @@ import EventActionsSheet from "./EventActionsSheet";
 const EventCard = ({
   event,
   userId,
-  onToggleSave,
   onToggleDown,
   onOpenSocial,
   onLongPress,
@@ -19,7 +18,6 @@ const EventCard = ({
 }: {
   event: Event;
   userId?: string | null;
-  onToggleSave: () => void;
   onToggleDown: () => void;
   onOpenSocial: () => void;
   onLongPress?: () => void;
@@ -82,18 +80,6 @@ const EventCard = ({
   );
 
   const actionButtons = (
-    <div className="flex gap-2">
-      <button
-        onClick={onToggleSave}
-        className={cn(
-          "flex-1 rounded-lg py-1.5 font-mono text-tiny font-bold cursor-pointer uppercase tracking-[0.08em]",
-          event.saved
-            ? "bg-dt text-on-accent border-none"
-            : "bg-transparent text-dt border border-dt"
-        )}
-      >
-        {event.saved ? "✓ Saved" : "Save to Cal"}
-      </button>
       <button
         onClick={onToggleDown}
         className={cn(
@@ -105,7 +91,6 @@ const EventCard = ({
       >
         {event.isDown ? <><span>DOWN</span><svg width="12" height="12" viewBox="0 0 256 256" fill="currentColor" className="inline ml-1"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg></> : "DOWN ?"}
       </button>
-    </div>
   );
 
   const hasDetails = !!(event.posterName || event.note || event.movieTitle || event.vibe.length > 0 || sourceLink);

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -83,10 +83,10 @@ const EventCard = ({
       <button
         onClick={onToggleDown}
         className={cn(
-          "flex-1 rounded-lg py-1.5 font-mono text-tiny font-bold cursor-pointer uppercase tracking-[0.08em] border",
+          "rounded-full py-1.5 px-3 font-mono text-tiny font-bold cursor-pointer whitespace-nowrap",
           event.isDown
-            ? "bg-down-active-bg text-down-active-text border-none"
-            : "bg-down-idle-bg text-dt border-down-idle-border"
+            ? "bg-dt text-on-accent border-none"
+            : "bg-transparent text-primary border border-border-mid"
         )}
       >
         {event.isDown ? <><span>DOWN</span><svg width="12" height="12" viewBox="0 0 256 256" fill="currentColor" className="inline ml-1"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg></> : "DOWN ?"}

--- a/src/features/events/hooks/useEvents.ts
+++ b/src/features/events/hooks/useEvents.ts
@@ -162,26 +162,6 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
     setEvents((prev) => prev.map(enrichEvent));
   }, []);
 
-  const toggleSave = (id: string) => {
-    const event = events.find((e) => e.id === id);
-    if (!event) return;
-    const newSaved = !event.saved;
-    setEvents((prev) =>
-      prev.map((e) => e.id === id ? { ...e, saved: newSaved } : e)
-    );
-    showToast(newSaved ? "Added to your calendar \u2713" : "Removed from calendar");
-    if (event.id) {
-      (newSaved ? db.saveEvent(event.id) : db.unsaveEvent(event.id))
-        .catch((err) => {
-          logError("toggleSave", err, { eventId: id });
-          setEvents((prev) =>
-            prev.map((e) => e.id === id ? { ...e, saved: !newSaved } : e)
-          );
-          showToast("Failed to save \u2014 try again");
-        });
-    }
-  };
-
   const toggleDown = async (id: string) => {
     const event = events.find((e) => e.id === id);
     if (!event) return;
@@ -260,7 +240,6 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
     setArchivedChecks,
     hydrateEvents,
     hydrateSocialData,
-    toggleSave,
     toggleDown,
     handleEditEvent,
   };

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -135,7 +135,6 @@ export default function FeedView({
     events,
     newlyAddedEventId,
     unhideCheck,
-    toggleSave,
     toggleDown,
   } = useFeedContext();
 
@@ -272,7 +271,6 @@ export default function FeedView({
                   key={item.data.id}
                   event={item.data}
                   userId={userId}
-                  onToggleSave={() => toggleSave(item.data.id)}
                   onToggleDown={() => toggleDown(item.data.id)}
                   onOpenSocial={() => onOpenSocial(item.data)}
                   onLongPress={

--- a/src/lib/themes/index.ts
+++ b/src/lib/themes/index.ts
@@ -3,11 +3,12 @@ import { guava } from "./guava";
 import { acid } from "./acid";
 import { firefly } from "./firefly";
 import { midnight } from "./midnight";
+import { monochrome } from "./monochrome";
 import type { ThemeName, ThemeTokens } from "./types";
 
-export const themes: Record<ThemeName, ThemeTokens> = { guava, acid, firefly, midnight };
+export const themes: Record<ThemeName, ThemeTokens> = { guava, acid, firefly, midnight, monochrome };
 
-export const DEFAULT_THEME: ThemeName = "guava";
+export const DEFAULT_THEME: ThemeName = "monochrome";
 
 export function getThemeName(): ThemeName {
   const envTheme = process.env.NEXT_PUBLIC_THEME as ThemeName | undefined;

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -1,0 +1,35 @@
+import type { ThemeTokens } from "./types";
+
+export const monochrome: ThemeTokens = {
+  accent: "#000000",
+  bg: "#FFFFFF",
+  card: "#FFFFFF",
+  surface: "#F0F0F0",
+  deep: "#E5E5E5",
+  text: "#1A1A1A",
+  muted: "#666666",
+  dim: "#888888",
+  faint: "#BBBBBB",
+  border: "#E0E0E0",
+  borderLight: "#D0D0D0",
+  borderMid: "#C0C0C0",
+  pool: "#666666",
+
+  danger: "#CC0000",
+  success: "#2D8A2D",
+  warn: "#B37300",
+  info: "#4A7DAA",
+  squad: "#666666",
+
+  accentFaint: "rgba(0,0,0,0.03)",
+  accentSubtle: "rgba(0,0,0,0.06)",
+  accentLight: "rgba(0,0,0,0.12)",
+  accentMid: "rgba(0,0,0,0.5)",
+
+  onAccent: "#fff",
+
+  fontMono: "var(--font-exo), sans-serif",
+  fontSerif: "var(--font-sora), sans-serif",
+
+  themeColor: "#FFFFFF",
+};

--- a/src/lib/themes/types.ts
+++ b/src/lib/themes/types.ts
@@ -1,4 +1,4 @@
-export type ThemeName = "guava" | "acid" | "firefly" | "midnight";
+export type ThemeName = "guava" | "acid" | "firefly" | "midnight" | "monochrome";
 
 export interface ThemeTokens {
   // Core palette

--- a/src/lib/ui-types.ts
+++ b/src/lib/ui-types.ts
@@ -145,7 +145,7 @@ export const TABS = ["feed", "squads", "profile"] as const;
 export type Tab = (typeof TABS)[number];
 
 export const AVAILABILITY_OPTIONS: { value: AvailabilityStatus; label: string; emoji: string; color: string }[] = [
-  { value: "open", label: "open to friends!", emoji: "✨", color: "#E8FF5A" },
+  { value: "open", label: "open to friends!", emoji: "✨", color: "var(--color-dt)" },
   { value: "awkward", label: "available, but awkward", emoji: "👀", color: "#ffaa5a" },
   { value: "not-available", label: "not available rn", emoji: "🌙", color: "#666" },
 ];


### PR DESCRIPTION
## Summary
- Add monochrome theme (black & white, grayscale) and set as default
- Remove Save to Cal button and all toggleSave infrastructure
- Fix availability status color to follow theme accent (var(--color-dt))
- Match event down button style to check card (rounded-full pill)

## Test plan
- [ ] App loads with monochrome (b&w) theme by default
- [ ] Theme switcher in profile still works for other themes
- [ ] "open to friends" text is visible (black) in monochrome
- [ ] No "Save to Cal" button on event cards
- [ ] Down button on events matches check card style

🤖 Generated with [Claude Code](https://claude.com/claude-code)