### PR TITLE
fix: admin dashboard scroll not working

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -160,7 +160,7 @@ export default function AdminPage() {
   ];
 
   return (
-    <div className="flex-1 bg-bg px-4 py-6 flex flex-col max-w-[640px] w-full mx-auto overflow-x-hidden overflow-y-auto">
+    <div className="fixed inset-0 bg-bg px-4 py-6 flex flex-col max-w-[640px] w-full mx-auto overflow-x-hidden overflow-y-auto">
       <h1 className="font-serif text-primary mb-5" style={{ fontSize: 28 }}>
         Admin
       </h1>


### PR DESCRIPTION
## Summary
Global `html, body { overflow: hidden }` blocks body scroll on the admin page. Fixed by using `fixed inset-0` with `overflow-y-auto` on the admin container.

## Test plan
- [ ] Admin dashboard is scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)