### PR TITLE
fix: allow ngrok cross-origin requests in dev

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,7 +35,7 @@ const isCapacitorBuild = process.env.CAPACITOR_BUILD === "true";
 
 const nextConfig: NextConfig = {
   ...(isCapacitorBuild && { output: "export" }),
-  allowedDevOrigins: ["http://127.0.0.1"],
+  allowedDevOrigins: ["http://127.0.0.1", "*.ngrok-free.dev"],
   reactStrictMode: true,
   typescript: {
     // Type errors are caught in dev/IDE; skip during build to save ~8s on Vercel


### PR DESCRIPTION
## Summary
Next.js 16 blocks cross-origin dev requests. Added `*.ngrok-free.dev` wildcard to `allowedDevOrigins` in next.config.ts.

## Test plan
- [ ] ngrok tunnel loads without "no link element found for chunk" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)