### PR TITLE
fix: squad fading bucket triggered too early

### DIFF
--- a/src/features/squads/components/GroupsView.tsx
+++ b/src/features/squads/components/GroupsView.tsx
@@ -18,13 +18,16 @@ const getEventSortKey = (s: Squad): number => {
 
 const isFading = (s: Squad): boolean => {
   const now = Date.now();
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  // Event is "fading" only once it's been 24h since the event time
   if (s.eventIsoDate) {
     const t = new Date(s.eventIsoDate).getTime();
-    if (!Number.isNaN(t) && t < now) return true;
+    if (!Number.isNaN(t) && now - t > DAY_MS) return true;
   }
+  // Or when the squad is within 24h of its own expiry
   if (s.expiresAt) {
     const ms = new Date(s.expiresAt).getTime() - now;
-    if (!Number.isNaN(ms) && ms < 24 * 60 * 60 * 1000) return true;
+    if (!Number.isNaN(ms) && ms < DAY_MS) return true;
   }
   return false;
 };


### PR DESCRIPTION
## Summary
Events happening "today" were being placed in the FADING bucket because their `eventIsoDate` parses as midnight. By afternoon, `eventTime < now` is true and the squad falls into FADING — even though the event hasn't happened yet.

Fix: fade only when it's been more than 24h since the event.

## Test plan
- [ ] Squad for event happening today appears in UPCOMING (or NEW MESSAGES)
- [ ] Squad for event that ended yesterday (>24h ago) appears in FADING
- [ ] Squad with expiresAt within 24h still appears in FADING

🤖 Generated with [Claude Code](https://claude.com/claude-code)