### PR TITLE
fix: restrict interest check edit to author

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -180,13 +180,13 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className="p-4 cursor-pointer"
-          onClick={(e) => {
+          className={`p-4 ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
+          onClick={(check.isYours || check.isCoAuthor) ? (e) => {
             // Only open modal if click wasn't on an interactive element
             const target = e.target as HTMLElement;
             if (target.closest("button") || target.closest("a") || target.closest("input") || target.closest("textarea")) return;
             setEditModalOpen(true);
-          }}
+          } : undefined}
         >
           {check.movieTitle && (
             <div

--- a/supabase/migrations/20260416000001_restrict_check_edit_to_author.sql
+++ b/supabase/migrations/20260416000001_restrict_check_edit_to_author.sql
@@ -1,0 +1,17 @@
+-- Revert: restrict interest_checks UPDATE to author (and accepted co-authors).
+-- The previous policy allowed any friend/FoF viewer to edit, which let
+-- unrelated users change check titles.
+
+DROP POLICY IF EXISTS "Viewers can update interest checks" ON public.interest_checks;
+DROP POLICY IF EXISTS "Users can update own interest checks" ON public.interest_checks;
+
+CREATE POLICY "Author and co-authors can update interest checks" ON public.interest_checks
+  FOR UPDATE USING (
+    author_id = (SELECT auth.uid())
+    OR EXISTS (
+      SELECT 1 FROM public.check_co_authors
+      WHERE check_id = interest_checks.id
+        AND user_id = (SELECT auth.uid())
+        AND status = 'accepted'
+    )
+  );


### PR DESCRIPTION
## Summary
Non-authors could edit the title of any check they could see. Locking UPDATE back down to author + accepted co-authors, both at the RLS layer and in the UI (tap-to-edit only for owners).

## Test plan
- [ ] Tap own check card → EditCheckModal opens
- [ ] Tap someone else's check card → nothing happens (no cursor-pointer)
- [ ] Attempt direct API update as non-author → 42501 permission denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)