### PR TITLE
Move comments into event detail sheet

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -90,6 +90,18 @@ const Header = ({
             </div>
           )}
         </button>
+        {/* Sort toggle */}
+        {showSort && sortBy && onSortChange && (
+          <button
+            onClick={() => onSortChange(sortBy === 'recent' ? 'upcoming' : 'recent')}
+            className="bg-transparent border-none cursor-pointer p-2 flex items-center justify-center"
+            title={sortBy === 'recent' ? 'Sort by upcoming' : 'Sort by recent'}
+          >
+            <svg width="18" height="18" viewBox="0 0 256 256" fill={sortBy === 'recent' ? color.text : color.accent}>
+              <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm64-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h56A8,8,0,0,1,192,128Z"/>
+            </svg>
+          </button>
+        )}
         {/* Add event button */}
         <div className="relative">
           {glowAdd && (
@@ -113,19 +125,7 @@ const Header = ({
         </div>
       </div>
     </div>
-    {showSort && sortBy && onSortChange && (
-      <div className="absolute right-5 top-1/2 -translate-y-1/2" style={{ paddingTop: "env(safe-area-inset-top, 16px)" }}>
-        <button
-          onClick={() => onSortChange(sortBy === 'recent' ? 'upcoming' : 'recent')}
-          className="bg-transparent border-none cursor-pointer p-2 flex items-center justify-center"
-          title={sortBy === 'recent' ? 'Sort by upcoming' : 'Sort by recent'}
-        >
-          <svg width="18" height="18" viewBox="0 0 256 256" fill={sortBy === 'recent' ? color.text : color.accent}>
-            <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm64-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h56A8,8,0,0,1,192,128Z"/>
-          </svg>
-        </button>
-      </div>
-    )}
+
   </div>
 );
 

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -37,11 +37,11 @@ const Header = ({
     {/* Blur layer — smooth 8-stop eased fade */}
     <div className="absolute pointer-events-none transition-opacity duration-300" style={{
       inset: "0 0 -24px 0",
-      opacity: scrolled ? 1 : 0.2,
+      opacity: scrolled ? 1 : 0.5,
       backdropFilter: "blur(40px)",
       WebkitBackdropFilter: "blur(40px)",
-      mask: "linear-gradient(to bottom, black 30%, rgba(0,0,0,0.9) 45%, rgba(0,0,0,0.7) 55%, rgba(0,0,0,0.5) 65%, rgba(0,0,0,0.3) 75%, rgba(0,0,0,0.15) 85%, rgba(0,0,0,0.05) 93%, transparent 100%)",
-      WebkitMaskImage: "linear-gradient(to bottom, black 30%, rgba(0,0,0,0.9) 45%, rgba(0,0,0,0.7) 55%, rgba(0,0,0,0.5) 65%, rgba(0,0,0,0.3) 75%, rgba(0,0,0,0.15) 85%, rgba(0,0,0,0.05) 93%, transparent 100%)",
+      mask: "linear-gradient(to bottom, black 0%, rgba(0,0,0,0.9) 45%, rgba(0,0,0,0.7) 55%, rgba(0,0,0,0.5) 65%, rgba(0,0,0,0.3) 75%, rgba(0,0,0,0.15) 85%, rgba(0,0,0,0.05) 93%, transparent 100%)",
+      WebkitMaskImage: "linear-gradient(to bottom, black 0%, rgba(0,0,0,0.9) 45%, rgba(0,0,0,0.7) 55%, rgba(0,0,0,0.5) 65%, rgba(0,0,0,0.3) 75%, rgba(0,0,0,0.15) 85%, rgba(0,0,0,0.05) 93%, transparent 100%)",
     }} />
     {/* Color tint — smooth fade with noise dithering */}
     <div className="absolute pointer-events-none transition-opacity duration-300" style={{
@@ -59,12 +59,8 @@ const Header = ({
       mask: "linear-gradient(to bottom, transparent 30%, black 60%, transparent 100%)",
       WebkitMaskImage: "linear-gradient(to bottom, transparent 30%, black 60%, transparent 100%)",
     }} />
-    {/* Solid cover behind status bar only */}
-    <div className="absolute top-0 left-0 right-0 pointer-events-none" style={{
-      height: "env(safe-area-inset-top, 16px)",
-      background: "var(--color-bg)",
-    }} />
-    <div className="px-5 pb-1 flex justify-between items-center relative">
+
+    <div className="px-5 pb-0 flex justify-between items-center relative">
       <h1
         className="font-serif text-dt font-normal"
         style={{ fontSize: 24, letterSpacing: "-0.06em" }}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -72,6 +72,18 @@ const Header = ({
         downto
       </h1>
       <div className="flex items-center gap-2.5">
+        {/* Sort toggle */}
+        {showSort && sortBy && onSortChange && (
+          <button
+            onClick={() => onSortChange(sortBy === 'recent' ? 'upcoming' : 'recent')}
+            className="bg-transparent border-none cursor-pointer p-2 flex items-center justify-center"
+            title={sortBy === 'recent' ? 'Sort by upcoming' : 'Sort by recent'}
+          >
+            <svg width="18" height="18" viewBox="0 0 256 256" fill={sortBy === 'recent' ? color.text : color.accent}>
+              <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm64-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h56A8,8,0,0,1,192,128Z"/>
+            </svg>
+          </button>
+        )}
         {/* Bell icon */}
         <button
           onClick={onOpenNotifications}
@@ -90,18 +102,6 @@ const Header = ({
             </div>
           )}
         </button>
-        {/* Sort toggle */}
-        {showSort && sortBy && onSortChange && (
-          <button
-            onClick={() => onSortChange(sortBy === 'recent' ? 'upcoming' : 'recent')}
-            className="bg-transparent border-none cursor-pointer p-2 flex items-center justify-center"
-            title={sortBy === 'recent' ? 'Sort by upcoming' : 'Sort by recent'}
-          >
-            <svg width="18" height="18" viewBox="0 0 256 256" fill={sortBy === 'recent' ? color.text : color.accent}>
-              <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm64-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h56A8,8,0,0,1,192,128Z"/>
-            </svg>
-          </button>
-        )}
         {/* Add event button */}
         <div className="relative">
           {glowAdd && (

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -114,28 +114,16 @@ const Header = ({
       </div>
     </div>
     {showSort && sortBy && onSortChange && (
-      <div className="flex justify-center pb-1.5 relative">
-        <div className="inline-flex rounded-full p-0.5 relative" style={{ border: "1px solid #CDC999" }}>
-          {/* Sliding pill highlight */}
-          <div
-            className="absolute top-0.5 bottom-0.5 rounded-full bg-dt transition-all duration-200 ease-out"
-            style={{
-              left: sortBy === 'recent' ? 2 : '50%',
-              right: sortBy === 'recent' ? '50%' : 2,
-            }}
-          />
-          {(['recent', 'upcoming'] as const).map((mode) => (
-            <button
-              key={mode}
-              onClick={() => onSortChange(mode)}
-              className={`relative z-[1] rounded-full w-[5.5rem] py-1 font-mono text-tiny font-bold tracking-[0.08em] uppercase cursor-pointer border-none bg-transparent transition-colors duration-200 text-center ${
-                sortBy === mode ? 'text-on-accent' : 'text-dim'
-              }`}
-            >
-              {mode === 'recent' ? 'Recent' : 'Upcoming'}
-            </button>
-          ))}
-        </div>
+      <div className="absolute right-5 top-1/2 -translate-y-1/2" style={{ paddingTop: "env(safe-area-inset-top, 16px)" }}>
+        <button
+          onClick={() => onSortChange(sortBy === 'recent' ? 'upcoming' : 'recent')}
+          className="bg-transparent border-none cursor-pointer p-2 flex items-center justify-center"
+          title={sortBy === 'recent' ? 'Sort by upcoming' : 'Sort by recent'}
+        >
+          <svg width="18" height="18" viewBox="0 0 256 256" fill={sortBy === 'recent' ? color.text : color.accent}>
+            <path d="M128,24A104,104,0,1,0,232,128,104.11,104.11,0,0,0,128,24Zm0,192a88,88,0,1,1,88-88A88.1,88.1,0,0,1,128,216Zm64-88a8,8,0,0,1-8,8H128a8,8,0,0,1-8-8V72a8,8,0,0,1,16,0v48h56A8,8,0,0,1,192,128Z"/>
+          </svg>
+        </button>
       </div>
     )}
   </div>

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -69,7 +69,7 @@
 
 /* Mono font spacing */
 .font-mono {
-  letter-spacing: 0.04em;
+  letter-spacing: -0.01em;
 }
 
 .font-serif {

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -72,6 +72,10 @@
   letter-spacing: 0.04em;
 }
 
+.font-serif {
+  letter-spacing: -0.03em;
+}
+
 /* "Down" state check card - lime wash */
 .check-down {
   background-color: #ECFFA5 !important;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -74,6 +74,7 @@
 
 .font-serif {
   letter-spacing: -0.04em;
+  font-weight: 700;
 }
 
 /* "Down" state check card - lime wash */

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -39,7 +39,7 @@
 
   /* Font family */
   --font-serif: var(--font-inter), sans-serif;
-  --font-mono: var(--font-ibm-plex-mono), monospace;
+  --font-mono: var(--font-inter), sans-serif;
 
   --animate-fade-in: fadeIn 0.3s ease;
   --animate-slide-up: slideUp 0.3s ease-out;
@@ -71,7 +71,6 @@
 .font-mono {
   letter-spacing: -0.02em;
   font-weight: 300;
-  -webkit-text-stroke: 0.3px;
 }
 
 .font-serif {

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,7 +38,7 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-spectral), serif;
+  --font-serif: var(--font-outfit), sans-serif;
   --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,7 +38,7 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-sora), sans-serif;
+  --font-serif: var(--font-ibm-plex-mono), monospace;
   --font-mono: var(--font-exo), sans-serif;
 
   --animate-fade-in: fadeIn 0.3s ease;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,7 +38,7 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-outfit), sans-serif;
+  --font-serif: var(--font-inter), sans-serif;
   --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,7 +38,7 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-exo), sans-serif;
+  --font-serif: var(--font-dm-serif-display), serif;
   --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;
@@ -69,11 +69,11 @@
 
 /* Mono font spacing */
 .font-mono {
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
 }
 
 .font-serif {
-  letter-spacing: -0.03em;
+  letter-spacing: -0.04em;
 }
 
 /* "Down" state check card - lime wash */

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,7 +38,7 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-dm-serif-display), serif;
+  --font-serif: var(--font-cormorant), serif;
   --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -78,6 +78,12 @@
   border-color: transparent !important;
 }
 
+/* Author's own check card - pale green wash, no border */
+.check-mine {
+  background-color: #F0FFD8 !important;
+  border-color: transparent !important;
+}
+
 @layer base {
   html, body {
     overflow: hidden;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -69,7 +69,7 @@
 
 /* Mono font spacing */
 .font-mono {
-  letter-spacing: -0.02em;
+  letter-spacing: -0.04em;
   font-weight: 300;
   -webkit-text-stroke: 0.15px;
 }

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -70,7 +70,8 @@
 /* Mono font spacing */
 .font-mono {
   letter-spacing: -0.02em;
-  font-weight: 700;
+  font-weight: 300;
+  -webkit-text-stroke: 0.3px;
 }
 
 .font-serif {

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -39,7 +39,7 @@
 
   /* Font family */
   --font-serif: var(--font-inter), sans-serif;
-  --font-mono: var(--font-inter), sans-serif;
+  --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;
   --animate-slide-up: slideUp 0.3s ease-out;
@@ -71,6 +71,7 @@
 .font-mono {
   letter-spacing: -0.02em;
   font-weight: 300;
+  -webkit-text-stroke: 0.15px;
 }
 
 .font-serif {

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,8 +38,8 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-ibm-plex-mono), monospace;
-  --font-mono: var(--font-exo), sans-serif;
+  --font-serif: var(--font-exo), sans-serif;
+  --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;
   --animate-slide-up: slideUp 0.3s ease-out;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -38,7 +38,7 @@
   --color-neutral-925: #FCFFE2;
 
   /* Font family */
-  --font-serif: var(--font-cormorant), serif;
+  --font-serif: var(--font-spectral), serif;
   --font-mono: var(--font-ibm-plex-mono), monospace;
 
   --animate-fade-in: fadeIn 0.3s ease;

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -70,11 +70,11 @@
 /* Mono font spacing */
 .font-mono {
   letter-spacing: -0.02em;
+  font-weight: 700;
 }
 
 .font-serif {
   letter-spacing: -0.04em;
-  font-weight: 700;
 }
 
 /* "Down" state check card - lime wash */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -91,7 +91,7 @@ export default function RootLayout({
           input, textarea, select { font-size: 16px !important; }
         `}</style>
       </head>
-      <body className="flex min-h-screen justify-center bg-bg font-mono font-light text-[#6B6B5A] antialiased">
+      <body className="flex min-h-screen justify-center bg-bg font-mono text-[#6B6B5A] antialiased">
         <ThemeHydrator />
         <NativeStatusBar />
         <Grain />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono } from 'next/font/google';
+import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
@@ -27,6 +27,11 @@ const instrumentSerif = Instrument_Serif({
 const spaceMono = Space_Mono({
   weight: ['400', '700'],
   variable: '--font-space-mono',
+  subsets: ['latin'],
+});
+const ibmPlexMono = IBM_Plex_Mono({
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
 });
 
@@ -62,7 +67,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable}`}
+      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable}`}
     >
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Outfit } from 'next/font/google';
+import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Inter } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
@@ -34,9 +34,9 @@ const ibmPlexMono = IBM_Plex_Mono({
   variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
 });
-const outfit = Outfit({
+const inter = Inter({
   weight: ['300', '400', '500', '600', '700'],
-  variable: '--font-outfit',
+  variable: '--font-inter',
   subsets: ['latin'],
 });
 
@@ -72,7 +72,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${outfit.variable}`}
+      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${inter.variable}`}
     >
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, DM_Serif_Display } from 'next/font/google';
+import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Cormorant } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
@@ -34,9 +34,9 @@ const ibmPlexMono = IBM_Plex_Mono({
   variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
 });
-const dmSerifDisplay = DM_Serif_Display({
-  weight: '400',
-  variable: '--font-dm-serif-display',
+const cormorant = Cormorant({
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-cormorant',
   subsets: ['latin'],
 });
 
@@ -72,7 +72,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${dmSerifDisplay.variable}`}
+      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${cormorant.variable}`}
     >
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono } from 'next/font/google';
+import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, DM_Serif_Display } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
@@ -32,6 +32,11 @@ const spaceMono = Space_Mono({
 const ibmPlexMono = IBM_Plex_Mono({
   weight: ['400', '500', '600', '700'],
   variable: '--font-ibm-plex-mono',
+  subsets: ['latin'],
+});
+const dmSerifDisplay = DM_Serif_Display({
+  weight: '400',
+  variable: '--font-dm-serif-display',
   subsets: ['latin'],
 });
 
@@ -67,7 +72,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable}`}
+      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${dmSerifDisplay.variable}`}
     >
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Cormorant } from 'next/font/google';
+import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Spectral } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
@@ -34,9 +34,9 @@ const ibmPlexMono = IBM_Plex_Mono({
   variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
 });
-const cormorant = Cormorant({
-  weight: ['300', '400', '500', '600', '700'],
-  variable: '--font-cormorant',
+const spectral = Spectral({
+  weight: ['400', '500', '600', '700'],
+  variable: '--font-spectral',
   subsets: ['latin'],
 });
 
@@ -72,7 +72,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${cormorant.variable}`}
+      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${spectral.variable}`}
     >
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,7 +30,7 @@ const spaceMono = Space_Mono({
   subsets: ['latin'],
 });
 const ibmPlexMono = IBM_Plex_Mono({
-  weight: ['400', '500', '600', '700'],
+  weight: ['200', '300', '400', '500', '600', '700'],
   variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
 });
@@ -91,7 +91,7 @@ export default function RootLayout({
           input, textarea, select { font-size: 16px !important; }
         `}</style>
       </head>
-      <body className="flex min-h-screen justify-center bg-bg font-mono font-medium text-[#6B6B5A] antialiased">
+      <body className="flex min-h-screen justify-center bg-bg font-mono font-light text-[#6B6B5A] antialiased">
         <ThemeHydrator />
         <NativeStatusBar />
         <Grain />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Spectral } from 'next/font/google';
+import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Outfit } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
@@ -34,9 +34,9 @@ const ibmPlexMono = IBM_Plex_Mono({
   variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
 });
-const spectral = Spectral({
-  weight: ['400', '500', '600', '700'],
-  variable: '--font-spectral',
+const outfit = Outfit({
+  weight: ['300', '400', '500', '600', '700'],
+  variable: '--font-outfit',
   subsets: ['latin'],
 });
 
@@ -72,7 +72,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${spectral.variable}`}
+      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${outfit.variable}`}
     >
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ export default function Home() {
     newlyAddedId, setNewlyAddedId,
     archivedChecks, setArchivedChecks,
     hydrateEvents, hydrateSocialData,
-    toggleSave, toggleDown, handleEditEvent,
+    toggleDown, handleEditEvent,
   } = eventsHook;
 
   const [addModalOpen, setAddModalOpen] = useState(false);
@@ -698,7 +698,6 @@ export default function Home() {
       redownFromLeft: checksHook.redownFromLeft,
       events: eventsHook.events,
       newlyAddedEventId: eventsHook.newlyAddedId,
-      toggleSave: eventsHook.toggleSave,
       toggleDown: eventsHook.toggleDown,
     }}>
     <div className="flex flex-col h-dvh overflow-x-hidden">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -738,7 +738,7 @@ export default function Home() {
         <div
           ref={scrollRef}
           className="h-full overflow-y-auto"
-          style={{ paddingTop: `calc(env(safe-area-inset-top, 16px) + ${(tab === 'feed' ? HEADER_HEIGHT_WITH_TABS_PX : HEADER_HEIGHT_PX) + HEADER_OFFSET_PX}px)`, paddingBottom: "calc(72px + env(safe-area-inset-bottom, 0px))" }}
+          style={{ paddingTop: `calc(env(safe-area-inset-top, 16px) + ${(HEADER_HEIGHT_PX) + HEADER_OFFSET_PX}px)`, paddingBottom: "calc(72px + env(safe-area-inset-bottom, 0px))" }}
           onScroll={() => {
             const scrolled = (scrollRef.current?.scrollTop ?? 0) > 0;
             if (scrolled !== scrolledDown) setScrolledDown(scrolled);

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -354,18 +354,6 @@ export default function CheckCard({
               </div>
             )}
 
-                  </div>
-                ) : (
-                  <span className="font-mono text-tiny text-faint">
-                    {initialCommentCount} comment{initialCommentCount !== 1 ? "s" : ""}
-                  </span>
-                )}
-              </div>
-
-            </div>
-          )}
-
-
           </div>
         </div>
       </div>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -99,19 +99,12 @@ export default function CheckCard({
   } = useFeedContext();
   const [isExpanded, setIsExpanded] = useState(false);
   const hasComments = initialCommentCount > 0;
-  const [isCommentsOpen, setIsCommentsOpen] = useState(hasComments);
-  const [commentsEverOpened, setCommentsEverOpened] = useState(hasComments);
+  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
+  const [commentsEverOpened, setCommentsEverOpened] = useState(false);
   const commentsRef = React.useRef<HTMLDivElement>(null);
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
-  // Auto-fetch and expand comments when count becomes available
-  useEffect(() => {
-    if (hasComments && !isCommentsOpen) {
-      openComments();
-      setCommentsEverOpened(true);
-      setIsCommentsOpen(true);
-    }
-  }, [check.id, hasComments]);
+
   // Also open when navigated via notification
   useEffect(() => {
     if (newlyAddedCheckId === check.id && !isCommentsOpen) {
@@ -191,7 +184,7 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className={`p-4 ${isCommentsOpen ? "pb-6" : ""} ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
+          className={`p-4  ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
           onClick={(check.isYours || check.isCoAuthor) ? (e) => {
             // Only open modal if click wasn't on an interactive element
             const target = e.target as HTMLElement;
@@ -394,6 +387,37 @@ export default function CheckCard({
                 )}
               </div>
             )}
+
+          {/* Last comment teaser — tap to expand full thread */}
+          {hasComments && !isCommentsOpen && (
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+                openComments();
+                setCommentsEverOpened(true);
+                setIsCommentsOpen(true);
+              }}
+              className="mt-2 cursor-pointer"
+            >
+              {comments.length > 0 ? (
+                <div className="flex items-center gap-2 min-w-0">
+                  <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${comments[comments.length - 1].isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+                    {comments[comments.length - 1].userAvatar}
+                  </div>
+                  <span className="font-mono text-tiny text-muted truncate min-w-0">
+                    <span className="text-dim">{comments[comments.length - 1].userName}:</span>{" "}{comments[comments.length - 1].text}
+                  </span>
+                  {initialCommentCount > 1 && (
+                    <span className="font-mono text-tiny text-faint shrink-0">+{initialCommentCount - 1}</span>
+                  )}
+                </div>
+              ) : (
+                <span className="font-mono text-tiny text-faint">
+                  {initialCommentCount} comment{initialCommentCount !== 1 ? "s" : ""}
+                </span>
+              )}
+            </div>
+          )}
 
           </div>
         </div>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -398,6 +398,9 @@ export default function CheckCard({
                   openComments();
                   setCommentsEverOpened(true);
                   setIsCommentsOpen(true);
+                  setTimeout(() => {
+                    commentsRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+                  }, 250);
                 }}
                 className="cursor-pointer"
               >

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -431,7 +431,7 @@ export default function CheckCard({
 
       {/* Comments — overlaps the bottom of the check card when open */}
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-4" : ""}`}
+        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-1" : ""}`}
         style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden" ref={commentsRef}>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -403,7 +403,7 @@ export default function CheckCard({
                 setCommentsEverOpened(true);
                 setIsCommentsOpen(true);
               }}
-              className="mt-2 cursor-pointer"
+              className="mt-3.5 cursor-pointer"
             >
               {comments.length > 0 ? (
                 <div className="flex items-center gap-2 min-w-0">

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -99,7 +99,7 @@ export default function CheckCard({
   } = useFeedContext();
   const [isExpanded, setIsExpanded] = useState(false);
   const hasComments = initialCommentCount > 0;
-  const [showInlineInput, setShowInlineInput] = useState(false);
+
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [commentsEverOpened, setCommentsEverOpened] = useState(false);
   const commentsRef = React.useRef<HTMLDivElement>(null);
@@ -329,13 +329,7 @@ export default function CheckCard({
               )}
 
               <div className="flex gap-1.5 items-center ml-auto flex-wrap justify-end">
-                <button
-                  onClick={(e) => { e.stopPropagation(); handleToggleComments(); }}
-                  className={`rounded-full py-1.5 px-3 font-mono text-tiny cursor-pointer flex items-center gap-1 ${isCommentsOpen ? "bg-[#F5F7EA] border border-dt text-dt" : "bg-[#F5F7EA] border border-[#CDC999] text-dt"}`}
-                >
-                  <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor"><path d="M132,24A100.11,100.11,0,0,0,32,124v84a16,16,0,0,0,16,16h84a100,100,0,0,0,0-200Zm0,184H48V124a84,84,0,1,1,84,84Z"/></svg>
-                  {commentCount > 0 && <span>{commentCount}</span>}
-                </button>
+
               {!check.isYours && (
                 <>
                   <button
@@ -401,7 +395,9 @@ export default function CheckCard({
               <div
                 onClick={(e) => {
                   e.stopPropagation();
-                  setShowInlineInput(true);
+                  openComments();
+                  setCommentsEverOpened(true);
+                  setIsCommentsOpen(true);
                 }}
                 className="cursor-pointer"
               >
@@ -414,17 +410,7 @@ export default function CheckCard({
                       <span className="text-dim">{comments[comments.length - 1].userName}:</span>{" "}{comments[comments.length - 1].text}
                     </span>
                     {initialCommentCount > 1 && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openComments();
-                          setCommentsEverOpened(true);
-                          setIsCommentsOpen(true);
-                        }}
-                        className="font-mono text-tiny text-faint shrink-0 bg-transparent border-none cursor-pointer p-0"
-                      >
-                        view all {initialCommentCount}
-                      </button>
+                      <span className="font-mono text-tiny text-faint shrink-0">+{initialCommentCount - 1}</span>
                     )}
                   </div>
                 ) : (
@@ -433,22 +419,7 @@ export default function CheckCard({
                   </span>
                 )}
               </div>
-              {showInlineInput && (
-                <div className="flex gap-2 items-center mt-2 min-w-0" onClick={(e) => e.stopPropagation()}>
-                  <input
-                    autoFocus
-                    value=""
-                    onChange={() => {}}
-                    onFocus={() => {
-                      openComments();
-                      setCommentsEverOpened(true);
-                      setIsCommentsOpen(true);
-                    }}
-                    placeholder="Add a comment…"
-                    className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
-                  />
-                </div>
-              )}
+
             </div>
           )}
 

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -105,6 +105,12 @@ export default function CheckCard({
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
 
+  // Auto-fetch comments for teaser (but don't expand)
+  useEffect(() => {
+    if (hasComments) {
+      openComments();
+    }
+  }, [check.id, hasComments]);
   // Also open when navigated via notification
   useEffect(() => {
     if (newlyAddedCheckId === check.id && !isCommentsOpen) {

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -104,12 +104,14 @@ export default function CheckCard({
   const commentsRef = React.useRef<HTMLDivElement>(null);
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
-  // Auto-fetch comments on mount when there are any
+  // Auto-fetch and expand comments when count becomes available
   useEffect(() => {
-    if (hasComments) {
+    if (hasComments && !isCommentsOpen) {
       openComments();
+      setCommentsEverOpened(true);
+      setIsCommentsOpen(true);
     }
-  }, [check.id]);
+  }, [check.id, hasComments]);
   // Also open when navigated via notification
   useEffect(() => {
     if (newlyAddedCheckId === check.id && !isCommentsOpen) {

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -244,7 +244,7 @@ export default function CheckCard({
           {/* Check text + expiry + actions */}
           <div className="mb-3">
             <div className="flex items-start gap-1.5">
-              <p className="font-serif text-lg text-primary m-0 font-normal leading-snug flex-1 tracking-[-0.01em]">
+              <p className="font-serif text-lg text-primary m-0 font-light leading-snug flex-1 tracking-[-0.01em]">
                 <Linkify coAuthors={check.coAuthors} onViewProfile={onViewProfile}>{check.text}</Linkify>
               </p>
               <div className="flex items-center gap-1 shrink-0 mt-1">

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -439,6 +439,7 @@ export default function CheckCard({
               userId={userId}
               friends={friendsList}
               onPost={postComment}
+              onCollapse={() => setIsCommentsOpen(false)}
             />
           )}
         </div>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -98,18 +98,20 @@ export default function CheckCard({
     hideCheck,
   } = useFeedContext();
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
-  const [commentsEverOpened, setCommentsEverOpened] = useState(false);
+  const hasComments = initialCommentCount > 0;
+  const [isCommentsOpen, setIsCommentsOpen] = useState(hasComments);
+  const [commentsEverOpened, setCommentsEverOpened] = useState(hasComments);
   const commentsRef = React.useRef<HTMLDivElement>(null);
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
-  // Auto-open comments when navigated to this check via notification
+  // Auto-open comments when there are any, or when navigated via notification
   useEffect(() => {
-    if (newlyAddedCheckId === check.id && !isCommentsOpen) {
+    if ((hasComments || newlyAddedCheckId === check.id) && !isCommentsOpen) {
       openComments();
+      setCommentsEverOpened(true);
       setIsCommentsOpen(true);
     }
-  }, [newlyAddedCheckId, check.id]);
+  }, [newlyAddedCheckId, check.id, hasComments]);
   const [editModalOpen, setEditModalOpen] = useState(false);
 
   const { comments, commentCount, openComments, postComment } = useCheckComments({

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -99,6 +99,7 @@ export default function CheckCard({
   } = useFeedContext();
   const [isExpanded, setIsExpanded] = useState(false);
   const hasComments = initialCommentCount > 0;
+  const [showInlineInput, setShowInlineInput] = useState(false);
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [commentsEverOpened, setCommentsEverOpened] = useState(false);
   const commentsRef = React.useRef<HTMLDivElement>(null);
@@ -394,33 +395,59 @@ export default function CheckCard({
               </div>
             )}
 
-          {/* Last comment teaser — tap to expand full thread */}
+          {/* Last comment teaser + inline input */}
           {hasComments && !isCommentsOpen && (
-            <div
-              onClick={(e) => {
-                e.stopPropagation();
-                openComments();
-                setCommentsEverOpened(true);
-                setIsCommentsOpen(true);
-              }}
-              className="mt-3.5 cursor-pointer"
-            >
-              {comments.length > 0 ? (
-                <div className="flex items-center gap-2 min-w-0">
-                  <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${comments[comments.length - 1].isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
-                    {comments[comments.length - 1].userAvatar}
+            <div className="mt-3.5">
+              <div
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowInlineInput(true);
+                }}
+                className="cursor-pointer"
+              >
+                {comments.length > 0 ? (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${comments[comments.length - 1].isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+                      {comments[comments.length - 1].userAvatar}
+                    </div>
+                    <span className="font-mono text-tiny text-muted truncate min-w-0">
+                      <span className="text-dim">{comments[comments.length - 1].userName}:</span>{" "}{comments[comments.length - 1].text}
+                    </span>
+                    {initialCommentCount > 1 && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          openComments();
+                          setCommentsEverOpened(true);
+                          setIsCommentsOpen(true);
+                        }}
+                        className="font-mono text-tiny text-faint shrink-0 bg-transparent border-none cursor-pointer p-0"
+                      >
+                        view all {initialCommentCount}
+                      </button>
+                    )}
                   </div>
-                  <span className="font-mono text-tiny text-muted truncate min-w-0">
-                    <span className="text-dim">{comments[comments.length - 1].userName}:</span>{" "}{comments[comments.length - 1].text}
+                ) : (
+                  <span className="font-mono text-tiny text-faint">
+                    {initialCommentCount} comment{initialCommentCount !== 1 ? "s" : ""}
                   </span>
-                  {initialCommentCount > 1 && (
-                    <span className="font-mono text-tiny text-faint shrink-0">+{initialCommentCount - 1}</span>
-                  )}
+                )}
+              </div>
+              {showInlineInput && (
+                <div className="flex gap-2 items-center mt-2 min-w-0" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    autoFocus
+                    value=""
+                    onChange={() => {}}
+                    onFocus={() => {
+                      openComments();
+                      setCommentsEverOpened(true);
+                      setIsCommentsOpen(true);
+                    }}
+                    placeholder="Add a comment…"
+                    className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
+                  />
                 </div>
-              ) : (
-                <span className="font-mono text-tiny text-faint">
-                  {initialCommentCount} comment{initialCommentCount !== 1 ? "s" : ""}
-                </span>
               )}
             </div>
           )}

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -181,7 +181,7 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className={`p-4 ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
+          className={`p-4 ${isCommentsOpen ? "pb-10" : ""} ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
           onClick={(check.isYours || check.isCoAuthor) ? (e) => {
             // Only open modal if click wasn't on an interactive element
             const target = e.target as HTMLElement;

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -256,7 +256,7 @@ export default function CheckCard({
               </div>
             </div>
             {(check.eventDateLabel || check.eventTime || check.location) && (() => {
-              const when = [check.eventDateLabel, check.eventTime].filter(Boolean).join(" ");
+              const when = [check.eventDateLabel, check.eventTime].filter(Boolean).join(" · ");
               if (!when && !check.location) return null;
               return (
                 <div className="flex justify-between items-baseline mt-2">

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -164,7 +164,7 @@ export default function CheckCard({
         ref={check.id === newlyAddedCheckId ? (el) => {
           if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
         } : undefined}
-        className={`overflow-hidden relative z-[1] ${
+        className={`overflow-hidden relative ${
           myCheckResponses[check.id] === "down" ? "check-down rounded-2xl" :
           (check.isYours || check.isCoAuthor) ? "check-mine rounded-2xl" :
           check.id === newlyAddedCheckId ? "bg-[#FFF5CC] border border-[#E8E0B0] rounded-sm" :
@@ -392,7 +392,7 @@ export default function CheckCard({
 
       {/* Comments — overlaps the bottom of the check card when open */}
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-out px-3 ${isCommentsOpen ? "-mt-3" : ""}`}
+        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] ${isCommentsOpen ? "-mt-7" : ""}`}
         style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden" ref={commentsRef}>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -392,7 +392,7 @@ export default function CheckCard({
 
       {/* Comments — overlaps the bottom of the check card when open */}
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-7" : ""}`}
+        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-4" : ""}`}
         style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden" ref={commentsRef}>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -159,11 +159,12 @@ export default function CheckCard({
 
   return (
     <>
+      <div className="mb-2">
       <div
         ref={check.id === newlyAddedCheckId ? (el) => {
           if (el) el.scrollIntoView({ behavior: "smooth", block: "center" });
         } : undefined}
-        className={`overflow-hidden mb-2 ${
+        className={`overflow-hidden relative z-[1] ${
           myCheckResponses[check.id] === "down" ? "check-down rounded-2xl" :
           (check.isYours || check.isCoAuthor) ? "check-mine rounded-2xl" :
           check.id === newlyAddedCheckId ? "bg-[#FFF5CC] border border-[#E8E0B0] rounded-sm" :
@@ -385,24 +386,28 @@ export default function CheckCard({
               </div>
             )}
 
-            {/* Comments section */}
-            <div
-              className="grid transition-[grid-template-rows] duration-200 ease-out"
-              style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
-            >
-              <div className="overflow-hidden" ref={commentsRef}>
-                {commentsEverOpened && (
-                  <CheckCommentsSection
-                    comments={comments}
-                    userId={userId}
-                    friends={friendsList}
-                    onPost={postComment}
-                  />
-                )}
-              </div>
-            </div>
           </div>
         </div>
+      </div>
+
+      {/* Comments — overlaps the bottom of the check card */}
+      <div
+        className="grid transition-[grid-template-rows] duration-200 ease-out -mt-4 px-2"
+        style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
+      >
+        <div className="overflow-hidden" ref={commentsRef}>
+          {commentsEverOpened && (
+            <div className="pt-6">
+              <CheckCommentsSection
+                comments={comments}
+                userId={userId}
+                friends={friendsList}
+                onPost={postComment}
+              />
+            </div>
+          )}
+        </div>
+      </div>
       </div>
 
       <EditCheckModal

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -100,26 +100,12 @@ export default function CheckCard({
   const [isExpanded, setIsExpanded] = useState(false);
   const hasComments = initialCommentCount > 0;
 
-  const [isCommentsOpen, setIsCommentsOpen] = useState(hasComments);
-  const [commentsEverOpened, setCommentsEverOpened] = useState(hasComments);
-  const commentsRef = React.useRef<HTMLDivElement>(null);
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
 
-  // Auto-fetch comments for teaser (but don't expand)
-  useEffect(() => {
-    if (hasComments) {
-      openComments();
-    }
-  }, [check.id, hasComments]);
-  // Also open when navigated via notification
-  useEffect(() => {
-    if (newlyAddedCheckId === check.id && !isCommentsOpen) {
-      openComments();
-      setCommentsEverOpened(true);
-      setIsCommentsOpen(true);
-    }
-  }, [newlyAddedCheckId, check.id]);
+
+
+  useEffect(() => { openComments(); }, [check.id]);
   const [editModalOpen, setEditModalOpen] = useState(false);
 
   const { comments, commentCount, openComments, postComment } = useCheckComments({
@@ -129,28 +115,7 @@ export default function CheckCard({
     initialCommentCount,
   });
 
-  const handleToggleComments = async () => {
-    if (!isCommentsOpen) {
-      await openComments();
-      setCommentsEverOpened(true);
-      setIsCommentsOpen(true);
-      setTimeout(() => {
-        const el = commentsRef.current;
-        if (!el) return;
-        const scrollParent = el.closest('[class*="overflow-y"]') || el.closest('[style*="overflow"]');
-        if (scrollParent) {
-          const elRect = el.getBoundingClientRect();
-          const parentRect = scrollParent.getBoundingClientRect();
-          const overflow = elRect.bottom - parentRect.bottom + 80;
-          if (overflow > 0) {
-            scrollParent.scrollBy({ top: overflow, behavior: "smooth" });
-          }
-        }
-      }, 250);
-    } else {
-      setIsCommentsOpen(false);
-    }
-  };
+
 
   const shareCheck = async () => {
     try { await db.markCheckShared(check.id); } catch { /* best-effort */ }
@@ -191,7 +156,7 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className={`p-4 ${isCommentsOpen ? "pb-6" : ""} ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
+          className={`p-4 ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
           onClick={(check.isYours || check.isCoAuthor) ? (e) => {
             // Only open modal if click wasn't on an interactive element
             const target = e.target as HTMLElement;
@@ -389,32 +354,6 @@ export default function CheckCard({
               </div>
             )}
 
-          {/* Last comment teaser + inline input */}
-          {hasComments && !isCommentsOpen && (
-            <div className="mt-3.5">
-              <div
-                onClick={(e) => {
-                  e.stopPropagation();
-                  openComments();
-                  setCommentsEverOpened(true);
-                  setIsCommentsOpen(true);
-                  setTimeout(() => {
-                    commentsRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" });
-                  }, 250);
-                }}
-                className="cursor-pointer"
-              >
-                {comments.length > 0 ? (
-                  <div className="flex items-center gap-2 min-w-0">
-                    <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${comments[comments.length - 1].isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
-                      {comments[comments.length - 1].userAvatar}
-                    </div>
-                    <span className="font-mono text-tiny text-muted truncate min-w-0">
-                      <span className="text-dim">{comments[comments.length - 1].userName}:</span>{" "}{comments[comments.length - 1].text}
-                    </span>
-                    {initialCommentCount > 1 && (
-                      <span className="font-mono text-tiny text-faint shrink-0">+{initialCommentCount - 1}</span>
-                    )}
                   </div>
                 ) : (
                   <span className="font-mono text-tiny text-faint">
@@ -426,41 +365,19 @@ export default function CheckCard({
             </div>
           )}
 
-          {/* Add comment link when no comments exist */}
-          {!hasComments && !isCommentsOpen && (
-            <div
-              onClick={(e) => {
-                e.stopPropagation();
-                openComments();
-                setCommentsEverOpened(true);
-                setIsCommentsOpen(true);
-              }}
-              className="mt-3 cursor-pointer"
-            >
-              <span className="font-mono text-tiny text-faint">add a comment…</span>
-            </div>
-          )}
 
           </div>
         </div>
       </div>
 
-      {/* Comments — overlaps the bottom of the check card when open */}
-      <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-3" : ""}`}
-        style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
-      >
-        <div className="overflow-hidden" ref={commentsRef}>
-          {commentsEverOpened && (
-            <CheckCommentsSection
-              comments={comments}
-              userId={userId}
-              friends={friendsList}
-              onPost={postComment}
-              onCollapse={() => setIsCommentsOpen(false)}
-            />
-          )}
-        </div>
+      {/* Inline comments */}
+      <div className="px-4 pb-3">
+        <CheckCommentsSection
+          comments={comments}
+          userId={userId}
+          friends={friendsList}
+          onPost={postComment}
+        />
       </div>
       </div>
 

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -244,7 +244,7 @@ export default function CheckCard({
           {/* Check text + expiry + actions */}
           <div className="mb-3">
             <div className="flex items-start gap-1.5">
-              <p className="font-serif text-lg text-primary m-0 font-light leading-snug flex-1 tracking-[-0.01em]">
+              <p className="font-serif text-lg text-primary m-0 font-normal leading-snug flex-1 tracking-[-0.01em]">
                 <Linkify coAuthors={check.coAuthors} onViewProfile={onViewProfile}>{check.text}</Linkify>
               </p>
               <div className="flex items-center gap-1 shrink-0 mt-1">

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -181,7 +181,7 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className={`p-4 ${isCommentsOpen ? "pb-10" : ""} ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
+          className={`p-4 ${isCommentsOpen ? "pb-6" : ""} ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
           onClick={(check.isYours || check.isCoAuthor) ? (e) => {
             // Only open modal if click wasn't on an interactive element
             const target = e.target as HTMLElement;

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -104,14 +104,20 @@ export default function CheckCard({
   const commentsRef = React.useRef<HTMLDivElement>(null);
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
-  // Auto-open comments when there are any, or when navigated via notification
+  // Auto-fetch comments on mount when there are any
   useEffect(() => {
-    if ((hasComments || newlyAddedCheckId === check.id) && !isCommentsOpen) {
+    if (hasComments) {
+      openComments();
+    }
+  }, [check.id]);
+  // Also open when navigated via notification
+  useEffect(() => {
+    if (newlyAddedCheckId === check.id && !isCommentsOpen) {
       openComments();
       setCommentsEverOpened(true);
       setIsCommentsOpen(true);
     }
-  }, [newlyAddedCheckId, check.id, hasComments]);
+  }, [newlyAddedCheckId, check.id]);
   const [editModalOpen, setEditModalOpen] = useState(false);
 
   const { comments, commentCount, openComments, postComment } = useCheckComments({

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -358,8 +358,8 @@ export default function CheckCard({
         </div>
       </div>
 
-      {/* Inline comments */}
-      <div className="px-4 pb-3">
+      {/* Inline comments — overlaps bottom of card */}
+      <div className="-mt-3 px-1.5 pb-2 relative z-[2]">
         <CheckCommentsSection
           comments={comments}
           userId={userId}

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -458,7 +458,7 @@ export default function CheckCard({
 
       {/* Comments — overlaps the bottom of the check card when open */}
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-1" : ""}`}
+        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-3" : ""}`}
         style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden" ref={commentsRef}>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -392,7 +392,7 @@ export default function CheckCard({
 
       {/* Comments — overlaps the bottom of the check card when open */}
       <div
-        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] ${isCommentsOpen ? "-mt-7" : ""}`}
+        className={`grid transition-[grid-template-rows] duration-200 ease-out relative z-[2] px-1.5 ${isCommentsOpen ? "-mt-7" : ""}`}
         style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden" ref={commentsRef}>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -390,21 +390,19 @@ export default function CheckCard({
         </div>
       </div>
 
-      {/* Comments — overlaps the bottom of the check card */}
+      {/* Comments — overlaps the bottom of the check card when open */}
       <div
-        className="grid transition-[grid-template-rows] duration-200 ease-out -mt-4 px-2"
+        className={`grid transition-[grid-template-rows] duration-200 ease-out px-3 ${isCommentsOpen ? "-mt-3" : ""}`}
         style={{ gridTemplateRows: isCommentsOpen ? "1fr" : "0fr" }}
       >
         <div className="overflow-hidden" ref={commentsRef}>
           {commentsEverOpened && (
-            <div className="pt-6">
-              <CheckCommentsSection
-                comments={comments}
-                userId={userId}
-                friends={friendsList}
-                onPost={postComment}
-              />
-            </div>
+            <CheckCommentsSection
+              comments={comments}
+              userId={userId}
+              friends={friendsList}
+              onPost={postComment}
+            />
           )}
         </div>
       </div>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -100,8 +100,8 @@ export default function CheckCard({
   const [isExpanded, setIsExpanded] = useState(false);
   const hasComments = initialCommentCount > 0;
 
-  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
-  const [commentsEverOpened, setCommentsEverOpened] = useState(false);
+  const [isCommentsOpen, setIsCommentsOpen] = useState(hasComments);
+  const [commentsEverOpened, setCommentsEverOpened] = useState(hasComments);
   const commentsRef = React.useRef<HTMLDivElement>(null);
   const expandedRef = React.useRef<HTMLDivElement>(null);
 
@@ -191,7 +191,7 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className={`p-4  ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
+          className={`p-4 ${isCommentsOpen ? "pb-6" : ""} ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
           onClick={(check.isYours || check.isCoAuthor) ? (e) => {
             // Only open modal if click wasn't on an interactive element
             const target = e.target as HTMLElement;

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -259,13 +259,12 @@ export default function CheckCard({
               const when = [check.eventDateLabel, check.eventTime].filter(Boolean).join(" ");
               if (!when && !check.location) return null;
               return (
-                <p className="font-mono text-xs text-muted m-0 mt-2">
-                  {when}
-                  {when && check.location && " · "}
+                <div className="flex justify-between items-baseline mt-2">
+                  {when && <span className="font-mono text-xs text-muted">{when}</span>}
                   {check.location && (
-                    <span>{check.location}</span>
+                    <span className="font-mono text-xs text-muted text-right">{check.location}</span>
                   )}
-                </p>
+                </div>
               );
             })()}
             {(check.isYours || check.isCoAuthor) && !check.squadId && myCheckResponses[check.id] !== "down" && check.responses.some(r => r.status === "down") && (

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -426,6 +426,21 @@ export default function CheckCard({
             </div>
           )}
 
+          {/* Add comment link when no comments exist */}
+          {!hasComments && !isCommentsOpen && (
+            <div
+              onClick={(e) => {
+                e.stopPropagation();
+                openComments();
+                setCommentsEverOpened(true);
+                setIsCommentsOpen(true);
+              }}
+              className="mt-3 cursor-pointer"
+            >
+              <span className="font-mono text-tiny text-faint">add a comment…</span>
+            </div>
+          )}
+
           </div>
         </div>
       </div>

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -15,6 +15,7 @@ export default function CheckCommentsSection({
   onPost: (text: string, mentions?: string[]) => void;
 }) {
   const [text, setText] = useState("");
+  const [showAll, setShowAll] = useState(false);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -50,7 +51,7 @@ export default function CheckCommentsSection({
         <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
       ) : (
         <>
-          {comments.map((c) => (
+          {(showAll ? comments : comments.slice(0, 2)).map((c) => (
             <div key={c.id} className="flex items-center gap-2 min-w-0">
               <div className={`w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
                 {c.userAvatar}
@@ -67,6 +68,14 @@ export default function CheckCommentsSection({
               </span>
             </div>
           ))}
+          {!showAll && comments.length > 2 && (
+            <button
+              onClick={() => setShowAll(true)}
+              className="font-mono text-tiny text-dim cursor-pointer bg-transparent border-none p-0 mt-0.5"
+            >
+              + {comments.length - 2} more
+            </button>
+          )}
         </>
       )}
       </div>

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -79,8 +79,7 @@ export default function CheckCommentsSection({
           )}
         </>
       )}
-      </div>
-      {showInput && <div className="flex gap-2 items-center mt-2 min-w-0">
+      {showInput && <div className="flex gap-2 items-center mt-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
         <input
           ref={inputRef}
           value={text}
@@ -145,6 +144,7 @@ export default function CheckCommentsSection({
           </div>
         );
       })()}
+      </div>
     </div>
   );
 }

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -17,7 +17,7 @@ export default function CheckCommentsSection({
   onCollapse?: () => void;
 }) {
   const [text, setText] = useState("");
-  const [showAll, setShowAll] = useState(true);
+  const [showAll, setShowAll] = useState(false);
   const [showInput, setShowInput] = useState(false);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
@@ -54,7 +54,7 @@ export default function CheckCommentsSection({
         <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
       ) : (
         <>
-          {(showAll ? comments : comments.slice(0, 2)).map((c) => (
+          {(showAll ? comments : comments.slice(-3)).map((c) => (
             <div key={c.id} className="flex items-center gap-2 min-w-0">
               <div className={`w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
                 {c.userAvatar}
@@ -71,12 +71,12 @@ export default function CheckCommentsSection({
               </span>
             </div>
           ))}
-          {!showAll && comments.length > 2 && (
+          {!showAll && comments.length > 3 && (
             <button
               onClick={() => setShowAll(true)}
               className="font-mono text-tiny text-dim cursor-pointer bg-transparent border-none p-0 mt-0.5"
             >
-              + {comments.length - 2} more
+              + {comments.length - 3} more
             </button>
           )}
         </>

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -46,10 +46,11 @@ export default function CheckCommentsSection({
 
   return (
     <div>
+      <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5">
       {comments.length === 0 ? (
-        <span className="font-mono text-tiny text-dim">no comments yet</span>
+        <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
       ) : (
-        <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5">
+        <>
           {comments.map((c) => (
             <div key={c.id} className="flex gap-2 items-start">
               <div className={`size-5 rounded-full shrink-0 flex items-center justify-center font-mono text-tiny font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
@@ -74,8 +75,9 @@ export default function CheckCommentsSection({
               </div>
             </div>
           ))}
-        </div>
+        </>
       )}
+      </div>
       <div className="flex gap-2 items-center mt-2 min-w-0">
         <input
           ref={inputRef}

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -8,17 +8,14 @@ export default function CheckCommentsSection({
   userId,
   friends,
   onPost,
-  onCollapse,
 }: {
   comments: CommentUI[];
   userId: string | null;
   friends?: { id: string; name: string; avatar: string }[];
   onPost: (text: string, mentions?: string[]) => void;
-  onCollapse?: () => void;
 }) {
   const [text, setText] = useState("");
   const [showAll, setShowAll] = useState(false);
-  const [showInput, setShowInput] = useState(false);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -49,7 +46,7 @@ export default function CheckCommentsSection({
 
   return (
     <div>
-      <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5 cursor-pointer" onClick={(e) => { const t = e.target as HTMLElement; if (t.closest("button") || t.closest("a") || t.closest("input")) return; if (onCollapse) onCollapse(); else setShowInput(true); }}>
+      <div className="flex flex-col gap-1.5">
       {comments.length === 0 ? (
         <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
       ) : (
@@ -81,7 +78,7 @@ export default function CheckCommentsSection({
           )}
         </>
       )}
-      {showInput && <div className="flex gap-2 items-center mt-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
+      <div className="flex gap-2 items-center mt-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
         <input
           ref={inputRef}
           value={text}
@@ -116,8 +113,8 @@ export default function CheckCommentsSection({
         >
           Post
         </button>
-      </div>}
-      {showInput && mentionQuery !== null && mentionCandidates.length > 0 && (() => {
+      </div>
+      {mentionQuery !== null && mentionCandidates.length > 0 && (() => {
         const filtered = mentionCandidates.filter(c => c.name.toLowerCase().includes(mentionQuery));
         if (filtered.length === 0) return null;
         return (
@@ -146,7 +143,6 @@ export default function CheckCommentsSection({
           </div>
         );
       })()}
-      </div>
     </div>
   );
 }

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -15,6 +15,7 @@ export default function CheckCommentsSection({
   onPost: (text: string, mentions?: string[]) => void;
 }) {
   const [text, setText] = useState("");
+  const [showInput, setShowInput] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
@@ -45,7 +46,7 @@ export default function CheckCommentsSection({
   };
 
   return (
-    <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 flex flex-col gap-1.5">
+    <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 flex flex-col gap-1.5 cursor-pointer" onClick={() => !showInput && setShowInput(true)}>
       {comments.length === 0 ? (
         <span className="font-mono text-tiny text-faint py-0.5">no comments yet</span>
       ) : (
@@ -77,7 +78,7 @@ export default function CheckCommentsSection({
           )}
         </>
       )}
-      <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+      {showInput && <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
         <input
           ref={inputRef}
           value={text}
@@ -112,8 +113,8 @@ export default function CheckCommentsSection({
         >
           Post
         </button>
-      </div>
-      {mentionQuery !== null && mentionCandidates.length > 0 && (() => {
+      </div>}
+      {showInput && mentionQuery !== null && mentionCandidates.length > 0 && (() => {
         const filtered = mentionCandidates.filter(c => c.name.toLowerCase().includes(mentionQuery));
         if (filtered.length === 0) return null;
         return (

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -16,6 +16,7 @@ export default function CheckCommentsSection({
 }) {
   const [text, setText] = useState("");
   const [showAll, setShowAll] = useState(true);
+  const [showInput, setShowInput] = useState(false);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -46,7 +47,7 @@ export default function CheckCommentsSection({
 
   return (
     <div>
-      <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5">
+      <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5 cursor-pointer" onClick={() => setShowInput(true)}>
       {comments.length === 0 ? (
         <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
       ) : (
@@ -79,7 +80,7 @@ export default function CheckCommentsSection({
         </>
       )}
       </div>
-      <div className="flex gap-2 items-center mt-2 min-w-0">
+      {showInput && <div className="flex gap-2 items-center mt-2 min-w-0">
         <input
           ref={inputRef}
           value={text}
@@ -114,8 +115,8 @@ export default function CheckCommentsSection({
         >
           Post
         </button>
-      </div>
-      {mentionQuery !== null && mentionCandidates.length > 0 && (() => {
+      </div>}
+      {showInput && mentionQuery !== null && mentionCandidates.length > 0 && (() => {
         const filtered = mentionCandidates.filter(c => c.name.toLowerCase().includes(mentionQuery));
         if (filtered.length === 0) return null;
         return (

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -51,8 +51,8 @@ export default function CheckCommentsSection({
       ) : (
         <>
           {comments.map((c) => (
-            <div key={c.id} className="flex items-start gap-2 min-w-0">
-              <div className={`w-5 h-5 rounded-full shrink-0 mt-[1px] flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+            <div key={c.id} className="flex items-center gap-2 min-w-0">
+              <div className={`w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
                 {c.userAvatar}
               </div>
               <span className="font-mono text-xs text-muted shrink-0 leading-snug">

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useState, useRef } from "react";
-import { formatTimeAgo } from "@/lib/utils";
 import type { CommentUI } from "@/features/checks/hooks/useCheckComments";
 
 export default function CheckCommentsSection({
@@ -52,27 +51,20 @@ export default function CheckCommentsSection({
       ) : (
         <>
           {comments.map((c) => (
-            <div key={c.id} className="flex gap-2 items-start">
-              <div className={`size-5 rounded-full shrink-0 flex items-center justify-center font-mono text-tiny font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+            <div key={c.id} className="flex items-start gap-2 min-w-0">
+              <div className={`w-5 h-5 rounded-full shrink-0 mt-[1px] flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
                 {c.userAvatar}
               </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-baseline gap-1.5 mb-0.5">
-                  <span className={`font-mono text-tiny font-semibold ${c.isYours ? "text-dt" : "text-muted"}`}>
-                    {c.userName}
-                  </span>
-                  <span className="font-mono text-tiny text-faint">
-                    {formatTimeAgo(new Date(c.createdAt))}
-                  </span>
-                </div>
-                <p className="font-mono text-xs text-primary m-0 leading-[1.4]">
-                  {c.text.split(/(@\S+)/g).map((part, pi) =>
-                    part.startsWith("@") ? (
-                      <span key={pi} className="text-dt font-bold">{part}</span>
-                    ) : part
-                  )}
-                </p>
-              </div>
+              <span className="font-mono text-xs text-muted shrink-0 leading-snug">
+                {c.userName}
+              </span>
+              <span className="font-mono text-xs text-primary min-w-0 break-words leading-snug">
+                {c.text.split(/(@\S+)/g).map((part, pi) =>
+                  part.startsWith("@") ? (
+                    <span key={pi} className="text-dt font-bold">{part}</span>
+                  ) : part
+                )}
+              </span>
             </div>
           ))}
         </>

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -55,10 +55,10 @@ export default function CheckCommentsSection({
               <div className={`w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
                 {c.userAvatar}
               </div>
-              <span className="font-mono text-xs text-muted shrink-0 leading-snug">
+              <span className="font-mono text-tiny text-muted shrink-0 leading-snug">
                 {c.userName}
               </span>
-              <span className="font-mono text-xs text-primary min-w-0 break-words leading-snug">
+              <span className="font-mono text-tiny text-primary min-w-0 break-words leading-snug">
                 {c.text.split(/(@\S+)/g).map((part, pi) =>
                   part.startsWith("@") ? (
                     <span key={pi} className="text-dt font-bold">{part}</span>

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -8,11 +8,13 @@ export default function CheckCommentsSection({
   userId,
   friends,
   onPost,
+  onCollapse,
 }: {
   comments: CommentUI[];
   userId: string | null;
   friends?: { id: string; name: string; avatar: string }[];
   onPost: (text: string, mentions?: string[]) => void;
+  onCollapse?: () => void;
 }) {
   const [text, setText] = useState("");
   const [showAll, setShowAll] = useState(true);
@@ -47,7 +49,7 @@ export default function CheckCommentsSection({
 
   return (
     <div>
-      <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5 cursor-pointer" onClick={() => setShowInput(true)}>
+      <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5 cursor-pointer" onClick={(e) => { const t = e.target as HTMLElement; if (t.closest("button") || t.closest("a") || t.closest("input")) return; if (onCollapse) onCollapse(); else setShowInput(true); }}>
       {comments.length === 0 ? (
         <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
       ) : (

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -45,11 +45,11 @@ export default function CheckCommentsSection({
   };
 
   return (
-    <div className="mt-2.5 border-t border-border pt-2.5">
+    <div>
       {comments.length === 0 ? (
         <span className="font-mono text-tiny text-dim">no comments yet</span>
       ) : (
-        <div className="flex flex-col gap-2 mb-2">
+        <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 mb-2 flex flex-col gap-1.5">
           {comments.map((c) => (
             <div key={c.id} className="flex gap-2 items-start">
               <div className={`size-5 rounded-full shrink-0 flex items-center justify-center font-mono text-tiny font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -15,7 +15,7 @@ export default function CheckCommentsSection({
   onPost: (text: string, mentions?: string[]) => void;
 }) {
   const [text, setText] = useState("");
-  const [showAll, setShowAll] = useState(false);
+  const [showAll, setShowAll] = useState(true);
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -104,7 +104,7 @@ export default function CheckCommentsSection({
             }
             if (e.key === "Enter") handleSubmit();
           }}
-          placeholder="Add a comment\u2026"
+          placeholder="Add a comment…"
           className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
         />
         <button

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -45,10 +45,9 @@ export default function CheckCommentsSection({
   };
 
   return (
-    <div>
-      <div className="flex flex-col gap-1.5">
+    <div className="flex flex-col gap-1.5">
       {comments.length === 0 ? (
-        <span className="font-mono text-tiny text-dim py-0.5">no comments yet</span>
+        <span className="font-mono text-tiny text-faint py-0.5">no comments yet</span>
       ) : (
         <>
           {(showAll ? comments : comments.slice(-3)).map((c) => (
@@ -71,14 +70,14 @@ export default function CheckCommentsSection({
           {!showAll && comments.length > 3 && (
             <button
               onClick={() => setShowAll(true)}
-              className="font-mono text-tiny text-dim cursor-pointer bg-transparent border-none p-0 mt-0.5"
+              className="font-mono text-tiny text-faint cursor-pointer bg-transparent border-none p-0"
             >
               + {comments.length - 3} more
             </button>
           )}
         </>
       )}
-      <div className="flex gap-2 items-center mt-1.5 min-w-0" onClick={(e) => e.stopPropagation()}>
+      <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
         <input
           ref={inputRef}
           value={text}
@@ -104,7 +103,7 @@ export default function CheckCommentsSection({
             }
             if (e.key === "Enter") handleSubmit();
           }}
-          placeholder="Add a comment…"
+          placeholder="Add a comment\u2026"
           className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
         />
         <button

--- a/src/features/checks/components/CheckCommentsSection.tsx
+++ b/src/features/checks/components/CheckCommentsSection.tsx
@@ -45,7 +45,7 @@ export default function CheckCommentsSection({
   };
 
   return (
-    <div className="flex flex-col gap-1.5">
+    <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 flex flex-col gap-1.5">
       {comments.length === 0 ? (
         <span className="font-mono text-tiny text-faint py-0.5">no comments yet</span>
       ) : (

--- a/src/features/checks/hooks/useCheckComments.ts
+++ b/src/features/checks/hooks/useCheckComments.ts
@@ -23,7 +23,7 @@ function toCommentUI(c: CheckComment, userId: string | null): CommentUI {
     userId: c.user_id,
     text: c.text,
     createdAt: c.created_at,
-    userName: c.user_id === userId ? "You" : (c.user?.display_name ?? "Unknown"),
+    userName: c.user_id === userId ? (profile?.display_name ?? "You") : (c.user?.display_name ?? "Unknown"),
     userAvatar: c.user?.avatar_letter ?? "?",
     isYours: c.user_id === userId,
   };
@@ -77,7 +77,7 @@ export function useCheckComments({
       userId,
       text,
       createdAt: new Date().toISOString(),
-      userName: "You",
+      userName: profile?.display_name ?? "You",
       userAvatar: profile.avatar_letter,
       isYours: true,
     };

--- a/src/features/checks/hooks/useCheckComments.ts
+++ b/src/features/checks/hooks/useCheckComments.ts
@@ -23,7 +23,7 @@ function toCommentUI(c: CheckComment, userId: string | null): CommentUI {
     userId: c.user_id,
     text: c.text,
     createdAt: c.created_at,
-    userName: c.user_id === userId ? (profile?.display_name ?? "You") : (c.user?.display_name ?? "Unknown"),
+    userName: c.user?.display_name ?? "Unknown",
     userAvatar: c.user?.avatar_letter ?? "?",
     isYours: c.user_id === userId,
   };

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -12,7 +12,7 @@ import { checksReducer, initialChecksState, CheckActionType } from "@/features/c
 
 type ActiveCheck = Awaited<ReturnType<typeof db.getActiveChecks>>[number];
 
-function transformCheck(c: ActiveCheck, userId: string | null): InterestCheck {
+function transformCheck(c: ActiveCheck, userId: string | null, displayName?: string): InterestCheck {
   const now = new Date();
   const created = new Date(c.created_at);
   const msElapsed = now.getTime() - created.getTime();
@@ -57,7 +57,7 @@ function transformCheck(c: ActiveCheck, userId: string | null): InterestCheck {
     expiresIn,
     expiryPercent,
     responses: c.responses.map((r) => ({
-      name: r.user_id === userId ? "You" : (r.user?.display_name ?? "Unknown"),
+      name: r.user_id === userId ? (displayName ?? r.user?.display_name ?? "You") : (r.user?.display_name ?? "Unknown"),
       avatar: r.user?.avatar_letter ?? "?",
       status: r.response,
       odbc: r.user_id,
@@ -118,7 +118,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
         db.getActiveChecks(),
         db.getFofAnnotations().catch(() => [] as { check_id: string; via_friend_name: string }[]),
       ]);
-      const transformedChecks = activeChecks.map((c) => transformCheck(c, userId));
+      const transformedChecks = activeChecks.map((c) => transformCheck(c, userId, profile?.display_name));
       if (fofAnnotations.length > 0) {
         const viaMap = new Map(fofAnnotations.map((a) => [a.check_id, a.via_friend_name]));
         for (const c of transformedChecks) {
@@ -138,7 +138,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     hiddenIds: string[],
     fofAnnotations?: { check_id: string; via_friend_name: string }[]
   ) => {
-    const transformedChecks = activeChecks.map((c) => transformCheck(c, userId));
+    const transformedChecks = activeChecks.map((c) => transformCheck(c, userId, profile?.display_name));
     if (fofAnnotations && fofAnnotations.length > 0) {
       const viaMap = new Map(fofAnnotations.map((a) => [a.check_id, a.via_friend_name]));
       for (const c of transformedChecks) {
@@ -152,7 +152,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     // sets checks + hiddenIds + myCheckResponses in one render
     const restoredResponses: Record<string, "down" | "waitlist"> = {};
     for (const c of transformedChecks) {
-      const myResponse = c.responses.find((r) => r.name === "You");
+      const myResponse = c.responses.find((r) => r.odbc === userId);
       if (myResponse && (myResponse.status === "down" || myResponse.status === "waitlist")) {
         restoredResponses[c.id] = myResponse.status;
       }

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -166,15 +166,15 @@ const EventCard = ({
                   <span className="bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full leading-none ml-2">new</span>
                 )}
               </div>
-              <p className="font-mono text-xs text-muted m-0 mt-2">
-                <span className="text-dt">
+              <div className="flex justify-between items-baseline mt-2">
+                <span className="font-mono text-xs text-muted">
                   {event.date}
-                  {event.time && event.time !== "TBD" && ` ${event.time}`}
+                  {event.time && event.time !== "TBD" && ` · ${event.time}`}
                 </span>
                 {event.venue && event.venue !== "TBD" && (
-                  <span>{" · "}{event.venue}</span>
+                  <span className="font-mono text-xs text-muted text-right">{event.venue}</span>
                 )}
-              </p>
+              </div>
             </div>
           </div>
 
@@ -197,7 +197,7 @@ const EventCard = ({
               className={cn(
                 "rounded-full py-1.5 px-3 font-mono text-tiny font-bold whitespace-nowrap cursor-pointer shrink-0",
                 event.isDown
-                  ? "bg-dt text-bg border-none"
+                  ? "bg-dt text-on-accent border-none"
                   : "bg-[#F5F7EA] text-dt border border-[#CDC999]"
               )}
             >

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -158,7 +158,7 @@ const EventCard = ({
             <div className="mb-3">
               <div className="flex justify-between items-start">
                 <h3
-                  className="font-serif text-lg text-primary m-0 leading-snug font-normal tracking-[-0.01em] flex-1"
+                  className="font-serif text-lg text-primary m-0 leading-snug font-light tracking-[-0.01em] flex-1"
                 >
                   {event.title}
                 </h3>

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { font } from "@/lib/styles";
 import type { Event } from "@/lib/ui-types";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
 import cn from "@/lib/tailwindMerge";
+import * as db from "@/lib/db";
 
 const EventCard = ({
   event,
@@ -29,6 +30,32 @@ const EventCard = ({
   const [showDetail, setShowDetail] = useState(false);
   const touchMoved = useRef(false);
   const touchStartPos = useRef({ x: 0, y: 0 });
+  // Event comments
+  const [evComments, setEvComments] = useState<{ id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean }[]>([]);
+  const [cmtText, setCmtText] = useState("");
+  useEffect(() => {
+    if (!event.id) return;
+    db.getEventComments(event.id).then((fetched) => {
+      setEvComments(fetched.map((c) => ({
+        id: c.id, userId: c.user_id,
+        userName: c.user?.display_name ?? "Unknown",
+        userAvatar: c.user?.avatar_letter ?? "?",
+        text: c.text, isYours: c.user_id === userId,
+      })));
+    }).catch(() => {});
+  }, [event.id, userId]);
+  const postCmt = useCallback(async () => {
+    const t = cmtText.trim();
+    if (!t || !event.id) return;
+    const opt = { id: `opt-${Date.now()}`, userId: userId ?? "", userName: "You", userAvatar: "?", text: t, isYours: true };
+    setEvComments((p) => [...p, opt]);
+    setCmtText("");
+    try {
+      const saved = await db.postEventComment(event.id, t);
+      setEvComments((p) => p.map((c) => c.id === opt.id ? { id: saved.id, userId: saved.user_id, userName: saved.user?.display_name ?? "You", userAvatar: saved.user?.avatar_letter ?? "?", text: saved.text, isYours: true } : c));
+    } catch { setEvComments((p) => p.filter((c) => c.id !== opt.id)); }
+  }, [cmtText, event.id, userId]);
+
   const poolPeople = event.peopleDown.filter((p) => p.inPool);
   const poolFriends = poolPeople.filter((p) => p.mutual);
   const poolStrangerCount = poolPeople.length - poolFriends.length;
@@ -203,6 +230,33 @@ const EventCard = ({
             >
               {event.isDown ? <><span>DOWN</span><svg width="12" height="12" viewBox="0 0 256 256" fill="currentColor" className="inline ml-1"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg></> : "DOWN ?"}
             </button>
+          </div>
+          {/* Inline comments */}
+          <div className="mt-3 flex flex-col gap-1.5">
+            {evComments.slice(-3).map((cm) => (
+              <div key={cm.id} className="flex items-center gap-2 min-w-0">
+                <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${cm.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+                  {cm.userAvatar}
+                </div>
+                <span className="font-mono text-tiny text-muted shrink-0">{cm.userName}</span>
+                <span className="font-mono text-tiny text-primary min-w-0 break-words">{cm.text}</span>
+              </div>
+            ))}
+            {evComments.length > 3 && (
+              <span className="font-mono text-tiny text-faint">+ {evComments.length - 3} more</span>
+            )}
+            <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+              <input
+                value={cmtText}
+                onChange={(e) => setCmtText(e.target.value.slice(0, 280))}
+                onKeyDown={(e) => { if (e.key === "Enter") postCmt(); }}
+                placeholder="Add a comment…"
+                className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
+              />
+              <button onClick={postCmt} className="shrink-0 bg-dt text-on-accent rounded-lg py-1.5 px-3 font-mono text-xs font-bold cursor-pointer">
+                Post
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -347,6 +347,38 @@ interface SheetProps {
   onViewProfile?: (userId: string) => void;
 }
 
+// Linkify URLs in text
+function LinkifyText({ children }: { children: string }) {
+  const urlRe = /(https?:\/\/[^\s),]+)/g;
+  const parts = children.split(urlRe);
+  if (parts.length === 1) return <>{children}</>;
+  return (
+    <>
+      {parts.map((part, i) =>
+        /^https?:\/\//.test(part) ? (
+          <a
+            key={i}
+            href={part}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="text-dt underline underline-offset-2 break-all"
+          >
+            {(() => {
+              try {
+                const u = new URL(part);
+                let d = u.host.replace(/^www\./, "") + u.pathname.replace(/\/$/, "");
+                if (d.length > 40) d = d.slice(0, 37) + "\u2026";
+                return d;
+              } catch { return part; }
+            })()}
+          </a>
+        ) : part
+      )}
+    </>
+  );
+}
+
 // Poster inline element (with optional note flowing on same line)
 function PosterInline({ event, userId, note, onViewProfile }: { event: Event; userId?: string | null; note?: boolean; onViewProfile?: (userId: string) => void }) {
   if (!event.posterName) return null;
@@ -373,7 +405,7 @@ function PosterInline({ event, userId, note, onViewProfile }: { event: Event; us
           {name}
         </span>
         {note && event.note && (
-          <span className="text-dim">{" "}{event.note}</span>
+          <span className="text-dim">{" "}<LinkifyText>{event.note}</LinkifyText></span>
         )}
       </div>
     </div>
@@ -601,7 +633,7 @@ function SheetHero(props: SheetProps) {
             <PosterInline event={event} userId={userId} note onViewProfile={props.onViewProfile} />
             {!event.posterName && event.note && (
               <div className="font-mono text-xs text-dim" style={{ lineHeight: 1.5 }}>
-                {event.note}
+                <LinkifyText>{event.note}</LinkifyText>
               </div>
             )}
           </div>

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -31,6 +31,7 @@ const EventCard = ({
   // Event comments
   const [evComments, setEvComments] = useState<{ id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean }[]>([]);
   const [cmtText, setCmtText] = useState("");
+  const [showEvInput, setShowEvInput] = useState(false);
   useEffect(() => {
     if (!event.id) return;
     db.getEventComments(event.id).then((fetched) => {
@@ -230,7 +231,7 @@ const EventCard = ({
             </button>
           </div>
           {/* Inline comments */}
-          <div className="mt-3 flex flex-col gap-1.5">
+          <div className="mt-3 flex flex-col gap-1.5 cursor-pointer" onClick={(e) => { e.stopPropagation(); if (!showEvInput) setShowEvInput(true); }}>
             {evComments.slice(-3).map((cm) => (
               <div key={cm.id} className="flex items-center gap-2 min-w-0">
                 <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${cm.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
@@ -243,7 +244,7 @@ const EventCard = ({
             {evComments.length > 3 && (
               <span className="font-mono text-tiny text-faint">+ {evComments.length - 3} more</span>
             )}
-            <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+            {showEvInput && <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
               <input
                 value={cmtText}
                 onChange={(e) => setCmtText(e.target.value.slice(0, 280))}

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -10,7 +10,6 @@ import * as db from "@/lib/db";
 const EventCard = ({
   event,
   userId,
-  onToggleSave,
   onToggleDown,
   onOpenSocial,
   onEdit,
@@ -19,7 +18,6 @@ const EventCard = ({
 }: {
   event: Event;
   userId?: string | null;
-  onToggleSave: () => void;
   onToggleDown: () => void;
   onOpenSocial: () => void;
   onEdit?: () => void;

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { font } from "@/lib/styles";
 import type { Event } from "@/lib/ui-types";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
 import cn from "@/lib/tailwindMerge";
@@ -28,10 +27,8 @@ const EventCard = ({
   const [showDetail, setShowDetail] = useState(false);
   const touchMoved = useRef(false);
   const touchStartPos = useRef({ x: 0, y: 0 });
-  // Event comments
+  // Event comments — state owned by card, sheet posts via callback
   const [evComments, setEvComments] = useState<{ id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean }[]>([]);
-  const [cmtText, setCmtText] = useState("");
-  const [showEvInput, setShowEvInput] = useState(false);
   useEffect(() => {
     if (!event.id) return;
     db.getEventComments(event.id).then((fetched) => {
@@ -43,17 +40,16 @@ const EventCard = ({
       })));
     }).catch(() => {});
   }, [event.id, userId]);
-  const postCmt = useCallback(async () => {
-    const t = cmtText.trim();
+  const postCmt = useCallback(async (text: string) => {
+    const t = text.trim();
     if (!t || !event.id) return;
     const opt = { id: `opt-${Date.now()}`, userId: userId ?? "", userName: "You", userAvatar: "?", text: t, isYours: true };
     setEvComments((p) => [...p, opt]);
-    setCmtText("");
     try {
       const saved = await db.postEventComment(event.id, t);
       setEvComments((p) => p.map((c) => c.id === opt.id ? { id: saved.id, userId: saved.user_id, userName: saved.user?.display_name ?? "You", userAvatar: saved.user?.avatar_letter ?? "?", text: saved.text, isYours: true } : c));
     } catch { setEvComments((p) => p.filter((c) => c.id !== opt.id)); }
-  }, [cmtText, event.id, userId]);
+  }, [event.id, userId]);
 
   const poolPeople = event.peopleDown.filter((p) => p.inPool);
   const poolFriends = poolPeople.filter((p) => p.mutual);
@@ -142,14 +138,32 @@ const EventCard = ({
           actionButtons={actionButtons}
           onOpenSocial={onOpenSocial}
           onViewProfile={onViewProfile}
+          comments={evComments}
+          onPostComment={postCmt}
           onClose={() => setShowDetail(false)}
         />
       )}
       <div
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
+        onTouchStart={(e) => {
+          touchMoved.current = false;
+          touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        }}
+        onTouchMove={(e) => {
+          const dx = e.touches[0].clientX - touchStartPos.current.x;
+          const dy = e.touches[0].clientY - touchStartPos.current.y;
+          if (Math.abs(dx) > 8 || Math.abs(dy) > 8) touchMoved.current = true;
+        }}
+        onClick={(e) => {
+          if (touchMoved.current) return;
+          const target = e.target as HTMLElement;
+          if (target.closest("button") || target.closest("a") || target.closest("input") || target.closest("textarea")) return;
+          if (onEdit) { onEdit(); return; }
+          setShowDetail(true);
+        }}
         className={cn(
-          "rounded-2xl overflow-hidden mb-2 transition-all relative border",
+          "rounded-2xl overflow-hidden mb-2 transition-all relative border cursor-pointer",
           isNew ? "border-dt/40" : hovered ? "border-[#CDC999]" : "border-[#CDC999]"
         )}
         style={{
@@ -159,48 +173,26 @@ const EventCard = ({
       >
         {bgImage}
         <div className="p-4 relative">
-          {/* Tappable area: opens edit modal for creator, detail sheet for everyone else */}
-          <div
-            onTouchStart={(e) => {
-              touchMoved.current = false;
-              touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-            }}
-            onTouchMove={(e) => {
-              const dx = e.touches[0].clientX - touchStartPos.current.x;
-              const dy = e.touches[0].clientY - touchStartPos.current.y;
-              if (Math.abs(dx) > 8 || Math.abs(dy) > 8) touchMoved.current = true;
-            }}
-            onClick={(e) => {
-              if (touchMoved.current) return;
-              const target = e.target as HTMLElement;
-              if (target.closest("button") || target.closest("a") || target.closest("input") || target.closest("textarea")) return;
-              // Creator → open edit modal directly. Everyone else → detail sheet.
-              if (onEdit) onEdit();
-              else setShowDetail(true);
-            }}
-            className="cursor-pointer"
-          >
-            {/* Title + date + social block */}
-            <div className="mb-3">
-              <div className="flex justify-between items-start">
-                <h3
-                  className="font-serif text-lg text-primary m-0 leading-snug font-normal tracking-[-0.01em] flex-1"
-                >
-                  {event.title}
-                </h3>
-                {isNew && (
-                  <span className="bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full leading-none ml-2">new</span>
-                )}
-              </div>
-              <div className="flex justify-between items-baseline mt-2">
-                <span className="font-mono text-xs text-muted">
-                  {event.date}
-                  {event.time && event.time !== "TBD" && ` · ${event.time}`}
-                </span>
-                {event.venue && event.venue !== "TBD" && (
-                  <span className="font-mono text-xs text-muted text-right">{event.venue}</span>
-                )}
-              </div>
+          {/* Title + date */}
+          <div className="mb-3">
+            <div className="flex justify-between items-start">
+              <h3
+                className="font-serif text-lg text-primary m-0 leading-snug font-normal tracking-[-0.01em] flex-1"
+              >
+                {event.title}
+              </h3>
+              {isNew && (
+                <span className="bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full leading-none ml-2">new</span>
+              )}
+            </div>
+            <div className="flex justify-between items-baseline mt-2">
+              <span className="font-mono text-xs text-muted">
+                {event.date}
+                {event.time && event.time !== "TBD" && ` · ${event.time}`}
+              </span>
+              {event.venue && event.venue !== "TBD" && (
+                <span className="font-mono text-xs text-muted text-right">{event.venue}</span>
+              )}
             </div>
           </div>
 
@@ -230,33 +222,23 @@ const EventCard = ({
               {event.isDown ? <><span>DOWN</span><svg width="12" height="12" viewBox="0 0 256 256" fill="currentColor" className="inline ml-1"><path d="M229.66,77.66l-128,128a8,8,0,0,1-11.32,0l-56-56a8,8,0,0,1,11.32-11.32L96,188.69,218.34,66.34a8,8,0,0,1,11.32,11.32Z"/></svg></> : "DOWN ?"}
             </button>
           </div>
-          {/* Inline comments */}
-          <div className="mt-3 flex flex-col gap-1.5 cursor-pointer" onClick={(e) => { e.stopPropagation(); if (!showEvInput) setShowEvInput(true); }}>
-            {evComments.slice(-3).map((cm) => (
-              <div key={cm.id} className="flex items-center gap-2 min-w-0">
-                <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${cm.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
-                  {cm.userAvatar}
+
+          {/* Comment preview: latest comment one-line + count badge */}
+          {evComments.length > 0 && (() => {
+            const latest = evComments[evComments.length - 1];
+            return (
+              <div className="mt-3 flex items-center gap-2 min-w-0">
+                <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${latest.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+                  {latest.userAvatar}
                 </div>
-                <span className="font-mono text-tiny text-muted shrink-0">{cm.userName}</span>
-                <span className="font-mono text-tiny text-primary min-w-0 break-words">{cm.text}</span>
+                <span className="font-mono text-tiny text-muted shrink-0">{latest.userName}</span>
+                <span className="font-mono text-tiny text-primary min-w-0 truncate flex-1">{latest.text}</span>
+                {evComments.length > 1 && (
+                  <span className="font-mono text-tiny text-faint shrink-0">💬 {evComments.length}</span>
+                )}
               </div>
-            ))}
-            {evComments.length > 3 && (
-              <span className="font-mono text-tiny text-faint">+ {evComments.length - 3} more</span>
-            )}
-            {showEvInput && <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
-              <input
-                value={cmtText}
-                onChange={(e) => setCmtText(e.target.value.slice(0, 280))}
-                onKeyDown={(e) => { if (e.key === "Enter") postCmt(); }}
-                placeholder="Add a comment…"
-                className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
-              />
-              <button onClick={postCmt} className="shrink-0 bg-dt text-on-accent rounded-lg py-1.5 px-3 font-mono text-xs font-bold cursor-pointer">
-                Post
-              </button>
-            </div>
-          </div>
+            );
+          })()}
         </div>
       </div>
     </>
@@ -267,10 +249,12 @@ const EventCard = ({
 
 interface Person { name: string; avatar: string; mutual?: boolean; inPool?: boolean; }
 
+interface Comment { id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean; }
+
 function EventDetailSheet({
   event, userId, sourceLink, hasDetails,
   poolPeople, poolFriends, poolStrangerCount, nonPoolFriends, mutuals, others, hasPool,
-  actionButtons, onOpenSocial, onViewProfile, onClose,
+  actionButtons, onOpenSocial, onViewProfile, comments, onPostComment, onClose,
 }: {
   event: Event;
   userId?: string | null;
@@ -281,6 +265,8 @@ function EventDetailSheet({
   actionButtons: React.ReactNode;
   onOpenSocial: () => void;
   onViewProfile?: (userId: string) => void;
+  comments: Comment[];
+  onPostComment: (text: string) => void;
   onClose: () => void;
 }) {
   const { visible, entering, closing, close } = useModalTransition(true, onClose);
@@ -380,6 +366,7 @@ function EventDetailSheet({
             nonPoolFriends={nonPoolFriends} mutuals={mutuals} others={others} hasPool={hasPool}
             actionButtons={actionButtons} onOpenSocial={onOpenSocial} onViewProfile={onViewProfile}
           />
+          <CommentsSection comments={comments} onPost={onPostComment} />
         </div>
       </div>
     </div>
@@ -554,8 +541,8 @@ function SocialBlock(props: SheetProps) {
                   <span className="font-bold uppercase tracking-[0.06em]"
                     style={{
                       fontSize: 9, padding: "1px 4px", borderRadius: 3,
-                      background: event.isPublic ? "rgba(255,255,255,0.06)" : "rgba(232,255,90,0.12)",
-                      color: event.isPublic ? "#444" : "#E8FF5A",
+                      background: event.isPublic ? "rgba(0,0,0,0.08)" : "#E8FF5A",
+                      color: event.isPublic ? "#666" : "#000",
                     }}>
                     {event.isPublic ? "public" : "friends"}
                   </span>
@@ -672,8 +659,8 @@ function SheetHero(props: SheetProps) {
         <span className="font-mono font-bold uppercase tracking-[0.06em]"
           style={{
             fontSize: 9, padding: "1px 5px", borderRadius: 3,
-            background: event.isPublic ? "rgba(255,255,255,0.06)" : "rgba(232,255,90,0.12)",
-            color: event.isPublic ? "#444" : "#E8FF5A",
+            background: event.isPublic ? "rgba(0,0,0,0.08)" : "#E8FF5A",
+            color: event.isPublic ? "#666" : "#000",
           }}>
           {event.isPublic ? "public" : "friends"}
         </span>
@@ -712,6 +699,56 @@ function SheetHero(props: SheetProps) {
 
       <div className="mt-3">{actionButtons}</div>
     </>
+  );
+}
+
+function CommentsSection({ comments, onPost }: { comments: Comment[]; onPost: (text: string) => void }) {
+  const [text, setText] = useState("");
+  const handlePost = () => {
+    const t = text.trim();
+    if (!t) return;
+    onPost(t);
+    setText("");
+  };
+  return (
+    <div className="mt-5">
+      <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-dim mb-2">Comments</div>
+      <div className="flex flex-col gap-2">
+        {comments.length === 0 && (
+          <div className="font-mono text-tiny text-faint">No comments yet. Be the first.</div>
+        )}
+        {comments.map((cm) => (
+          <div key={cm.id} className="flex items-start gap-2 min-w-0">
+            <div className={cn(
+              "w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold mt-px",
+              cm.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"
+            )}>
+              {cm.userAvatar}
+            </div>
+            <div className="min-w-0 flex-1 font-mono text-xs" style={{ lineHeight: 1.5 }}>
+              <span className="text-muted mr-1.5">{cm.userName}</span>
+              <span className="text-primary break-words">{cm.text}</span>
+            </div>
+          </div>
+        ))}
+        <div className="flex gap-2 mt-2">
+          <input
+            value={text}
+            onChange={(e) => setText(e.target.value.slice(0, 280))}
+            onKeyDown={(e) => { if (e.key === "Enter") handlePost(); }}
+            placeholder="Add a comment…"
+            className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
+          />
+          <button
+            onClick={handlePost}
+            disabled={!text.trim()}
+            className="shrink-0 bg-dt text-on-accent rounded-lg py-1.5 px-3 font-mono text-xs font-bold cursor-pointer disabled:opacity-50 disabled:cursor-default"
+          >
+            Post
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -158,7 +158,7 @@ const EventCard = ({
             <div className="mb-3">
               <div className="flex justify-between items-start">
                 <h3
-                  className="font-serif text-lg text-primary m-0 leading-snug font-light tracking-[-0.01em] flex-1"
+                  className="font-serif text-lg text-primary m-0 leading-snug font-normal tracking-[-0.01em] flex-1"
                 >
                   {event.title}
                 </h3>

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -283,6 +283,7 @@ export default function FeedView({
                   }
                   onViewProfile={onViewProfile}
                   isNew={item.data.id === newlyAddedEventId || newItemIds.has(item.data.id)}
+                  profile={profile}
                 />
               )
             )}

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -135,7 +135,6 @@ export default function FeedView({
     events,
     newlyAddedEventId,
     unhideCheck,
-    toggleSave,
     toggleDown,
   } = useFeedContext();
 
@@ -272,7 +271,6 @@ export default function FeedView({
                   key={item.data.id}
                   event={item.data}
                   userId={userId}
-                  onToggleSave={() => toggleSave(item.data.id)}
                   onToggleDown={() => toggleDown(item.data.id)}
                   onOpenSocial={() => onOpenSocial(item.data)}
                   onEdit={

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -126,7 +126,7 @@ export default function ChatMessage({
         </span>
       )}
       <div
-        className={cn("select-text font-mono max-w-[80%]",
+        className={cn("select-text font-serif max-w-[80%]",
           msg.isYou
             ? cn("bg-dt text-on-accent rounded-tr-2xl rounded-bl-2xl", {
                 "rounded-tl-2xl": isFirstInGroup,

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -72,7 +72,7 @@ export default function ChatMessage({
   if (msg.sender === "system") {
     if (msg.messageType === 'date_confirm' && isLastConfirm) {
       return (
-        <div className="text-center py-2">
+        <div className="text-center py-0.5">
           <span className="font-mono text-tiny text-muted">{msg.text}</span>
           {confirmLoading && (
             <div className="font-mono text-tiny text-dim mt-1.5">...</div>
@@ -112,7 +112,7 @@ export default function ChatMessage({
     }
 
     return (
-      <div className="text-center py-1">
+      <div className="text-center py-0.5">
         <span className="font-mono text-tiny text-muted">{msg.text}</span>
       </div>
     );

--- a/src/features/squads/components/GroupsView.tsx
+++ b/src/features/squads/components/GroupsView.tsx
@@ -117,29 +117,15 @@ const SquadRow = ({
             </span>
           )}
         </div>
-        <div className="flex flex-col gap-0.5 mt-0.5">
-          {squad.messages && squad.messages.length > 0 ? (
-            squad.messages.slice(-3).map((m, i) => {
-              const isSys = !m.isYou && m.sender === "system";
-              return (
-                <div key={m.id ?? i} className="font-mono text-[10px] text-dim truncate">
-                  {isSys ? (
-                    <span className="text-faint italic">{m.text}</span>
-                  ) : (
-                    <>
-                      <span className="text-muted">{m.isYou ? "You" : m.sender}:</span>{" "}{m.text}
-                    </>
-                  )}
-                </div>
-              );
-            })
-          ) : hasMessage ? (
-            <div className="font-mono text-[10px] text-dim truncate">
-              {sender ? <><span className="text-muted">{sender}:</span> {text}</> : text}
-            </div>
-          ) : eventCompound ? (
-            <div className="font-mono text-[10px] text-dim truncate">{eventCompound}</div>
-          ) : null}
+        <div className="font-mono text-[10px] text-dim mt-0.5 truncate">
+          {(() => {
+            const userMsgs = squad.messages?.filter((m) => m.sender !== "system") ?? [];
+            const last = userMsgs[userMsgs.length - 1];
+            if (last) return <><span className="text-muted">{last.isYou ? "You" : last.sender}:</span>{" "}{last.text}</>;
+            if (hasMessage) return sender ? <><span className="text-muted">{sender}:</span> {text}</> : text;
+            if (eventCompound) return eventCompound;
+            return null;
+          })()}
         </div>
       </div>
       <div className="flex items-center gap-2 shrink-0 self-start pt-1">

--- a/src/features/squads/components/GroupsView.tsx
+++ b/src/features/squads/components/GroupsView.tsx
@@ -117,20 +117,29 @@ const SquadRow = ({
             </span>
           )}
         </div>
-        <div className="font-mono text-[10px] text-dim mt-0.5 truncate">
-          {hasMessage ? (
-            sender ? (
-              <>
-                <span className="text-muted">{sender}:</span> {text}
-              </>
-            ) : (
-              text
-            )
+        <div className="flex flex-col gap-0.5 mt-0.5">
+          {squad.messages && squad.messages.length > 0 ? (
+            squad.messages.slice(-3).map((m, i) => {
+              const isSys = !m.isYou && m.sender === "system";
+              return (
+                <div key={m.id ?? i} className="font-mono text-[10px] text-dim truncate">
+                  {isSys ? (
+                    <span className="text-faint italic">{m.text}</span>
+                  ) : (
+                    <>
+                      <span className="text-muted">{m.isYou ? "You" : m.sender}:</span>{" "}{m.text}
+                    </>
+                  )}
+                </div>
+              );
+            })
+          ) : hasMessage ? (
+            <div className="font-mono text-[10px] text-dim truncate">
+              {sender ? <><span className="text-muted">{sender}:</span> {text}</> : text}
+            </div>
           ) : eventCompound ? (
-            eventCompound
-          ) : (
-            ""
-          )}
+            <div className="font-mono text-[10px] text-dim truncate">{eventCompound}</div>
+          ) : null}
         </div>
       </div>
       <div className="flex items-center gap-2 shrink-0 self-start pt-1">

--- a/src/features/squads/components/MessageComposer.tsx
+++ b/src/features/squads/components/MessageComposer.tsx
@@ -89,7 +89,7 @@ export default function MessageComposer({
             onClick={onOpenPollCreator}
             className="bg-none border-none p-0 text-xl opacity-60 cursor-pointer leading-none mb-2"
           >
-            📊
+            <svg width="16" height="16" viewBox="0 0 256 256" fill="currentColor"><path d="M224,200h-8V40a8,8,0,0,0-8-8H152a8,8,0,0,0-8,8V80H96a8,8,0,0,0-8,8v40H48a8,8,0,0,0-8,8v64H32a8,8,0,0,1,0-16H224a8,8,0,0,1,0,16ZM160,48h40V200H160ZM104,96h40V200H104ZM56,144H88v56H56Z"/></svg>
           </button>
         )}
         <textarea

--- a/src/features/squads/components/PollMessage.tsx
+++ b/src/features/squads/components/PollMessage.tsx
@@ -59,7 +59,7 @@ export default function PollMessage({
     <div ref={pollMessageRef} className="flex justify-center py-2">
       <div className="bg-card border border-border-mid rounded-xl p-4 max-w-[300px] w-full">
         <div className="flex items-center gap-1.5 mb-1">
-          <span className="text-base">📊</span>
+          <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor"><path d="M224,200h-8V40a8,8,0,0,0-8-8H152a8,8,0,0,0-8,8V80H96a8,8,0,0,0-8,8v40H48a8,8,0,0,0-8,8v64H32a8,8,0,0,1,0-16H224a8,8,0,0,1,0,16ZM160,48h40V200H160ZM104,96h40V200H104ZM56,144H88v56H56Z"/></svg>
           <span className="font-serif text-base text-primary">{poll.question}</span>
         </div>
         <div className="font-mono text-tiny text-faint mb-2.5">

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -838,7 +838,7 @@ const SquadChat = ({
             className="flex items-center gap-1.5 px-5 py-1.5 cursor-pointer"
           >
             <div className="flex items-center gap-1.5 bg-card border border-dt rounded-2xl px-3 py-1.5 flex-1 min-w-0">
-              <span className="text-xs shrink-0">📊</span>
+              <svg width="14" height="14" viewBox="0 0 256 256" fill="currentColor" className="shrink-0"><path d="M224,200h-8V40a8,8,0,0,0-8-8H152a8,8,0,0,0-8,8V80H96a8,8,0,0,0-8,8v40H48a8,8,0,0,0-8,8v64H32a8,8,0,0,1,0-16H224a8,8,0,0,1,0,16ZM160,48h40V200H160ZM104,96h40V200H104ZM56,144H88v56H56Z"/></svg>
               <span className="font-mono text-xs text-primary overflow-hidden text-ellipsis whitespace-nowrap flex-1">
                 {activePoll.question}
               </span>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1042,6 +1042,61 @@ export async function getCheckComments(checkId: string): Promise<CheckComment[]>
   return data ?? [];
 }
 
+
+// ── Event Comments ──────────────────────────────────────────────────────
+
+export async function getEventComments(eventId: string): Promise<CheckComment[]> {
+  const { data, error } = await supabase
+    .from('check_comments')
+    .select('*, user:profiles!user_id(*)')
+    .eq('event_id', eventId)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function postEventComment(eventId: string, text: string): Promise<CheckComment> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { data, error } = await supabase
+    .from('check_comments')
+    .insert({ event_id: eventId, user_id: user.id, text })
+    .select('*, user:profiles!user_id(*)')
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function getEventCommentCounts(eventIds: string[]): Promise<Record<string, number>> {
+  if (eventIds.length === 0) return {};
+  const { data, error } = await supabase
+    .from('check_comments')
+    .select('event_id')
+    .in('event_id', eventIds);
+
+  if (error) throw error;
+  const counts: Record<string, number> = {};
+  for (const row of (data ?? [])) {
+    if (row.event_id) counts[row.event_id] = (counts[row.event_id] ?? 0) + 1;
+  }
+  return counts;
+}
+
+export function subscribeToEventComments(eventId: string, onComment: (comment: CheckComment) => void) {
+  return supabase
+    .channel(\`event_comments:\${eventId}\`)
+    .on('postgres_changes', {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'check_comments',
+      filter: \`event_id=eq.\${eventId}\`,
+    }, (payload) => onComment(payload.new as CheckComment))
+    .subscribe();
+}
+
 export async function postCheckComment(checkId: string, text: string, mentions: string[] = []): Promise<CheckComment> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1087,12 +1087,12 @@ export async function getEventCommentCounts(eventIds: string[]): Promise<Record<
 
 export function subscribeToEventComments(eventId: string, onComment: (comment: CheckComment) => void) {
   return supabase
-    .channel(\`event_comments:\${eventId}\`)
+    .channel(`event_comments:${eventId}`)
     .on('postgres_changes', {
       event: 'INSERT',
       schema: 'public',
       table: 'check_comments',
-      filter: \`event_id=eq.\${eventId}\`,
+      filter: `event_id=eq.${eventId}`,
     }, (payload) => onComment(payload.new as CheckComment))
     .subscribe();
 }

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -29,7 +29,7 @@ export const acid: ThemeTokens = {
   onAccent: "#000",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-spectral), serif",
+  fontSerif: "var(--font-outfit), sans-serif",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -29,7 +29,7 @@ export const acid: ThemeTokens = {
   onAccent: "#000",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-dm-serif-display), serif",
+  fontSerif: "var(--font-cormorant), serif",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -29,7 +29,7 @@ export const acid: ThemeTokens = {
   onAccent: "#000",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-outfit), sans-serif",
+  fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -29,7 +29,7 @@ export const acid: ThemeTokens = {
   onAccent: "#000",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-cormorant), serif",
+  fontSerif: "var(--font-spectral), serif",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -28,7 +28,7 @@ export const acid: ThemeTokens = {
 
   onAccent: "#000",
 
-  fontMono: "var(--font-inter), sans-serif",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FFD4D4",

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -29,7 +29,7 @@ export const acid: ThemeTokens = {
   onAccent: "#000",
 
   fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-sora), sans-serif",
+  fontSerif: "var(--font-ibm-plex-mono), monospace",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -29,7 +29,7 @@ export const acid: ThemeTokens = {
   onAccent: "#000",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-exo), sans-serif",
+  fontSerif: "var(--font-dm-serif-display), serif",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -28,8 +28,8 @@ export const acid: ThemeTokens = {
 
   onAccent: "#000",
 
-  fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontSerif: "var(--font-exo), sans-serif",
 
   themeColor: "#FFD4D4",
 };

--- a/src/lib/themes/acid.ts
+++ b/src/lib/themes/acid.ts
@@ -28,7 +28,7 @@ export const acid: ThemeTokens = {
 
   onAccent: "#000",
 
-  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-inter), sans-serif",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FFD4D4",

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -28,8 +28,8 @@ export const firefly: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontSerif: "var(--font-exo), sans-serif",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -29,7 +29,7 @@ export const firefly: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-cormorant), serif",
+  fontSerif: "var(--font-spectral), serif",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -28,7 +28,7 @@ export const firefly: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-inter), sans-serif",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#F0FFD4",

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -29,7 +29,7 @@ export const firefly: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-spectral), serif",
+  fontSerif: "var(--font-outfit), sans-serif",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -28,7 +28,7 @@ export const firefly: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-inter), sans-serif",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#F0FFD4",

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -29,7 +29,7 @@ export const firefly: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-sora), sans-serif",
+  fontSerif: "var(--font-ibm-plex-mono), monospace",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -29,7 +29,7 @@ export const firefly: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-dm-serif-display), serif",
+  fontSerif: "var(--font-cormorant), serif",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -29,7 +29,7 @@ export const firefly: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-outfit), sans-serif",
+  fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/firefly.ts
+++ b/src/lib/themes/firefly.ts
@@ -29,7 +29,7 @@ export const firefly: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-exo), sans-serif",
+  fontSerif: "var(--font-dm-serif-display), serif",
 
   themeColor: "#F0FFD4",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -29,7 +29,7 @@ export const guava: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-exo), sans-serif",
+  fontSerif: "var(--font-dm-serif-display), serif",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -29,7 +29,7 @@ export const guava: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-spectral), serif",
+  fontSerif: "var(--font-outfit), sans-serif",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -28,7 +28,7 @@ export const guava: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-inter), sans-serif",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FCFFE2",

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -28,7 +28,7 @@ export const guava: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-inter), sans-serif",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FCFFE2",

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -29,7 +29,7 @@ export const guava: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-outfit), sans-serif",
+  fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -28,8 +28,8 @@ export const guava: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontSerif: "var(--font-exo), sans-serif",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -29,7 +29,7 @@ export const guava: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-dm-serif-display), serif",
+  fontSerif: "var(--font-cormorant), serif",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -29,7 +29,7 @@ export const guava: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-sora), sans-serif",
+  fontSerif: "var(--font-ibm-plex-mono), monospace",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/guava.ts
+++ b/src/lib/themes/guava.ts
@@ -29,7 +29,7 @@ export const guava: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-cormorant), serif",
+  fontSerif: "var(--font-spectral), serif",
 
   themeColor: "#FCFFE2",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -29,7 +29,7 @@ export const midnight: ThemeTokens = {
   onAccent: "#16192A",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-outfit), sans-serif",
+  fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -28,7 +28,7 @@ export const midnight: ThemeTokens = {
 
   onAccent: "#16192A",
 
-  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-inter), sans-serif",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#ECECEE",

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -29,7 +29,7 @@ export const midnight: ThemeTokens = {
   onAccent: "#16192A",
 
   fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-sora), sans-serif",
+  fontSerif: "var(--font-ibm-plex-mono), monospace",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -29,7 +29,7 @@ export const midnight: ThemeTokens = {
   onAccent: "#16192A",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-dm-serif-display), serif",
+  fontSerif: "var(--font-cormorant), serif",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -29,7 +29,7 @@ export const midnight: ThemeTokens = {
   onAccent: "#16192A",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-exo), sans-serif",
+  fontSerif: "var(--font-dm-serif-display), serif",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -29,7 +29,7 @@ export const midnight: ThemeTokens = {
   onAccent: "#16192A",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-spectral), serif",
+  fontSerif: "var(--font-outfit), sans-serif",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -28,7 +28,7 @@ export const midnight: ThemeTokens = {
 
   onAccent: "#16192A",
 
-  fontMono: "var(--font-inter), sans-serif",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#ECECEE",

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -28,8 +28,8 @@ export const midnight: ThemeTokens = {
 
   onAccent: "#16192A",
 
-  fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontSerif: "var(--font-exo), sans-serif",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/midnight.ts
+++ b/src/lib/themes/midnight.ts
@@ -29,7 +29,7 @@ export const midnight: ThemeTokens = {
   onAccent: "#16192A",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-cormorant), serif",
+  fontSerif: "var(--font-spectral), serif",
 
   themeColor: "#ECECEE",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -29,7 +29,7 @@ export const monochrome: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-outfit), sans-serif",
+  fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -28,7 +28,7 @@ export const monochrome: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-inter), sans-serif",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FFFFFF",

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -29,7 +29,7 @@ export const monochrome: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-sora), sans-serif",
+  fontSerif: "var(--font-ibm-plex-mono), monospace",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -28,8 +28,8 @@ export const monochrome: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-exo), sans-serif",
-  fontSerif: "var(--font-ibm-plex-mono), monospace",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
+  fontSerif: "var(--font-exo), sans-serif",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -29,7 +29,7 @@ export const monochrome: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-spectral), serif",
+  fontSerif: "var(--font-outfit), sans-serif",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -29,7 +29,7 @@ export const monochrome: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-cormorant), serif",
+  fontSerif: "var(--font-spectral), serif",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -29,7 +29,7 @@ export const monochrome: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-exo), sans-serif",
+  fontSerif: "var(--font-dm-serif-display), serif",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -29,7 +29,7 @@ export const monochrome: ThemeTokens = {
   onAccent: "#fff",
 
   fontMono: "var(--font-ibm-plex-mono), monospace",
-  fontSerif: "var(--font-dm-serif-display), serif",
+  fontSerif: "var(--font-cormorant), serif",
 
   themeColor: "#FFFFFF",
 };

--- a/src/lib/themes/monochrome.ts
+++ b/src/lib/themes/monochrome.ts
@@ -28,7 +28,7 @@ export const monochrome: ThemeTokens = {
 
   onAccent: "#fff",
 
-  fontMono: "var(--font-inter), sans-serif",
+  fontMono: "var(--font-ibm-plex-mono), monospace",
   fontSerif: "var(--font-inter), sans-serif",
 
   themeColor: "#FFFFFF",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -239,7 +239,8 @@ export const parseNaturalTime = (text: string): string | null => {
 const formatTimeMatch = (rawHour: number, minutes: string | null, meridiem: "am" | "pm" | undefined): string | null => {
   if (rawHour === 0 || rawHour > 12) return null;
   const suffix = meridiem ?? "pm";
-  return minutes ? `${rawHour}:${minutes}${suffix}` : `${rawHour}${suffix}`;
+  if (minutes && minutes !== "00") return `${rawHour}:${minutes}${suffix}`;
+  return `${rawHour}${suffix}`;
 };
 
 /** Parse a location from text, e.g. "dinner at Jollibee" → "Jollibee" */

--- a/supabase/migrations/20260417000001_event_comments.sql
+++ b/supabase/migrations/20260417000001_event_comments.sql
@@ -1,0 +1,40 @@
+-- Add event_id to check_comments so the same table supports both
+ALTER TABLE public.check_comments
+  ADD COLUMN IF NOT EXISTS event_id UUID REFERENCES public.events(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_check_comments_event_created
+  ON public.check_comments(event_id, created_at ASC);
+
+-- Update SELECT policy to also allow event viewers
+DROP POLICY IF EXISTS "Comments visible to check viewers" ON public.check_comments;
+CREATE POLICY "Comments visible to check or event viewers" ON public.check_comments
+  FOR SELECT USING (
+    user_id = (SELECT auth.uid())
+    OR (check_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM public.interest_checks ic
+      WHERE ic.id = check_comments.check_id
+      AND (
+        ic.author_id = (SELECT auth.uid())
+        OR public.is_friend_or_fof((SELECT auth.uid()), ic.author_id)
+      )
+    ))
+    OR (event_id IS NOT NULL)
+  );
+
+-- Update INSERT policy
+DROP POLICY IF EXISTS "Users can comment on visible checks" ON public.check_comments;
+CREATE POLICY "Users can comment on checks or events" ON public.check_comments
+  FOR INSERT WITH CHECK (
+    user_id = (SELECT auth.uid())
+    AND (
+      (check_id IS NOT NULL AND EXISTS (
+        SELECT 1 FROM public.interest_checks ic
+        WHERE ic.id = check_comments.check_id
+        AND (
+          ic.author_id = (SELECT auth.uid())
+          OR public.is_friend_or_fof((SELECT auth.uid()), ic.author_id)
+        )
+      ))
+      OR (event_id IS NOT NULL)
+    )
+  );


### PR DESCRIPTION
## Summary
- One-line latest-comment preview on the feed card (with `💬 N` count when > 1)
- Full comment list + input moved into the event detail sheet
- Whole card is tappable to open detail; removed the inline input + toggle state
- FRIENDS/public badge: solid fill + dark text so it's visible on both light and dark sheet backgrounds

## Test plan
- [ ] Feed card with 0 comments shows no preview strip
- [ ] Feed card with 1 comment shows author + text, one-line truncated
- [ ] Feed card with >1 comments shows `💬 N` count on the right
- [ ] Tap anywhere on the card opens detail sheet
- [ ] Detail sheet has Comments section at the bottom; can post and see it appear in both sheet + card preview
- [ ] FRIENDS badge readable in both feed card and detail sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)