### PR TITLE
Stop date/venue line from interleaving on long values

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -234,10 +234,10 @@ export default function CheckCard({
               const when = [check.eventDateLabel, check.eventTime].filter(Boolean).join(" · ");
               if (!when && !check.location) return null;
               return (
-                <div className="flex justify-between items-baseline mt-2">
+                <div className="flex flex-wrap justify-between items-baseline gap-x-3 gap-y-1 mt-2">
                   {when && <span className="font-mono text-xs text-muted">{when}</span>}
                   {check.location && (
-                    <span className="font-mono text-xs text-muted text-right">{check.location}</span>
+                    <span className="font-mono text-xs text-muted">{check.location}</span>
                   )}
                 </div>
               );

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -185,13 +185,13 @@ const EventCard = ({
                 <span className="bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full leading-none ml-2">new</span>
               )}
             </div>
-            <div className="flex justify-between items-baseline mt-2">
+            <div className="flex flex-wrap justify-between items-baseline gap-x-3 gap-y-1 mt-2">
               <span className="font-mono text-xs text-muted">
                 {event.date}
                 {event.time && event.time !== "TBD" && ` · ${event.time}`}
               </span>
               {event.venue && event.venue !== "TBD" && (
-                <span className="font-mono text-xs text-muted text-right">{event.venue}</span>
+                <span className="font-mono text-xs text-muted">{event.venue}</span>
               )}
             </div>
           </div>


### PR DESCRIPTION
## Summary
On event and check cards, the date (left) and venue (right) shared a `flex justify-between` row without `flex-wrap`. When both were long — e.g. a full street address — each span wrapped independently and the lines visually interleaved, reading as "Fri, Apr 151 Loisaida Ave, New York, NY / 17 10009, USA".

Switch to `flex-wrap` + `gap`: when they don't fit together, the venue drops to its own row (left-aligned); when they do fit, date stays left and venue stays right via `justify-between`.

## Test plan
- [ ] Event/check card with short date + short venue → single row, date left, venue right (unchanged)
- [ ] Event/check card with long venue → venue wraps to its own row below the date, no interleaving
- [ ] Check card without a venue → date-only row renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)