### PR TITLE
Inline comments on event cards, shared with checks

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -5,6 +5,7 @@ import type { Event } from "@/lib/ui-types";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
 import cn from "@/lib/tailwindMerge";
 import * as db from "@/lib/db";
+import InlineCommentsBox from "@/shared/components/InlineCommentsBox";
 
 const EventCard = ({
   event,
@@ -40,7 +41,7 @@ const EventCard = ({
       })));
     }).catch(() => {});
   }, [event.id, userId]);
-  const postCmt = useCallback(async (text: string) => {
+  const postCmt = useCallback(async (text: string, _mentions?: string[]) => {
     const t = text.trim();
     if (!t || !event.id) return;
     const opt = { id: `opt-${Date.now()}`, userId: userId ?? "", userName: "You", userAvatar: "?", text: t, isYours: true };
@@ -138,8 +139,6 @@ const EventCard = ({
           actionButtons={actionButtons}
           onOpenSocial={onOpenSocial}
           onViewProfile={onViewProfile}
-          comments={evComments}
-          onPostComment={postCmt}
           onEdit={onEdit}
           onClose={() => setShowDetail(false)}
         />
@@ -223,22 +222,14 @@ const EventCard = ({
             </button>
           </div>
 
-          {/* Comment preview: latest comment one-line + count badge */}
-          {evComments.length > 0 && (() => {
-            const latest = evComments[evComments.length - 1];
-            return (
-              <div className="mt-3 flex items-center gap-2 min-w-0">
-                <div className={`w-4 h-4 rounded-full shrink-0 flex items-center justify-center font-mono text-[8px] font-bold ${latest.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
-                  {latest.userAvatar}
-                </div>
-                <span className="font-mono text-tiny text-muted shrink-0">{latest.userName}</span>
-                <span className="font-mono text-tiny text-primary min-w-0 truncate flex-1">{latest.text}</span>
-                {evComments.length > 1 && (
-                  <span className="font-mono text-tiny text-faint shrink-0">💬 {evComments.length}</span>
-                )}
-              </div>
-            );
-          })()}
+          {/* Inline comments — tap to toggle input */}
+          <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+            <InlineCommentsBox
+              comments={evComments}
+              userId={userId ?? null}
+              onPost={postCmt}
+            />
+          </div>
         </div>
       </div>
     </>
@@ -249,12 +240,10 @@ const EventCard = ({
 
 interface Person { name: string; avatar: string; mutual?: boolean; inPool?: boolean; }
 
-interface Comment { id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean; }
-
 function EventDetailSheet({
   event, userId, sourceLink, hasDetails,
   poolPeople, poolFriends, poolStrangerCount, nonPoolFriends, mutuals, others, hasPool,
-  actionButtons, onOpenSocial, onViewProfile, comments, onPostComment, onEdit, onClose,
+  actionButtons, onOpenSocial, onViewProfile, onEdit, onClose,
 }: {
   event: Event;
   userId?: string | null;
@@ -265,8 +254,6 @@ function EventDetailSheet({
   actionButtons: React.ReactNode;
   onOpenSocial: () => void;
   onViewProfile?: (userId: string) => void;
-  comments: Comment[];
-  onPostComment: (text: string) => void;
   onEdit?: () => void;
   onClose: () => void;
 }) {
@@ -367,7 +354,6 @@ function EventDetailSheet({
             nonPoolFriends={nonPoolFriends} mutuals={mutuals} others={others} hasPool={hasPool}
             actionButtons={actionButtons} onOpenSocial={onOpenSocial} onViewProfile={onViewProfile}
           />
-          <CommentsSection comments={comments} onPost={onPostComment} />
           {onEdit && (
             <div className="mt-5 pt-4 border-t border-border">
               <button
@@ -711,56 +697,6 @@ function SheetHero(props: SheetProps) {
 
       <div className="mt-3">{actionButtons}</div>
     </>
-  );
-}
-
-function CommentsSection({ comments, onPost }: { comments: Comment[]; onPost: (text: string) => void }) {
-  const [text, setText] = useState("");
-  const handlePost = () => {
-    const t = text.trim();
-    if (!t) return;
-    onPost(t);
-    setText("");
-  };
-  return (
-    <div className="mt-5">
-      <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-dim mb-2">Comments</div>
-      <div className="flex flex-col gap-2">
-        {comments.length === 0 && (
-          <div className="font-mono text-tiny text-faint">No comments yet. Be the first.</div>
-        )}
-        {comments.map((cm) => (
-          <div key={cm.id} className="flex items-start gap-2 min-w-0">
-            <div className={cn(
-              "w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold mt-px",
-              cm.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"
-            )}>
-              {cm.userAvatar}
-            </div>
-            <div className="min-w-0 flex-1 font-mono text-xs" style={{ lineHeight: 1.5 }}>
-              <span className="text-muted mr-1.5">{cm.userName}</span>
-              <span className="text-primary break-words">{cm.text}</span>
-            </div>
-          </div>
-        ))}
-        <div className="flex gap-2 mt-2">
-          <input
-            value={text}
-            onChange={(e) => setText(e.target.value.slice(0, 280))}
-            onKeyDown={(e) => { if (e.key === "Enter") handlePost(); }}
-            placeholder="Add a comment…"
-            className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
-          />
-          <button
-            onClick={handlePost}
-            disabled={!text.trim()}
-            className="shrink-0 bg-dt text-on-accent rounded-lg py-1.5 px-3 font-mono text-xs font-bold cursor-pointer disabled:opacity-50 disabled:cursor-default"
-          >
-            Post
-          </button>
-        </div>
-      </div>
-    </div>
   );
 }
 

--- a/src/shared/components/InlineCommentsBox.tsx
+++ b/src/shared/components/InlineCommentsBox.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React, { useState, useRef } from "react";
+
+export interface InlineComment {
+  id: string;
+  userId: string;
+  userName: string;
+  userAvatar: string;
+  text: string;
+  isYours: boolean;
+}
+
+export default function InlineCommentsBox({
+  comments,
+  userId,
+  friends,
+  onPost,
+  emptyText = "no comments yet",
+}: {
+  comments: InlineComment[];
+  userId: string | null;
+  friends?: { id: string; name: string; avatar: string }[];
+  onPost: (text: string, mentions?: string[]) => void;
+  emptyText?: string;
+}) {
+  const [text, setText] = useState("");
+  const [showInput, setShowInput] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionIdx, setMentionIdx] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const mentionCandidates = (() => {
+    const map = new Map<string, { id: string; name: string; avatar: string }>();
+    for (const f of (friends ?? [])) map.set(f.id, { id: f.id, name: f.name, avatar: f.avatar });
+    for (const c of comments.filter((c) => c.userId !== userId && !c.isYours)) {
+      if (!map.has(c.userId)) map.set(c.userId, { id: c.userId, name: c.userName, avatar: c.userAvatar });
+    }
+    return Array.from(map.values());
+  })();
+
+  const handleSubmit = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const mentionedNames = [...trimmed.matchAll(/@(\S+)/g)].map((m) => m[1].toLowerCase());
+    const mentionedIds = mentionCandidates
+      .filter((c) => mentionedNames.some((n) =>
+        c.name.toLowerCase() === n || c.name.split(' ')[0].toLowerCase() === n
+      ))
+      .map((c) => c.id);
+    onPost(trimmed, mentionedIds.length > 0 ? mentionedIds : undefined);
+    setText("");
+    setMentionQuery(null);
+    setMentionIdx(-1);
+  };
+
+  return (
+    <div className="bg-card border border-[#CDC999] rounded-2xl px-3 py-2.5 flex flex-col gap-1.5 cursor-pointer" onClick={() => setShowInput((v) => !v)}>
+      {comments.length === 0 ? (
+        <span className="font-mono text-tiny text-faint py-0.5">{emptyText}</span>
+      ) : (
+        <>
+          {(showAll ? comments : comments.slice(-3)).map((c) => (
+            <div key={c.id} className="flex items-center gap-2 min-w-0">
+              <div className={`w-5 h-5 rounded-full shrink-0 flex items-center justify-center font-mono text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}>
+                {c.userAvatar}
+              </div>
+              <span className="font-mono text-tiny text-muted shrink-0 leading-snug">
+                {c.userName}
+              </span>
+              <span className="font-mono text-tiny text-primary min-w-0 break-words leading-snug">
+                {c.text.split(/(@\S+)/g).map((part, pi) =>
+                  part.startsWith("@") ? (
+                    <span key={pi} className="text-dt font-bold">{part}</span>
+                  ) : part
+                )}
+              </span>
+            </div>
+          ))}
+          {!showAll && comments.length > 3 && (
+            <button
+              onClick={(e) => { e.stopPropagation(); setShowAll(true); }}
+              className="font-mono text-tiny text-faint cursor-pointer bg-transparent border-none p-0"
+            >
+              + {comments.length - 3} more
+            </button>
+          )}
+        </>
+      )}
+      {showInput && <div className="flex gap-2 items-center mt-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+        <input
+          ref={inputRef}
+          value={text}
+          onChange={(e) => {
+            const val = e.target.value.slice(0, 280);
+            setText(val);
+            const cursor = e.target.selectionStart ?? val.length;
+            const before = val.slice(0, cursor);
+            const atMatch = before.match(/@([^\s@]*)$/);
+            if (atMatch) {
+              setMentionQuery(atMatch[1].toLowerCase());
+              setMentionIdx(before.length - atMatch[0].length);
+            } else {
+              setMentionQuery(null);
+              setMentionIdx(-1);
+            }
+          }}
+          onKeyDown={(e) => {
+            if (mentionQuery !== null && e.key === "Escape") {
+              setMentionQuery(null);
+              setMentionIdx(-1);
+              return;
+            }
+            if (e.key === "Enter") handleSubmit();
+          }}
+          placeholder="Add a comment…"
+          className="flex-1 min-w-0 bg-surface border border-border rounded-lg py-1.5 px-2.5 font-mono text-xs text-primary outline-none"
+        />
+        <button
+          onClick={handleSubmit}
+          className="shrink-0 bg-dt text-on-accent rounded-lg py-1.5 px-3 font-mono text-xs font-bold cursor-pointer"
+        >
+          Post
+        </button>
+      </div>}
+      {showInput && mentionQuery !== null && mentionCandidates.length > 0 && (() => {
+        const filtered = mentionCandidates.filter(c => c.name.toLowerCase().includes(mentionQuery));
+        if (filtered.length === 0) return null;
+        return (
+          <div className="bg-surface border border-border-mid rounded-lg mt-1 max-h-25 overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            {filtered.slice(0, 5).map(c => (
+              <button
+                key={c.id}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const before = text.slice(0, mentionIdx);
+                  const after = text.slice(mentionIdx + 1 + (mentionQuery?.length ?? 0));
+                  setText(before + "@" + c.name + " " + after);
+                  setMentionQuery(null);
+                  setMentionIdx(-1);
+                  inputRef.current?.focus();
+                }}
+                className="flex items-center gap-1.5 w-full py-1.5 px-2.5 bg-transparent cursor-pointer border-b border-border"
+              >
+                <div className="size-5 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-tiny font-bold">
+                  {c.avatar}
+                </div>
+                <span className="font-mono text-xs text-primary">{c.name}</span>
+              </button>
+            ))}
+          </div>
+        );
+      })()}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
First of a 3-PR series unifying check + event card behavior (keeping per-type specifics like check expiry / event hero intact).

- Extract `src/shared/components/InlineCommentsBox.tsx` — a generic inline comments box (tap to reveal input, last 3 shown, "+ N more" to expand, tap again to collapse, optional @mentions).
- Use it in `EventCard`, replacing the one-line latest-comment preview.
- Remove the redundant full-list `CommentsSection` from `EventDetailSheet` (inline version is comprehensive).

`CheckCard` is left on the existing `CheckCommentsSection` for this PR to avoid conflicts with in-flight PR #362. Follow-up PR will migrate it to the shared component and delete `CheckCommentsSection`.

## Test plan
- [ ] Event with 0 comments → box shows "no comments yet"
- [ ] Tap box → input appears; tap again → input collapses
- [ ] Post a comment → appears in list; `_mentions` param is accepted but ignored
- [ ] Event with >3 comments → "+ N more" shows all
- [ ] Detail sheet no longer duplicates comments

## Follow-ups
- PR #2 (after #362 merges): migrate `CheckCard` to `InlineCommentsBox`, delete `CheckCommentsSection`.
- PR #3: unify tap-to-detail — give checks a shared detail sheet with slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)