### PR TITLE
Tap-to-detail on checks + hide empty inline comments box

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -7,6 +7,7 @@ import type { InterestCheck, Friend } from "@/lib/ui-types";
 import { logError } from "@/lib/logger";
 import { useCheckComments } from "@/features/checks/hooks/useCheckComments";
 import InlineCommentsBox from "@/shared/components/InlineCommentsBox";
+import CheckDetailSheet from "./CheckDetailSheet";
 import EditCheckModal from "./EditCheckModal";
 import { useFeedContext } from "@/features/checks/context/FeedContext";
 
@@ -107,6 +108,7 @@ export default function CheckCard({
 
   useEffect(() => { openComments(); }, [check.id]);
   const [editModalOpen, setEditModalOpen] = useState(false);
+  const [showDetail, setShowDetail] = useState(false);
 
   const { comments, commentCount, openComments, postComment } = useCheckComments({
     checkId: check.id,
@@ -156,13 +158,13 @@ export default function CheckCard({
           </div>
         )}
         <div
-          className={`p-4 ${(check.isYours || check.isCoAuthor) ? "cursor-pointer" : ""}`}
-          onClick={(check.isYours || check.isCoAuthor) ? (e) => {
-            // Only open modal if click wasn't on an interactive element
+          className="p-4 cursor-pointer"
+          onClick={(e) => {
+            // Only open sheet if click wasn't on an interactive element
             const target = e.target as HTMLElement;
             if (target.closest("button") || target.closest("a") || target.closest("input") || target.closest("textarea")) return;
-            setEditModalOpen(true);
-          } : undefined}
+            setShowDetail(true);
+          }}
         >
           {check.movieTitle && (
             <div
@@ -358,16 +360,31 @@ export default function CheckCard({
         </div>
       </div>
 
-      {/* Inline comments — overlaps bottom of card */}
-      <div className="-mt-3 px-1.5 pb-2 relative z-[2]">
-        <InlineCommentsBox
-          comments={comments}
+      {/* Inline comments — only render when at least one comment exists; empty state lives in the sheet */}
+      {comments.length > 0 && (
+        <div className="-mt-3 px-1.5 pb-2 relative z-[2]">
+          <InlineCommentsBox
+            comments={comments}
+            userId={userId}
+            friends={friendsList}
+            onPost={postComment}
+          />
+        </div>
+      )}
+      </div>
+
+      {showDetail && (
+        <CheckDetailSheet
+          check={check}
           userId={userId}
+          comments={comments}
           friends={friendsList}
-          onPost={postComment}
+          onPostComment={postComment}
+          onEdit={(check.isYours || check.isCoAuthor) ? () => { setShowDetail(false); setEditModalOpen(true); } : undefined}
+          onViewProfile={onViewProfile}
+          onClose={() => setShowDetail(false)}
         />
-      </div>
-      </div>
+      )}
 
       <EditCheckModal
         check={editModalOpen ? check : null}

--- a/src/features/checks/components/CheckDetailSheet.tsx
+++ b/src/features/checks/components/CheckDetailSheet.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import React from "react";
+import type { InterestCheck } from "@/lib/ui-types";
+import DetailSheet from "@/shared/components/DetailSheet";
+import InlineCommentsBox from "@/shared/components/InlineCommentsBox";
+import type { CommentUI } from "@/features/checks/hooks/useCheckComments";
+
+function Linkify({ children, coAuthors, onViewProfile }: { children: string; coAuthors?: { name: string; userId?: string }[]; onViewProfile?: (userId: string) => void }) {
+  const tokenRe = /(https?:\/\/[^\s),]+|@\S+)/g;
+  const parts = children.split(tokenRe);
+  if (parts.length === 1) return <>{children}</>;
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (/^https?:\/\//.test(part)) {
+          const display = (() => {
+            try {
+              const u = new URL(part);
+              let d = u.host.replace(/^www\./, "") + u.pathname.replace(/\/$/, "");
+              if (d.length > 40) d = d.slice(0, 37) + "…";
+              return d;
+            } catch { return part; }
+          })();
+          return (
+            <a key={i} href={part} target="_blank" rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              className="underline underline-offset-2 break-all text-dt"
+            >
+              {display}
+            </a>
+          );
+        }
+        if (/^@\S+/.test(part)) {
+          const mention = part.slice(1).toLowerCase();
+          const matched = coAuthors?.find(ca => ca.name.toLowerCase() === mention || ca.name.split(" ")[0]?.toLowerCase() === mention);
+          const canTap = matched?.userId && onViewProfile;
+          return (
+            <span
+              key={i}
+              className="text-dt font-semibold"
+              style={canTap ? { cursor: "pointer" } : undefined}
+              onClick={canTap ? (e) => { e.stopPropagation(); onViewProfile!(matched!.userId!); } : undefined}
+            >
+              @{matched ? matched.name : part.slice(1)}
+            </span>
+          );
+        }
+        return <React.Fragment key={i}>{part}</React.Fragment>;
+      })}
+    </>
+  );
+}
+
+export default function CheckDetailSheet({
+  check,
+  userId,
+  comments,
+  friends,
+  onPostComment,
+  onEdit,
+  onViewProfile,
+  onClose,
+}: {
+  check: InterestCheck;
+  userId: string | null;
+  comments: CommentUI[];
+  friends?: { id: string; name: string; avatar: string }[];
+  onPostComment: (text: string, mentions?: string[]) => void;
+  onEdit?: () => void;
+  onViewProfile?: (userId: string) => void;
+  onClose: () => void;
+}) {
+  const downResponders = check.responses.filter(r => r.status === "down");
+  const waitlistResponders = check.responses.filter(r => r.status === "waitlist");
+
+  return (
+    <DetailSheet
+      onClose={onClose}
+      editLabel={onEdit ? "Edit check" : undefined}
+      onEdit={onEdit}
+    >
+      {/* Movie card (if applicable) */}
+      {check.movieTitle && (
+        <a
+          href={check.letterboxdUrl || undefined}
+          target={check.letterboxdUrl ? "_blank" : undefined}
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          className={`flex gap-2.5 mb-3 p-2.5 bg-deep rounded-lg border border-border no-underline ${check.letterboxdUrl ? "cursor-pointer" : "cursor-default"}`}
+        >
+          {check.thumbnail && (
+            <img src={check.thumbnail} alt={check.movieTitle}
+              className="w-14 h-20 object-cover rounded-md shrink-0" />
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="font-serif text-base text-primary leading-tight mb-0.5">{check.movieTitle}</div>
+            <div className="font-mono text-tiny text-muted mb-1">
+              {check.year}{check.director && ` · ${check.director}`}
+            </div>
+            {check.vibes && check.vibes.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {check.vibes.slice(0, 3).map((v) => (
+                  <span key={v} className="bg-border-light text-dt py-0.5 px-1.5 rounded-xl font-mono text-tiny uppercase tracking-widest">{v}</span>
+                ))}
+              </div>
+            )}
+          </div>
+        </a>
+      )}
+
+      {/* Title */}
+      <h3 className="font-serif text-lg text-primary mt-0 mb-2 leading-snug font-normal tracking-[-0.01em]">
+        <Linkify coAuthors={check.coAuthors} onViewProfile={onViewProfile}>{check.text}</Linkify>
+      </h3>
+
+      {/* Metadata row */}
+      <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1 mb-2">
+        {(check.eventDateLabel || check.eventTime) && (
+          <span className="font-mono text-xs text-dt">
+            {[check.eventDateLabel, check.eventTime].filter(Boolean).join(" · ")}
+          </span>
+        )}
+        {check.location && (
+          <a
+            href={`https://maps.google.com/?q=${encodeURIComponent(check.location)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className="font-mono text-xs text-dim no-underline"
+          >
+            {check.location}
+          </a>
+        )}
+        {check.expiresIn !== "open" && (
+          <span className={`font-mono text-tiny ml-auto ${check.expiryPercent > 75 ? "text-danger" : "text-dim"}`}>
+            {check.expiresIn === "expired" ? "expired" : `${check.expiresIn} left`}
+          </span>
+        )}
+      </div>
+
+      {/* Author */}
+      <div className="flex items-center gap-1.5 mb-3">
+        <span className="font-mono text-xs text-muted">by </span>
+        <span className="font-mono text-xs text-dt font-semibold">{check.author}</span>
+        {check.coAuthors && check.coAuthors.filter(c => c.status === "accepted").length > 0 && (
+          <>
+            <span className="font-mono text-xs text-muted"> · with </span>
+            <span className="font-mono text-xs text-dt font-semibold">
+              {check.coAuthors.filter(c => c.status === "accepted").map(c => c.name).join(", ")}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Responders */}
+      {check.responses.length > 0 && (
+        <div className="flex flex-col gap-2 mb-4">
+          {downResponders.length > 0 && (
+            <div>
+              <span className="font-mono text-tiny text-dt uppercase tracking-widest">Down</span>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {downResponders.map(r => (
+                  <span key={r.name} className="font-mono text-tiny text-on-accent bg-dt py-0.75 px-2 rounded-3xl font-semibold">{r.name}</span>
+                ))}
+              </div>
+            </div>
+          )}
+          {waitlistResponders.length > 0 && (
+            <div>
+              <span className="font-mono text-tiny text-muted uppercase tracking-widest">Waitlist</span>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {waitlistResponders.map(r => (
+                  <span key={r.name} className="font-mono text-tiny text-muted bg-border-light py-0.75 px-2 rounded-3xl border border-dashed">{r.name}</span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Inline comments (always visible in sheet, so user can post first comment from here) */}
+      <InlineCommentsBox
+        comments={comments}
+        userId={userId}
+        friends={friends}
+        onPost={onPostComment}
+      />
+    </DetailSheet>
+  );
+}

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -139,6 +139,8 @@ const EventCard = ({
           actionButtons={actionButtons}
           onOpenSocial={onOpenSocial}
           onViewProfile={onViewProfile}
+          comments={evComments}
+          onPostComment={postCmt}
           onEdit={onEdit}
           onClose={() => setShowDetail(false)}
         />
@@ -222,14 +224,16 @@ const EventCard = ({
             </button>
           </div>
 
-          {/* Inline comments — tap to toggle input */}
-          <div className="mt-3" onClick={(e) => e.stopPropagation()}>
-            <InlineCommentsBox
-              comments={evComments}
-              userId={userId ?? null}
-              onPost={postCmt}
-            />
-          </div>
+          {/* Inline comments — only render when at least one comment exists; empty state lives in the sheet */}
+          {evComments.length > 0 && (
+            <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+              <InlineCommentsBox
+                comments={evComments}
+                userId={userId ?? null}
+                onPost={postCmt}
+              />
+            </div>
+          )}
         </div>
       </div>
     </>
@@ -243,7 +247,7 @@ interface Person { name: string; avatar: string; mutual?: boolean; inPool?: bool
 function EventDetailSheet({
   event, userId, sourceLink, hasDetails,
   poolPeople, poolFriends, poolStrangerCount, nonPoolFriends, mutuals, others, hasPool,
-  actionButtons, onOpenSocial, onViewProfile, onEdit, onClose,
+  actionButtons, onOpenSocial, onViewProfile, comments, onPostComment, onEdit, onClose,
 }: {
   event: Event;
   userId?: string | null;
@@ -254,6 +258,8 @@ function EventDetailSheet({
   actionButtons: React.ReactNode;
   onOpenSocial: () => void;
   onViewProfile?: (userId: string) => void;
+  comments: { id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean }[];
+  onPostComment: (text: string, mentions?: string[]) => void;
   onEdit?: () => void;
   onClose: () => void;
 }) {
@@ -265,6 +271,13 @@ function EventDetailSheet({
         nonPoolFriends={nonPoolFriends} mutuals={mutuals} others={others} hasPool={hasPool}
         actionButtons={actionButtons} onOpenSocial={onOpenSocial} onViewProfile={onViewProfile}
       />
+      <div className="mt-4">
+        <InlineCommentsBox
+          comments={comments}
+          userId={userId ?? null}
+          onPost={onPostComment}
+        />
+      </div>
     </DetailSheet>
   );
 }


### PR DESCRIPTION
## Summary
Completes the check/event card unification.

**Checks now have a detail sheet.** New `CheckDetailSheet` (built on the shared `DetailSheet` shell): movie card, title, metadata row (date · time, venue map link, expiry), author + accepted co-authors, responders split into Down/Waitlist pills, `InlineCommentsBox`, and an "Edit check →" row at the bottom for author/co-author that hands off to the existing `EditCheckModal`.

**Unified tap behavior.** Tap on a check card now opens the detail sheet for everyone. Previously creator/co-author tap opened the edit modal directly and non-creator tap did nothing — both converge on the sheet now. Edit is reachable from the sheet's bottom row.

**Inline comments box hides when empty.** Applies to both `CheckCard` and `EventCard`. If no comments exist, the card has no comment box — the user opens the sheet to post the first one. Sheet always shows the box (card doesn't duplicate the empty state). `EventDetailSheet` gets the `InlineCommentsBox` back as the first-comment entry point (it was removed in #363 when the redundant full-list `CommentsSection` was dropped).

## Test plan
- [ ] Check with 0 comments → no box on card; tap card → sheet opens with `Add a comment…` input
- [ ] Check with ≥1 comment → box on card (tap-to-toggle input) AND in sheet (always expanded)
- [ ] Post from sheet → comment appears in both sheet and card (next render)
- [ ] Your own check: tap card → sheet opens, "Edit check →" row visible at bottom; tap it → sheet closes and edit modal opens
- [ ] Someone else's check: tap card → sheet opens, no edit row
- [ ] Movie check: movie card renders in sheet with letterboxd link
- [ ] Same flow works on event cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)