### PR TITLE
Hide attendance block when creator taps Edit event

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -263,13 +263,18 @@ function EventDetailSheet({
   onEdit?: () => void;
   onClose: () => void;
 }) {
+  // Creators: hide the attendance block the moment they tap "Edit event" so the
+  // list doesn't linger under the edit modal during the sheet's close animation.
+  const [editInitiated, setEditInitiated] = useState(false);
+  const handleEdit = onEdit ? () => { setEditInitiated(true); onEdit(); } : undefined;
   return (
-    <DetailSheet onClose={onClose} editLabel={onEdit ? "Edit event" : undefined} onEdit={onEdit}>
+    <DetailSheet onClose={onClose} editLabel={onEdit ? "Edit event" : undefined} onEdit={handleEdit}>
       <SheetHero
         event={event} userId={userId} sourceLink={sourceLink}
         poolPeople={poolPeople} poolFriends={poolFriends} poolStrangerCount={poolStrangerCount}
         nonPoolFriends={nonPoolFriends} mutuals={mutuals} others={others} hasPool={hasPool}
         actionButtons={actionButtons} onOpenSocial={onOpenSocial} onViewProfile={onViewProfile}
+        hideSocial={editInitiated}
       />
       <div className="mt-4">
         <InlineCommentsBox
@@ -294,6 +299,7 @@ interface SheetProps {
   actionButtons: React.ReactNode;
   onOpenSocial: () => void;
   onViewProfile?: (userId: string) => void;
+  hideSocial?: boolean;
 }
 
 // Linkify URLs in text
@@ -603,8 +609,8 @@ function SheetHero(props: SheetProps) {
         </div>
       )}
 
-      {/* Social */}
-      <SocialBlock {...props} />
+      {/* Social — hidden once the creator taps "Edit event" */}
+      {!props.hideSocial && <SocialBlock {...props} />}
 
       <div className="mt-3">{actionButtons}</div>
     </>


### PR DESCRIPTION
## Summary
On the event detail sheet, creators (users who see the "Edit event →" row) saw the SocialBlock (attendance/pool list) linger under the EditEventModal during the sheet's close animation. Track an `editInitiated` flag that flips when the row is tapped; `SheetHero` skips the `SocialBlock` when it's set.

## Test plan
- [ ] Non-creator taps an event card → detail sheet shows attendance (unchanged)
- [ ] Creator taps their own event → sheet shows attendance initially
- [ ] Creator taps "Edit event →" → attendance disappears, edit modal opens, sheet slides out

🤖 Generated with [Claude Code](https://claude.com/claude-code)