### PR TITLE
Wire client Sentry + enrich event-save error reports

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,8 +1,21 @@
 import * as Sentry from "@sentry/nextjs";
 
+const SENSITIVE_KEYS = ["note", "rawCaption", "caption", "email", "password"];
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
   release: process.env.NEXT_PUBLIC_BUILD_ID,
   tracesSampleRate: 0.1,
+  beforeSend(event) {
+    // Defensive: strip free-text fields (event notes, scraped captions) that
+    // could leak user content. Call sites should already avoid sending these
+    // via logError context — this is a safety net.
+    if (event.extra) {
+      for (const k of SENSITIVE_KEYS) {
+        if (k in event.extra) delete event.extra[k];
+      }
+    }
+    return event;
+  },
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -661,7 +661,18 @@ export default function Home() {
         setNewlyAddedId(newEvent.id);
         setTimeout(() => setNewlyAddedId(null), 2500);
       } catch (err) {
-        logError("saveEvent", err, { title });
+        logError("saveEvent", err, {
+          userId,
+          title,
+          venue,
+          dateISO,
+          visibility,
+          igUrl,
+          diceUrl,
+          letterboxdUrl,
+          raUrl,
+          hasMovie: !!movieMetadata,
+        });
         showToast("Failed to save - try again");
         return;
       }

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
 import type { Profile } from "@/lib/types";
-import { logError } from "@/lib/logger";
+import { logError, setSentryUser } from "@/lib/logger";
 
 export function useAuth() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -17,6 +17,7 @@ export function useAuth() {
         if (session?.user) {
           setIsLoggedIn(true);
           setUserId(session.user.id);
+          setSentryUser(session.user.id);
 
           try {
             const { data } = await supabase
@@ -46,6 +47,7 @@ export function useAuth() {
           setIsLoggedIn(false);
           setUserId(null);
           setProfile(null);
+          setSentryUser(null);
           setIsLoading(false);
         }
       }

--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useMemo } from 'react';
 import { useModalTransition } from '@/shared/hooks/useModalTransition';
 import type { ScrapedEvent } from '@/lib/ui-types';
 import { parseNaturalDate, parseNaturalTime, sanitize } from '@/lib/utils';
-import { logWarn } from '@/lib/logger';
+import { logError, logWarn } from '@/lib/logger';
 import * as db from '@/lib/db';
 import { API_BASE } from '@/lib/db';
 import cn from '@/lib/tailwindMerge';
@@ -262,6 +262,7 @@ const AddModal = ({
         }
       }
     } catch (err) {
+      logError('scrapeEvent', err, { url });
       setError('Network error. Please try again.');
     }
 

--- a/src/features/events/hooks/useEvents.ts
+++ b/src/features/events/hooks/useEvents.ts
@@ -212,7 +212,14 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
           note: updated.note || null,
         });
       } catch (err) {
-        logError("updateEvent", err, { eventId: editingEvent.id });
+        logError("updateEvent", err, {
+          userId,
+          eventId: editingEvent.id,
+          fields: Object.keys(updated),
+          title: updated.title,
+          venue: updated.venue,
+          dateISO,
+        });
         showToast("Failed to update - try again");
         return;
       }

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,0 +1,7 @@
+// Client-side Sentry init. Next.js 15+ loads this file automatically
+// (the older `sentry.client.config.ts` at the project root is no longer
+// auto-picked up on the client — that's why DSN-set deploys were still silent).
+import "../sentry.client.config";
+
+import * as Sentry from "@sentry/nextjs";
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/nextjs';
 import { supabase } from './supabase';
 import { toLocalISODate } from './utils';
 
@@ -145,6 +146,13 @@ export async function createEvent(event: Omit<Event, 'id' | 'created_at' | 'crea
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
+  Sentry.addBreadcrumb({
+    category: 'db',
+    message: 'createEvent',
+    level: 'info',
+    data: { title: event.title, visibility: (event as { visibility?: string }).visibility, hasIg: !!event.ig_url, hasDice: !!event.dice_url, hasLetterboxd: !!event.letterboxd_url, hasRa: !!(event as { ra_url?: string }).ra_url },
+  });
+
   const { data, error } = await supabase
     .from('events')
     .insert({ ...event, created_by: user.id })
@@ -163,6 +171,13 @@ export async function updateEvent(
 ): Promise<Event> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
+
+  Sentry.addBreadcrumb({
+    category: 'db',
+    message: 'updateEvent',
+    level: 'info',
+    data: { eventId, fields: Object.keys(updates) },
+  });
 
   const { data, error } = await supabase
     .from('events')

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -2,6 +2,24 @@ import * as Sentry from "@sentry/nextjs";
 
 const isDev = process.env.NODE_ENV === "development";
 
+/** Set the current user on the Sentry scope. Call after auth resolves. */
+export function setSentryUser(userId: string | null) {
+  if (userId) {
+    Sentry.setUser({ id: userId });
+  } else {
+    Sentry.setUser(null);
+  }
+}
+
+/** Browser-only context attached to every error report. */
+function browserContext(): Record<string, unknown> | undefined {
+  if (typeof window === "undefined") return undefined;
+  return {
+    url: window.location.href,
+    ua: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+  };
+}
+
 /**
  * Extract useful fields from Supabase/Postgres errors.
  */
@@ -32,22 +50,29 @@ export function logError(
   context?: Record<string, unknown>,
 ) {
   const errorInfo = extractErrorInfo(error);
+  const fullContext = { ...context, ...browserContext() };
 
   if (isDev) {
     console.groupCollapsed(`%c✖ ${action}`, "color: #ff6b6b; font-weight: bold");
     console.error("Error:", errorInfo);
-    if (context) console.log("Context:", context);
+    if (Object.keys(fullContext).length > 0) console.log("Context:", fullContext);
     if (error instanceof Error && error.stack) console.log("Stack:", error.stack);
     console.groupEnd();
   } else {
     console.error(
-      JSON.stringify({ level: "error", action, error: errorInfo, ...context }),
+      JSON.stringify({ level: "error", action, error: errorInfo, ...fullContext }),
     );
-    Sentry.captureException(error instanceof Error ? error : new Error(String(errorInfo.message ?? errorInfo.raw)), {
-      tags: { action },
-      extra: context,
-    });
   }
+
+  // Always ship to Sentry (it's a no-op if DSN isn't set). Report in dev too
+  // when the DSN is on — makes smoke-testing the wiring easy.
+  Sentry.captureException(
+    error instanceof Error ? error : new Error(String(errorInfo.message ?? errorInfo.raw)),
+    {
+      tags: { action },
+      extra: { ...errorInfo, ...fullContext },
+    },
+  );
 }
 
 export function logWarn(


### PR DESCRIPTION
## Summary
Main finding: **`NEXT_PUBLIC_SENTRY_DSN` was set in Vercel since March**, but Next.js 15+ no longer auto-loads `sentry.client.config.ts`. It needs an `instrumentation-client.ts` file. Without one, `Sentry.init` never runs on the client and every `captureException` is a silent no-op. That's why no browser errors were arriving.

## Changes
- **New** `src/instrumentation-client.ts` — imports `sentry.client.config` + wires `onRouterTransitionStart` (the Next.js 15+ pattern).
- **`src/lib/logger.ts`** — always ship to Sentry (was gated on `!isDev` — no-op anyway when DSN is unset, and this makes smoke-testing simpler). Attach `url` + `userAgent` to every report. New `setSentryUser(id)` helper.
- **`src/features/auth/hooks/useAuth.ts`** — call `setSentryUser(id)` on `SIGN_IN` / `INITIAL_SESSION`, clear on `SIGN_OUT`.
- **`src/features/events/components/CreateModal.tsx`** — close the silent `catch (err) { setError(...) }` on `/api/scrape` with `logError('scrapeEvent', err, { url })`.
- **`src/app/page.tsx`** `saveEvent` catch — attach `userId`, `venue`, `dateISO`, `visibility`, source URLs, `hasMovie`.
- **`src/features/events/hooks/useEvents.ts`** `updateEvent` catch — attach `userId`, `eventId`, `fields`, `title`, `venue`, `dateISO`.
- **`src/lib/db.ts`** — `Sentry.addBreadcrumb` on `createEvent` and `updateEvent` so captured exceptions include the DB attempt context.
- **`sentry.client.config.ts`** — `beforeSend` strips `note`, `rawCaption`, `caption`, `email`, `password` from `extra` as a defensive PII guard.

No free-text event notes, emails, or scraped captions are sent.

## Test plan
- [ ] After merge + Vercel redeploy, open `/api/version` / any page → Sentry dashboard shows a session
- [ ] Force a save failure (e.g. temporarily break the supabase URL locally) and confirm a report appears with `userId`, `title`, `venue` in extras and a `createEvent` breadcrumb
- [ ] Confirm `beforeSend` scrubs: send a test event with `extra.note = "test"` and check Sentry strips it

🤖 Generated with [Claude Code](https://claude.com/claude-code)