### PR TITLE
Add Date/Time and Where labels above when/where inputs

### DIFF
--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -252,22 +252,27 @@ const EditCheckModal = ({
           </div>
 
           {/* When / Where inputs — matching creation flow */}
-          <div className="flex gap-2 mb-1">
-            <input
-              type="text"
-              placeholder="when? (e.g. tmr 7pm)"
-              value={whenInput}
-              onChange={(e) => setWhenInput(e.target.value)}
-              className="flex-1 min-w-0 py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
-            />
-            <input
-              type="text"
-              placeholder="where?"
-              value={whereInput}
-              onChange={(e) => setWhereInput(e.target.value)}
-              className="min-w-0 py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
-              style={{ flex: 0.6 }}
-            />
+          <div className="flex gap-2 mb-1 items-end">
+            <div className="flex-1 min-w-0">
+              <div className="font-mono text-tiny uppercase text-dim mb-1" style={{ letterSpacing: "0.15em" }}>Date/Time</div>
+              <input
+                type="text"
+                placeholder="e.g. tmr 7pm"
+                value={whenInput}
+                onChange={(e) => setWhenInput(e.target.value)}
+                className="w-full py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
+              />
+            </div>
+            <div className="min-w-0" style={{ flex: 0.6 }}>
+              <div className="font-mono text-tiny uppercase text-dim mb-1" style={{ letterSpacing: "0.15em" }}>Where</div>
+              <input
+                type="text"
+                placeholder="location"
+                value={whereInput}
+                onChange={(e) => setWhereInput(e.target.value)}
+                className="w-full py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
+              />
+            </div>
           </div>
           {whenPreview && (
             <div className="font-mono text-tiny text-dim mb-2" style={{ paddingLeft: 2 }}>

--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -737,25 +737,30 @@ const AddModal = ({
                 })()}
             </div>
             {/* When / Where inputs */}
-            <div className="flex gap-2 mb-1">
-              <input
-                type="text"
-                placeholder="when? (e.g. tmr 7pm)"
-                value={whenInput}
-                onChange={(e) => setWhenInput(e.target.value)}
-                className="flex-1 min-w-0 py-2.5 px-3 bg-deep rounded-lg font-mono text-xs text-primary outline-none box-border"
-                style={{
-                  border: `1px solid ${idea.trim() && !parsedDate ? '#ff6b6b44' : '#333'}`,
-                }}
-              />
-              <input
-                type="text"
-                placeholder="where?"
-                value={whereInput}
-                onChange={(e) => setWhereInput(e.target.value)}
-                className="min-w-0 py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
-                style={{ flex: 0.6 }}
-              />
+            <div className="flex gap-2 mb-1 items-end">
+              <div className="flex-1 min-w-0">
+                <div className="font-mono text-tiny uppercase text-dim mb-1" style={{ letterSpacing: "0.15em" }}>Date/Time</div>
+                <input
+                  type="text"
+                  placeholder="e.g. tmr 7pm"
+                  value={whenInput}
+                  onChange={(e) => setWhenInput(e.target.value)}
+                  className="w-full py-2.5 px-3 bg-deep rounded-lg font-mono text-xs text-primary outline-none box-border"
+                  style={{
+                    border: `1px solid ${idea.trim() && !parsedDate ? '#ff6b6b44' : '#333'}`,
+                  }}
+                />
+              </div>
+              <div className="min-w-0" style={{ flex: 0.6 }}>
+                <div className="font-mono text-tiny uppercase text-dim mb-1" style={{ letterSpacing: "0.15em" }}>Where</div>
+                <input
+                  type="text"
+                  placeholder="location"
+                  value={whereInput}
+                  onChange={(e) => setWhereInput(e.target.value)}
+                  className="w-full py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
+                />
+              </div>
             </div>
             {whenPreview && (
               <div className="font-mono text-tiny text-dim mb-2" style={{ paddingLeft: 2 }}>

--- a/src/features/events/components/EditEventModal.tsx
+++ b/src/features/events/components/EditEventModal.tsx
@@ -156,7 +156,7 @@ const EditEventModal = ({
             {/* When / Where — matching creation flow */}
             <div className="flex gap-2">
               <div className="flex-1">
-                <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>When</div>
+                <div className="font-mono text-tiny uppercase text-dim mb-1.5" style={{ letterSpacing: "0.15em" }}>Date/Time</div>
                 <input
                   type="text"
                   placeholder="e.g. fri 9pm"


### PR DESCRIPTION
## Summary
- **`CreateModal`**: wrap the when/where input row in labeled columns ("Date/Time" and "Where" as `font-mono text-tiny uppercase text-dim` hints above each box).
- **`EditCheckModal`**: same treatment — previously the inputs were unlabeled.
- **`EditEventModal`**: rename existing "When" label to "Date/Time" so all three modals match.

Placeholders dropped to plain `"e.g. tmr 7pm"` / `"location"` since the label now carries the semantic weight.

## Test plan
- [ ] Open Create Event/Check modal → see "DATE/TIME" and "WHERE" labels above the two inputs
- [ ] Tap an own event → "Edit event" → labels read "DATE/TIME" and "WHERE"
- [ ] Tap an own check → "Edit check" → labels read "DATE/TIME" and "WHERE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)