### PR TITLE
feat: y2k palette on OKLCH scales + theme preview route

### DIFF
--- a/src/app/theme-preview/page.tsx
+++ b/src/app/theme-preview/page.tsx
@@ -1,0 +1,334 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import EventCard from "@/features/events/components/EventCard";
+import CheckCard from "@/features/checks/components/CheckCard";
+import { FeedContext } from "@/features/checks/context/FeedContext";
+import type { FeedContextValue } from "@/features/checks/context/FeedContext";
+import type { Event, InterestCheck, Friend } from "@/lib/ui-types";
+import type { Profile } from "@/lib/types";
+import { themes } from "@/lib/themes";
+import type { ThemeName } from "@/lib/themes";
+import { applyTheme } from "@/app/components/ThemeHydrator";
+import cn from "@/lib/tailwindMerge";
+
+const THEME_STORAGE_KEY = "downto-theme";
+const THEME_NAMES = Object.keys(themes) as ThemeName[];
+
+const MOCK_USER_ID = "mock-user";
+const MOCK_PROFILE: Profile = {
+  id: MOCK_USER_ID,
+  display_name: "kat",
+  avatar_letter: "K",
+  username: "kat",
+} as Profile;
+
+const MOCK_PEOPLE = [
+  { name: "Sara", avatar: "S", mutual: true, userId: "u1" },
+  { name: "Devon", avatar: "D", mutual: true, userId: "u2" },
+  { name: "Nic", avatar: "N", mutual: false, userId: "u3" },
+  { name: "Gian", avatar: "G", mutual: true, userId: "u4" },
+];
+
+const FLYER_IMAGE = "https://images.unsplash.com/photo-1514525253161-7a46d19cd819?w=800&q=80";
+const POSTER_IMAGE = "https://images.unsplash.com/photo-1492684223066-81342ee5ff30?w=800&q=80";
+
+// Stable fake UUIDs so DB queries return empty instead of throwing.
+const uuid = (n: number) => `00000000-0000-0000-0000-${String(n).padStart(12, "0")}`;
+
+const mockEvent = (id: string, overrides: Partial<Event> = {}): Event => ({
+  id,
+  createdBy: "u1",
+  title: "viet heritage night @yankees (free hat giveaway)",
+  venue: "Yankee Stadium",
+  date: "Thu, Aug 27",
+  time: "7pm",
+  vibe: [],
+  image: "",
+  igHandle: "vcs.nyc",
+  saved: false,
+  isDown: false,
+  peopleDown: MOCK_PEOPLE.slice(0, 3),
+  isPublic: false,
+  visibility: "friends",
+  posterName: "martinckong24",
+  posterAvatar: "M",
+  ...overrides,
+});
+
+const mockCheck = (id: string, overrides: Partial<InterestCheck> = {}): InterestCheck => ({
+  id,
+  text: "ramen in bushwick this weekend?",
+  author: "sara",
+  authorId: "u1",
+  timeAgo: "2h",
+  expiresIn: "6h",
+  expiryPercent: 40,
+  responses: [
+    { name: "Devon", avatar: "D", status: "down" as const },
+    { name: "Nic", avatar: "N", status: "down" as const },
+  ],
+  isYours: false,
+  ...overrides,
+});
+
+const noopFeedCtx: FeedContextValue = {
+  checks: [],
+  myCheckResponses: {},
+  hiddenCheckIds: new Set(),
+  pendingDownCheckIds: new Set(),
+  newlyAddedCheckId: null,
+  leftChecks: [],
+  events: [],
+  newlyAddedEventId: null,
+  respondToCheck: () => {},
+  clearResponse: () => {},
+  acceptCoAuthorTag: async () => {},
+  declineCoAuthorTag: async () => {},
+  hideCheck: () => {},
+  unhideCheck: () => {},
+  redownFromLeft: () => {},
+  toggleDown: async () => {},
+};
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-8">
+      <div
+        className="font-mono text-tiny uppercase text-faint mb-2"
+        style={{ letterSpacing: "0.15em" }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export default function ThemePreview() {
+  const [activeTheme, setActiveTheme] = useState<ThemeName | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null;
+    if (stored && stored in themes) setActiveTheme(stored);
+    else setActiveTheme("dragonfruit");
+  }, []);
+
+  const sharedCheckProps = {
+    userId: MOCK_USER_ID,
+    profile: MOCK_PROFILE,
+    friends: [] as Friend[],
+    initialCommentCount: 0,
+    startSquadFromCheck: async () => {},
+    onNavigateToGroups: () => {},
+    showToast: () => {},
+    loadRealData: async () => {},
+  };
+
+  const sharedEventProps = {
+    userId: MOCK_USER_ID,
+    onToggleDown: () => {},
+    onOpenSocial: () => {},
+  };
+
+  return (
+    <FeedContext.Provider value={noopFeedCtx}>
+      <div className="min-h-screen bg-bg p-4 pb-20 overflow-y-auto" style={{ height: "100vh" }}>
+        <div className="max-w-[480px] mx-auto">
+          <h1 className="font-serif text-2xl text-primary mb-1">theme preview</h1>
+          <p className="font-mono text-xs text-dim mb-4">
+            Every card variant rendered at once so you can see how token changes ripple.
+          </p>
+
+          {/* Theme switcher */}
+          <div className="mb-6 bg-card rounded-2xl p-3 border border-border">
+            <div
+              className="font-mono text-tiny uppercase text-faint mb-2"
+              style={{ letterSpacing: "0.15em" }}
+            >
+              Theme
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {THEME_NAMES.map((name) => {
+                const isActive = activeTheme === name;
+                return (
+                  <button
+                    key={name}
+                    onClick={() => {
+                      setActiveTheme(name);
+                      localStorage.setItem(THEME_STORAGE_KEY, name);
+                      applyTheme(name);
+                    }}
+                    className={cn(
+                      "rounded-xl py-1.5 px-3 font-mono text-xs cursor-pointer transition-all",
+                      isActive
+                        ? "bg-dt text-on-accent font-bold border border-transparent"
+                        : "bg-transparent text-muted border border-border-mid"
+                    )}
+                  >
+                    {name}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <Section title="Event cards — no image">
+            <EventCard
+              {...sharedEventProps}
+              event={mockEvent(uuid(1), {
+                title: "Mietze Conte, CFCF dj set",
+                venue: "Elsewhere",
+                date: "Fri, May 1",
+                time: "6pm",
+                posterName: "nic",
+                posterAvatar: "N",
+              })}
+            />
+            <EventCard
+              {...sharedEventProps}
+              event={mockEvent(uuid(2), {
+                title: "late night ramen run",
+                venue: "Ippudo",
+                date: "Sat, May 2",
+                time: "11pm",
+                isDown: true,
+                peopleDown: MOCK_PEOPLE,
+                posterName: "gian",
+                posterAvatar: "G",
+              })}
+            />
+          </Section>
+
+          <Section title="Event cards — with image (wash)">
+            <EventCard
+              {...sharedEventProps}
+              event={mockEvent(uuid(3), {
+                image: FLYER_IMAGE,
+                title: "Teksupport: FOUR TET",
+                venue: "Brooklyn Storehouse",
+                date: "Thu, Sep 17",
+                time: "10:00 PM",
+                posterName: "aidanfox",
+                posterAvatar: "A",
+              })}
+            />
+            <EventCard
+              {...sharedEventProps}
+              event={mockEvent(uuid(4), {
+                image: POSTER_IMAGE,
+                title: "pole hang & kbbq",
+                venue: "sarah f's in LIC",
+                date: "Sat, May 30",
+                time: "7pm",
+                isDown: true,
+                peopleDown: MOCK_PEOPLE,
+                posterName: "sarah f",
+                posterAvatar: "S",
+              })}
+            />
+            <EventCard
+              {...sharedEventProps}
+              event={mockEvent(uuid(5), {
+                image: FLYER_IMAGE,
+                title: "new event card (glow)",
+                posterName: "ninja",
+                posterAvatar: "N",
+              })}
+              isNew
+            />
+          </Section>
+
+          <Section title="Interest checks — regular, mine, via friend, others-down">
+            <CheckCard
+              {...sharedCheckProps}
+              check={mockCheck(uuid(11))}
+            />
+            <CheckCard
+              {...sharedCheckProps}
+              check={mockCheck(uuid(12), {
+                text: "watch @krn shave my head and someone else bleaches/dyes it in the near future",
+                author: "kat",
+                authorId: MOCK_USER_ID,
+                isYours: true,
+                eventDate: "2026-04-20",
+                eventDateLabel: "Mon, Apr 20",
+                eventTime: "7:20pm",
+                location: "kat apt 591 willoughby ave apt 2",
+                responses: MOCK_PEOPLE.map(p => ({ name: p.name, avatar: p.avatar, status: "down" as const })),
+              })}
+            />
+            <CheckCard
+              {...sharedCheckProps}
+              check={mockCheck(uuid(13), {
+                text: "anyone down for a coffee walk tomorrow morning?",
+                author: "devon",
+                authorId: "u2",
+                viaFriendName: "sara",
+              })}
+            />
+            <CheckCard
+              {...sharedCheckProps}
+              check={mockCheck(uuid(14), {
+                text: "late-night diner run anyone?",
+                author: "nic",
+                authorId: "u3",
+                responses: MOCK_PEOPLE.slice(0, 3).map(p => ({ name: p.name, avatar: p.avatar, status: "down" as const })),
+              })}
+            />
+          </Section>
+
+          <Section title="Buttons & controls">
+            <div className="flex flex-wrap gap-2 items-center">
+              <button className="rounded-full py-1.5 px-3 font-mono text-tiny font-bold bg-dt text-on-accent">
+                DOWN ✓
+              </button>
+              <button className="rounded-full py-1.5 px-3 font-mono text-tiny font-bold bg-[var(--color-down-idle-bg)] text-dt border border-[var(--color-down-idle-border)]">
+                DOWN ?
+              </button>
+              <button className="rounded-xl py-2 px-3.5 font-mono text-xs bg-transparent text-muted border border-border-mid">
+                secondary
+              </button>
+              <button className="rounded-lg py-2 px-3 font-mono text-xs bg-[#ff4444] text-white">
+                destructive
+              </button>
+              <span className="px-2 py-0.5 rounded-full bg-dt/15 text-dt font-mono text-tiny">
+                accent tag
+              </span>
+              <span className="px-2 py-0.5 rounded-full bg-surface text-muted border border-border font-mono text-tiny">
+                neutral tag
+              </span>
+            </div>
+          </Section>
+
+          <Section title="Color tokens (swatches)">
+            <div className="grid grid-cols-2 gap-2 font-mono text-tiny">
+              {[
+                ["bg", "--color-bg"],
+                ["card", "--color-card"],
+                ["surface", "--color-surface"],
+                ["deep", "--color-deep"],
+                ["primary", "--color-primary"],
+                ["muted", "--color-muted"],
+                ["dim", "--color-dim"],
+                ["faint", "--color-faint"],
+                ["border", "--color-border"],
+                ["border-light", "--color-border-light"],
+                ["border-mid", "--color-border-mid"],
+                ["accent (dt)", "--color-dt"],
+              ].map(([label, cssVar]) => (
+                <div key={cssVar} className="flex items-center gap-2 border border-border rounded-md p-1.5">
+                  <div
+                    className="w-6 h-6 rounded-sm border border-border-mid shrink-0"
+                    style={{ background: `var(${cssVar})` }}
+                  />
+                  <span className="text-dim">{label}</span>
+                </div>
+              ))}
+            </div>
+          </Section>
+        </div>
+      </div>
+    </FeedContext.Provider>
+  );
+}

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -185,7 +185,7 @@ const EventCard = ({
           {/* Author header */}
           {event.posterName && (
             <div className="flex items-center gap-1.5 mb-2">
-              <div className="w-5 h-5 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-[9px] font-bold shrink-0">
+              <div className="w-5 h-5 rounded-full bg-border-light text-dt flex items-center justify-center font-mono text-[9px] font-bold shrink-0">
                 {event.posterAvatar || event.posterName[0]?.toUpperCase()}
               </div>
               <span className="font-mono text-tiny text-muted min-w-0 truncate">
@@ -371,7 +371,7 @@ function PosterInline({ event, userId, note, onViewProfile }: { event: Event; us
         onClick={canTap ? (e) => { e.stopPropagation(); onViewProfile!(event.createdBy!); } : undefined}
         className={cn(
           "rounded-full flex items-center justify-center font-mono font-bold shrink-0",
-          event.createdBy === userId ? "bg-dt text-on-accent" : "bg-border-light text-dim",
+          event.createdBy === userId ? "bg-dt text-on-accent" : "bg-border-light text-dt",
           canTap ? "cursor-pointer" : "cursor-default"
         )}
         style={{ width: 20, height: 20, fontSize: 8 }}
@@ -637,8 +637,6 @@ function SheetHero(props: SheetProps) {
 
       {/* Social — hidden once the creator taps "Edit event" */}
       {!props.hideSocial && <SocialBlock {...props} />}
-
-      <div className="mt-3">{actionButtons}</div>
     </>
   );
 }

--- a/src/lib/themes/dragonfruit.ts
+++ b/src/lib/themes/dragonfruit.ts
@@ -1,47 +1,57 @@
 import type { ThemeTokens } from "./types";
+import { gray, magenta, lime } from "./scales";
 
+// Dragonfruit — Y2K direction: loud, saturated magenta borders, lime
+// accent at max punch. Built on OKLCH scales so tuning `scales.ts`
+// ripples through every token that references a step.
 export const dragonfruit: ThemeTokens = {
-  accent: "#E8FF5A",
-  bg: "#141412",
-  card: "#1c1c19",
-  surface: "#252521",
-  deep: "#181815",
-  text: "#E5E5DC",
-  muted: "#8A8A80",
-  dim: "#70706A",
-  faint: "#55554F",
-  border: "#3D1F3D",
-  borderLight: "#4A2548",
-  borderMid: "#5C2E5A",
-  pool: "#00D4FF",
+  // Surfaces — low chroma warm gray, dragonfruit-tinted
+  bg: gray[1],
+  card: gray[2],
+  surface: gray[3],
+  deep: gray[4],
 
-  danger: "#ff6b6b",
+  // Text ramp
+  text: gray[12],
+  muted: gray[10],
+  dim: gray[9],
+  faint: gray[8],
+
+  // Borders — vivid magenta. Meant to be seen.
+  border: magenta[6],
+  borderLight: magenta[7],
+  borderMid: magenta[9],
+
+  // Accent — lime at max punch
+  accent: lime[10],
+  onAccent: "#0a0a00",
+  accentFaint: `oklch(0.92 0.22 115 / 0.06)`,
+  accentSubtle: `oklch(0.92 0.22 115 / 0.12)`,
+  accentLight: `oklch(0.92 0.22 115 / 0.22)`,
+  accentMid: `oklch(0.92 0.22 115 / 0.55)`,
+
+  pool: "#00D4FF",
+  danger: "#ff4d6d",
   success: "#51cf66",
   warn: "#ffa94d",
   info: "#5ac8fa",
-  squad: "#a855f7",
+  squad: "#c026d3",
 
-  accentFaint: "rgba(232,255,90,0.04)",
-  accentSubtle: "rgba(232,255,90,0.08)",
-  accentLight: "rgba(232,255,90,0.15)",
-  accentMid: "rgba(232,255,90,0.5)",
+  downIdleBg: gray[5],
+  downIdleBorder: magenta[7],
 
-  onAccent: "#000",
+  // Check states
+  checkMineBg: magenta[3],
+  checkDownBg: lime[3],
+  checkNewBg: lime[4],
+  checkNewBorder: lime[7],
 
-  downIdleBg: "#2A2A24",
-  downIdleBorder: "#3D3D38",
-
-  checkMineBg: "#252419",
-  checkDownBg: "#3A3D1D",
-  checkNewBg: "#2A2A15",
-  checkNewBorder: "#55572A",
-
-  eventImageWash: "rgba(252,255,226,0.3)",
-  eventImageWashDown: "rgba(200,230,60,0.3)",
+  eventImageWash: "rgba(255,240,245,0.55)",
+  eventImageWashDown: "rgba(200,230,60,0.6)",
 
   fontMono: "var(--font-space-mono), monospace",
   fontSerif: "var(--font-instrument-serif), serif",
-  serifTitleTracking: "0.02em",
+  serifTitleTracking: "0.04em",
 
   themeColor: "#141412",
 };

--- a/src/lib/themes/scales.ts
+++ b/src/lib/themes/scales.ts
@@ -1,0 +1,72 @@
+// Perceptual OKLCH color scales — 12 steps per hue, Radix-inspired
+// roles:
+//   1  app background        (darkest)
+//   2  card background
+//   3  elevated surface
+//   4  deep/between (1–2)
+//   5  subtle border
+//   6  border
+//   7  strong border / quiet text
+//   8  hairline / faint text
+//   9  dim text
+//   10 muted text
+//   11 secondary text
+//   12 primary text         (brightest)
+//
+// Tweak a single step's L or C and it ripples through every token that
+// references it, so contrast relationships stay coherent.
+
+type Scale = { [K in 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12]: string };
+
+const buildScale = (hue: number, L: number[], C: number[]): Scale => {
+  const out: Record<number, string> = {};
+  for (let i = 0; i < 12; i++) {
+    out[i + 1] = `oklch(${L[i].toFixed(3)} ${C[i].toFixed(3)} ${hue})`;
+  }
+  return out as Scale;
+};
+
+// Hues (degrees)
+export const HUE = {
+  gray: 340,      // whisper of magenta in the neutrals
+  magenta: 340,   // dragonfruit identity
+  lime: 115,      // accent yellow-green
+  warmPaper: 85,  // cream/paper for image wash overlays
+};
+
+// Warm gray — neutrals with tiny magenta bias. Chroma stays under 0.03.
+export const gray = buildScale(
+  HUE.gray,
+  [0.140, 0.170, 0.210, 0.180, 0.250, 0.320, 0.400, 0.500, 0.600, 0.720, 0.850, 0.940],
+  [0.010, 0.012, 0.015, 0.012, 0.018, 0.022, 0.025, 0.028, 0.025, 0.020, 0.015, 0.012],
+);
+
+// Magenta — chroma climbs with lightness, peaks at mid. For borders + identity.
+export const magenta = buildScale(
+  HUE.magenta,
+  [0.150, 0.200, 0.250, 0.300, 0.350, 0.420, 0.500, 0.580, 0.650, 0.720, 0.800, 0.880],
+  [0.050, 0.070, 0.100, 0.120, 0.150, 0.170, 0.190, 0.200, 0.220, 0.220, 0.200, 0.150],
+);
+
+// Lime — the accent. Step 9–10 = the vivid yellow-green.
+export const lime = buildScale(
+  HUE.lime,
+  [0.150, 0.220, 0.300, 0.380, 0.450, 0.550, 0.650, 0.750, 0.850, 0.920, 0.960, 0.980],
+  [0.050, 0.080, 0.100, 0.120, 0.140, 0.160, 0.180, 0.200, 0.220, 0.220, 0.180, 0.120],
+);
+
+// Warm paper — cream tones for image-wash overlays + their text/borders.
+// Darker steps here are the "on-cream" ramp (borders + text over the wash).
+export const warmPaper = buildScale(
+  HUE.warmPaper,
+  [0.120, 0.180, 0.260, 0.340, 0.420, 0.520, 0.620, 0.720, 0.820, 0.900, 0.960, 0.985],
+  [0.012, 0.018, 0.028, 0.035, 0.040, 0.045, 0.040, 0.032, 0.025, 0.020, 0.015, 0.010],
+);
+
+// Cold gray — pure neutrals, zero chroma. For editorial/minimal direction
+// where color shouldn't bleed into structure.
+export const coldGray = buildScale(
+  0,
+  [0.140, 0.170, 0.210, 0.180, 0.250, 0.320, 0.400, 0.500, 0.600, 0.720, 0.850, 0.940],
+  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+);


### PR DESCRIPTION
## Summary
- Dragonfruit rebuilt on perceptual OKLCH scales (`scales.ts` — warm gray, magenta, lime). Tuning one step ripples through every token that references it, so contrast math stays consistent as you iterate.
- Y2K direction: vivid magenta borders, lime accent at max punch, higher chroma neutrals.
- New `/theme-preview` route shows every card variant + a live theme switcher. Lets you evaluate token changes across all contexts at once instead of screenshot-chasing.
- Event card: avatar letters now use the accent color for readability against magenta avatar backgrounds. Detail sheet drops the redundant DOWN button (the feed card itself handles the toggle).

## Test plan
- [ ] Visit `/theme-preview` — switcher toggles between `guava` and `dragonfruit` live
- [ ] Confirm event cards with + without images render legibly
- [ ] Confirm check-mine, check-down, via-friend variants all legible
- [ ] Tap a feed event card → detail sheet shows no DOWN button at the bottom
- [ ] Tap DOWN on the feed card itself → still toggles state as before
- [ ] Avatar initials visible on author chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)