### PR TITLE
Tag active theme on Sentry scope for usage metrics

### DIFF
--- a/src/app/components/ThemeHydrator.tsx
+++ b/src/app/components/ThemeHydrator.tsx
@@ -1,17 +1,32 @@
 "use client";
 
 import { useEffect } from "react";
-import { themes, themeToCSSSVars } from "@/lib/themes";
+import * as Sentry from "@sentry/nextjs";
+import { themes, themeToCSSSVars, DEFAULT_THEME } from "@/lib/themes";
 import type { ThemeName } from "@/lib/themes";
 
 const THEME_STORAGE_KEY = "downto-theme";
 const THEME_VERSION_KEY = "downto-theme-version";
 const CURRENT_THEME_VERSION = "4";
 
+/**
+ * Tag the active theme on the Sentry scope. Attaches to every error, session,
+ * and performance event so we can slice theme usage / theme-specific bugs.
+ */
+function tagTheme(name: ThemeName) {
+  Sentry.setTag("theme", name);
+  Sentry.addBreadcrumb({ category: "theme", message: `apply ${name}`, level: "info" });
+}
+
 /** Apply a theme by injecting CSS vars, updating meta theme-color, and bg image */
 export function applyTheme(name: ThemeName) {
   if (!(name in themes)) return;
-  if (name === document.documentElement.dataset.theme) return;
+  if (name === document.documentElement.dataset.theme) {
+    // Even a no-op apply should re-tag — covers the switcher re-applying the
+    // current theme and the initial hydration call on default users.
+    tagTheme(name);
+    return;
+  }
 
   const cssVars = themeToCSSSVars(themes[name]);
   document.documentElement.dataset.theme = name;
@@ -32,6 +47,8 @@ export function applyTheme(name: ThemeName) {
   document.body.style.background = t.bgImage
     ? `var(--t-bg) url(${t.bgImage}) center/cover fixed`
     : "var(--t-bg)";
+
+  tagTheme(name);
 }
 
 export default function ThemeHydrator() {
@@ -54,6 +71,10 @@ export default function ThemeHydrator() {
     const stored = localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null;
     if (stored && stored in themes) {
       applyTheme(stored);
+    } else {
+      // No override stored → user is on the default theme. Still tag it so
+      // the Sentry "theme" breakdown reflects default-theme users too.
+      Sentry.setTag("theme", DEFAULT_THEME);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
Now that Sentry is actually capturing (PR #372), add a "theme" tag so we can see which themes users are on.

- `applyTheme` in `ThemeHydrator.tsx` sets `Sentry.setTag("theme", name)` on every call and drops a breadcrumb.
- The default-theme path (no override stored) also tags with `DEFAULT_THEME` so users who never customize still show up in distributions.
- The tag attaches automatically to every error event, session, and performance trace — no extra network calls.

## How to read it
Sentry → Issues or Discover → filter/group by `theme`. Sessions also carry the tag, so the Insights "Release Health" view breaks down active users per theme.

## Test plan
- [ ] After deploy, open the app → browser console: `window.__SENTRY__?.['10.42.0']?.defaultCurrentScope?._tags` should include `theme: "guava"` (or whatever you picked)
- [ ] Switch theme in the profile switcher → `_tags.theme` updates
- [ ] Trigger the smoke-test error — the captured event in Sentry carries the `theme` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)