### PR TITLE
style: darken image gradient on event detail sheet

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -561,7 +561,7 @@ function SheetHero(props: SheetProps) {
             />
             <div
               className="absolute inset-0"
-              style={{ background: "linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 60%)" }}
+              style={{ background: "linear-gradient(to top, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.65) 45%, transparent 100%)" }}
             />
             {/* Title over image */}
             <div className="absolute bottom-3 left-3.5 right-3.5 flex items-end justify-between">


### PR DESCRIPTION
## Summary
- Strengthen the bottom-up scrim behind the title on the event detail sheet hero (`SheetHero`) so the title stays readable on bright flyers.
- Was `rgba(0,0,0,0.7)` → transparent at 60%; now `rgba(0,0,0,0.92)` at bottom → `0.65` at 45% → transparent at 100%.

## Test plan
- [ ] Tap an event card with a light/bright flyer → title in the detail sheet is still readable against the image
- [ ] Tap an event card with a dark flyer → title still reads, gradient doesn't feel too heavy

🤖 Generated with [Claude Code](https://claude.com/claude-code)