### PR TITLE
Theme usage tracking via version_pings + admin dashboard

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,7 +16,7 @@ interface PushFailure {
   error: string | null;
 }
 
-type AdminTab = "users" | "engagement" | "push" | "versions";
+type AdminTab = "users" | "engagement" | "push" | "versions" | "themes";
 
 interface Metrics {
   totalUsers: number;
@@ -42,6 +42,10 @@ interface Metrics {
     distribution: { build_id: string; users: number; pings24h: number; latestPing: string; userNames: string[] }[];
     commitMessages: Record<string, string>;
   };
+  themes: {
+    distribution: { theme: string; users: number; pings24h: number; userNames: string[] }[];
+    usersReporting: number;
+  };
   engagement: {
     active7d: number;
     engaged7d: number;
@@ -66,6 +70,7 @@ export default function AdminPage() {
   const [loading, setLoading] = useState(true);
   const [versionSort, setVersionSort] = useState<"latest" | "users">("latest");
   const [expandedBuild, setExpandedBuild] = useState<string | null>(null);
+  const [expandedTheme, setExpandedTheme] = useState<string | null>(null);
   const [tab, setTab] = useState<AdminTab>("users");
 
   useEffect(() => {
@@ -157,6 +162,7 @@ export default function AdminPage() {
     { key: "engagement", label: "Engagement" },
     { key: "push", label: "Push" },
     { key: "versions", label: "Versions" },
+    { key: "themes", label: "Themes" },
   ];
 
   return (
@@ -470,6 +476,67 @@ export default function AdminPage() {
           ) : (
             <p className="text-faint font-mono text-xs text-center py-8">
               No version data
+            </p>
+          )}
+        </>
+      )}
+
+      {/* Themes tab */}
+      {tab === "themes" && (
+        <>
+          {metrics.themes.distribution.length > 0 ? (
+            <>
+              <p className="font-mono text-tiny text-dim mb-3">
+                Latest theme per user · {metrics.themes.usersReporting} users reporting (7d)
+              </p>
+              {(() => {
+                const total = metrics.themes.distribution.reduce((s, t) => s + t.users, 0) || 1;
+                return (
+                  <div className="flex flex-col gap-2">
+                    {metrics.themes.distribution.map((t) => {
+                      const pct = Math.round((t.users / total) * 100);
+                      const isExpanded = expandedTheme === t.theme;
+                      return (
+                        <div
+                          key={t.theme}
+                          onClick={() => setExpandedTheme(isExpanded ? null : t.theme)}
+                          className="p-3 rounded-lg border border-border bg-card cursor-pointer relative overflow-hidden"
+                        >
+                          <div
+                            className="absolute inset-y-0 left-0 bg-dt/10 pointer-events-none"
+                            style={{ width: `${pct}%` }}
+                          />
+                          <div className="relative flex justify-between items-center gap-2">
+                            <span className="font-mono text-xs text-primary shrink-0">
+                              <span className="text-faint mr-1.5">{isExpanded ? "▾" : "▸"}</span>
+                              {t.theme}
+                            </span>
+                            <span className="font-mono text-xs shrink-0">
+                              <span className="text-dt font-bold">{t.users}</span>
+                              <span className="text-dim"> users</span>
+                              <span className="text-faint ml-2">{pct}%</span>
+                              <span className="text-faint ml-2">{t.pings24h} 24h</span>
+                            </span>
+                          </div>
+                          {isExpanded && (
+                            <div className="flex flex-wrap gap-1 mt-2 relative" style={{ paddingLeft: 18 }}>
+                              {t.userNames.map((name) => (
+                                <span key={name} className="font-mono text-tiny text-muted bg-border-light px-2 py-0.5 rounded-md">
+                                  {name}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })()}
+            </>
+          ) : (
+            <p className="text-faint font-mono text-xs text-center py-8">
+              No theme data yet. Ship the ping and wait for users to load the app.
             </p>
           )}
         </>

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
       .order('created_at', { ascending: false })
       .limit(20),
     admin.from('version_pings')
-      .select('user_id, build_id, created_at')
+      .select('user_id, build_id, theme, created_at')
       .gte('created_at', since7d)
       .order('created_at', { ascending: false })
       .limit(10000),
@@ -149,6 +149,40 @@ export async function GET(request: NextRequest) {
       userNames: (usersByBuild.get(build_id) || []).map(uid => profileNames.get(uid) || uid.slice(0, 8)),
     }))
     .sort((a, b) => b.latestPing.localeCompare(a.latestPing));
+
+  // Theme distribution — latest theme per user (by most-recent ping), count unique
+  // users per theme, plus 24h ping count per theme.
+  const latestThemeByUser = new Map<string, string>(); // user_id → theme
+  const pingsPerTheme24h = new Map<string, number>();
+  if (versionPingsRes.data) {
+    for (const row of versionPingsRes.data as { user_id: string; theme: string | null; created_at: string }[]) {
+      const t = row.theme;
+      if (!t) continue;
+      if (!latestThemeByUser.has(row.user_id)) {
+        latestThemeByUser.set(row.user_id, t);
+      }
+      if (row.created_at >= since24h) {
+        pingsPerTheme24h.set(t, (pingsPerTheme24h.get(t) || 0) + 1);
+      }
+    }
+  }
+  const themeUsers = new Map<string, number>();
+  const themeUserIds = new Map<string, string[]>();
+  for (const [uid, t] of latestThemeByUser.entries()) {
+    themeUsers.set(t, (themeUsers.get(t) || 0) + 1);
+    const list = themeUserIds.get(t) || [];
+    list.push(uid);
+    themeUserIds.set(t, list);
+  }
+  const themeDistribution = Array.from(themeUsers.entries())
+    .map(([theme, users]) => ({
+      theme,
+      users,
+      pings24h: pingsPerTheme24h.get(theme) || 0,
+      userNames: (themeUserIds.get(theme) || []).map(uid => profileNames.get(uid) || uid.slice(0, 8)),
+    }))
+    .sort((a, b) => b.users - a.users);
+  const themeUsersReporting = latestThemeByUser.size;
 
   // Engagement metrics (7d)
   const [checksRes, responsesRes, commentsRes, messagesRes] = await Promise.all([
@@ -251,6 +285,10 @@ export async function GET(request: NextRequest) {
     versions: {
       distribution: versionDistribution,
       commitMessages,
+    },
+    themes: {
+      distribution: themeDistribution,
+      usersReporting: themeUsersReporting,
     },
     engagement: {
       active7d: activeUserIds.size,

--- a/src/app/components/UpdateBanner.tsx
+++ b/src/app/components/UpdateBanner.tsx
@@ -4,8 +4,22 @@ import { useEffect, useRef, useState } from "react";
 import { logVersionPing, API_BASE } from "@/lib/db";
 import { supabase } from "@/lib/supabase";
 import { color } from "@/lib/styles";
+import { DEFAULT_THEME } from "@/lib/themes";
 
 const CLIENT_BUILD_ID = process.env.NEXT_PUBLIC_BUILD_ID ?? "";
+const THEME_STORAGE_KEY = "downto-theme";
+
+/** Current theme: localStorage override, URL ?theme= param, or default. */
+function getActiveTheme(): string {
+  if (typeof window === "undefined") return DEFAULT_THEME;
+  try {
+    const q = new URLSearchParams(window.location.search).get("theme");
+    if (q) return q;
+    return window.localStorage.getItem(THEME_STORAGE_KEY) || DEFAULT_THEME;
+  } catch {
+    return DEFAULT_THEME;
+  }
+}
 const MIN_BACKGROUND_MS = 5 * 60 * 1000; // 5 minutes
 const POLL_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -29,7 +43,7 @@ export default function UpdateBanner() {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
       if ((event === "INITIAL_SESSION" || event === "SIGNED_IN") && !hasPinged.current) {
         hasPinged.current = true;
-        logVersionPing(CLIENT_BUILD_ID);
+        logVersionPing(CLIENT_BUILD_ID, getActiveTheme());
       }
     });
     return () => subscription.unsubscribe();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -103,12 +103,12 @@ export async function getFriendshipWith(userId: string): Promise<{ id: string; s
   return { id: data.id, status: data.status, isRequester: data.requester_id === user.id };
 }
 
-export async function logVersionPing(buildId: string): Promise<void> {
+export async function logVersionPing(buildId: string, theme?: string | null): Promise<void> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return;
   await supabase
     .from("version_pings")
-    .insert({ user_id: user.id, build_id: buildId });
+    .insert({ user_id: user.id, build_id: buildId, theme: theme ?? null });
 }
 
 // ============================================================================

--- a/supabase/migrations/20260420000001_version_pings_theme.sql
+++ b/supabase/migrations/20260420000001_version_pings_theme.sql
@@ -1,0 +1,9 @@
+-- Track which theme each user is on, piggybacking on version_pings.
+-- Nullable so old rows (and clients that don't know about themes yet) are fine.
+ALTER TABLE public.version_pings
+  ADD COLUMN IF NOT EXISTS theme TEXT;
+
+-- Index for admin aggregation: "users per theme in last N days"
+CREATE INDEX IF NOT EXISTS idx_version_pings_theme_created
+  ON public.version_pings(theme, created_at DESC)
+  WHERE theme IS NOT NULL;


### PR DESCRIPTION
## Summary
Sentry's tag-based aggregation is paywalled on the free tier. Piggyback on the existing `version_pings` table instead — it already fires on every auth'd page load with `user_id` + `build_id`. Add a `theme` column, an aggregation in the admin metrics endpoint, and a Themes tab in `/admin`.

- **Migration** `20260420000001_version_pings_theme.sql`: `ADD COLUMN theme TEXT` to `version_pings` (nullable, old rows stay valid) + partial index for fast "users per theme" queries.
- **`logVersionPing(buildId, theme?)`**: optional second arg; `UpdateBanner` reads it from `localStorage` (falls back to `DEFAULT_THEME`).
- **`/api/admin/metrics`**: compute latest-theme-per-user over the last 7d of pings plus 24h ping counts per theme; returned as `themes: { distribution, usersReporting }`.
- **`/admin`**: new **Themes** tab with a row per theme (user count, percentage, 24h ping count, expand → user names). Inline bar shading shows proportion at a glance.

## Rollout
1. **Apply the migration manually** in Supabase dashboard → SQL editor (timestamp clash with an unapplied `20260419000001_notify_on_date_update.sql` prevents `supabase db push` here):
```sql
ALTER TABLE public.version_pings ADD COLUMN IF NOT EXISTS theme TEXT;
CREATE INDEX IF NOT EXISTS idx_version_pings_theme_created
  ON public.version_pings(theme, created_at DESC) WHERE theme IS NOT NULL;
```
2. Merge this PR — Vercel redeploys.
3. Load the app to fire a ping, then `/admin` → Themes tab.

## Test plan
- [ ] Migration applied: `SELECT theme FROM version_pings LIMIT 1` returns null (column exists)
- [ ] Open app, reload → new `version_pings` row has `theme` populated
- [ ] `/admin` → Themes tab shows per-theme user counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)