### PR TITLE
fix: drop transient network errors from Sentry reports

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -7,6 +7,16 @@ Sentry.init({
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
   release: process.env.NEXT_PUBLIC_BUILD_ID,
   tracesSampleRate: 0.1,
+  // Transient network failures (user lost wifi, cellular hiccup, request aborted).
+  // Not actionable — the app already catches and retries on refocus.
+  ignoreErrors: [
+    "Load failed", // Safari / WebKit
+    "Failed to fetch", // Chrome, Firefox, Edge
+    "NetworkError when attempting to fetch resource", // Firefox
+    "The network connection was lost", // iOS
+    "The Internet connection appears to be offline", // iOS
+    "cancelled", // Safari aborted request
+  ],
   beforeSend(event) {
     // Defensive: strip free-text fields (event notes, scraped captions) that
     // could leak user content. Call sites should already avoid sending these


### PR DESCRIPTION
## Summary
- Sentry issue [DOWNTO-2](https://downto.sentry.io/issues/7428356308/) is a burst of `TypeError: Load failed` on Mobile Safari — Safari's generic fetch-failed error. Breadcrumbs show consecutive Supabase requests failing together during `loadRealData` / `loadSquads` / `loadSuggestions`, the signature of a user's network dropping mid-session.
- The app already catches these gracefully (`handled: yes`), but `logError` ships them to Sentry regardless, creating noise that isn't actionable — wifi drops aren't a code bug.
- Add `ignoreErrors` patterns for the cross-browser variants of transient fetch failures. `inboundFiltersIntegration` (default in `@sentry/nextjs`) honors this option and drops matching events before they're sent.

## Test plan
- [ ] Confirm DOWNTO-2 stops accruing new events after deploy
- [ ] Verify non-network errors still reach Sentry (e.g. a real thrown error in an event-save flow)
- [ ] Check the release tag in Sentry matches the deployed build

🤖 Generated with [Claude Code](https://claude.com/claude-code)