### PR TITLE
feat: image attachments in squad chat

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -917,8 +917,13 @@ export default function Home() {
           onSquadUpdate={squadsHook.setSquads}
           onChatOpen={setChatOpen}
           onViewProfile={(uid) => setViewingUserId(uid)}
-          onSendMessage={async (squadDbId, text, mentions) => {
-            await db.sendMessage(squadDbId, text, mentions);
+          onSendMessage={async (squadDbId, text, mentions, image) => {
+            let imageMeta: { path: string; width: number; height: number } | undefined;
+            if (image) {
+              const path = await db.uploadChatImage(squadDbId, image.blob);
+              imageMeta = { path, width: image.width, height: image.height };
+            }
+            await db.sendMessage(squadDbId, text, mentions, imageMeta);
           }}
           onLeaveSquad={async (squadDbId) => {
             await db.leaveSquad(squadDbId);

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -34,7 +34,13 @@ interface ChatMessageProps {
     isYou?: boolean;
     messageType?: 'date_confirm' | 'poll';
     messageId?: string;
+    imagePath?: string;
+    imageWidth?: number;
+    imageHeight?: number;
+    imagePreviewUrl?: string;
   };
+  imageUrl?: string;
+  onOpenImage?: (url: string) => void;
   isFirstInGroup: boolean;
   isLastInGroup: boolean;
   isLastConfirm: boolean;
@@ -57,6 +63,8 @@ interface ChatMessageProps {
 
 export default function ChatMessage({
   msg,
+  imageUrl,
+  onOpenImage,
   isFirstInGroup,
   isLastInGroup,
   isLastConfirm,
@@ -118,6 +126,25 @@ export default function ChatMessage({
     );
   }
 
+  const hasImage = !!msg.imagePath;
+  const hasText = !!msg.text && msg.text.length > 0;
+  const displayUrl = msg.imagePreviewUrl ?? imageUrl;
+  // Cap preview to a reasonable max so portrait shots don't hog the viewport.
+  // Keep aspect ratio from server-provided dimensions to prevent layout shift.
+  const MAX_W = 240;
+  const MAX_H = 320;
+  let imgStyle: React.CSSProperties | undefined;
+  if (hasImage && msg.imageWidth && msg.imageHeight) {
+    const ratio = msg.imageWidth / msg.imageHeight;
+    let w = Math.min(MAX_W, msg.imageWidth);
+    let h = w / ratio;
+    if (h > MAX_H) {
+      h = MAX_H;
+      w = h * ratio;
+    }
+    imgStyle = { width: Math.round(w), height: Math.round(h) };
+  }
+
   return (
     <div className={cn("flex flex-col", { "items-end": msg.isYou, "items-start": !msg.isYou, "mt-2": isFirstInGroup, "mt-0": !isFirstInGroup })}>
       {isFirstInGroup && !msg.isYou && (
@@ -125,31 +152,53 @@ export default function ChatMessage({
           {msg.sender}
         </span>
       )}
-      <div
-        className={cn("select-text font-serif max-w-[80%]",
-          msg.isYou
-            ? cn("bg-dt text-on-accent rounded-tr-2xl rounded-bl-2xl", {
-                "rounded-tl-2xl": isFirstInGroup,
-                "rounded-tl-lg": !isFirstInGroup,
-                "rounded-br": isLastInGroup,
-                "rounded-br-lg": !isLastInGroup,
-              })
-            : cn("bg-surface text-primary rounded-tl-2xl rounded-br-lg", {
-                "rounded-tr-2xl": isFirstInGroup,
-                "rounded-tr-lg": !isFirstInGroup,
-                "rounded-bl": isLastInGroup,
-                "rounded-bl-lg": !isLastInGroup,
-              })
-        )}
-        style={{
-          padding: "10px 14px",
-          fontSize: 12,
-          lineHeight: 1.3,
-          letterSpacing: "0.025em",
-        }}
-      >
-        {linkify(msg.text, !!msg.isYou)}
-      </div>
+      {hasImage && (
+        <div
+          className={cn(
+            "overflow-hidden bg-deep mb-1",
+            msg.isYou ? "rounded-tl-2xl rounded-bl-2xl rounded-tr-2xl rounded-br-lg" : "rounded-tr-2xl rounded-br-2xl rounded-tl-2xl rounded-bl-lg",
+          )}
+          style={imgStyle}
+        >
+          {displayUrl ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={displayUrl}
+              alt={hasText ? msg.text : "shared image"}
+              onClick={() => onOpenImage?.(displayUrl)}
+              className="w-full h-full object-cover cursor-pointer"
+              loading="lazy"
+            />
+          ) : null}
+        </div>
+      )}
+      {hasText && (
+        <div
+          className={cn("select-text font-serif max-w-[80%]",
+            msg.isYou
+              ? cn("bg-dt text-on-accent rounded-tr-2xl rounded-bl-2xl", {
+                  "rounded-tl-2xl": isFirstInGroup && !hasImage,
+                  "rounded-tl-lg": !isFirstInGroup || hasImage,
+                  "rounded-br": isLastInGroup,
+                  "rounded-br-lg": !isLastInGroup,
+                })
+              : cn("bg-surface text-primary rounded-tl-2xl rounded-br-lg", {
+                  "rounded-tr-2xl": isFirstInGroup && !hasImage,
+                  "rounded-tr-lg": !isFirstInGroup || hasImage,
+                  "rounded-bl": isLastInGroup,
+                  "rounded-bl-lg": !isLastInGroup,
+                })
+          )}
+          style={{
+            padding: "10px 14px",
+            fontSize: 12,
+            lineHeight: 1.3,
+            letterSpacing: "0.025em",
+          }}
+        >
+          {linkify(msg.text, !!msg.isYou)}
+        </div>
+      )}
       {isLastInGroup && (
         <span className="font-mono text-tiny text-dim mt-0.5">
           {msg.time}

--- a/src/features/squads/components/MessageComposer.tsx
+++ b/src/features/squads/components/MessageComposer.tsx
@@ -1,13 +1,26 @@
 "use client";
 
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { color } from "@/lib/styles";
 import type { Squad } from "@/lib/ui-types";
+import { resizeImageForChat } from "@/lib/imageResize";
+import { logError } from "@/lib/logger";
+
+interface PendingImage {
+  blob: Blob;
+  width: number;
+  height: number;
+  previewUrl: string;
+}
 
 interface MessageComposerProps {
   members: Squad['members'];
   activePoll: { status: string } | null;
-  onSend: (text: string, mentionUserIds: string[]) => Promise<void>;
+  onSend: (
+    text: string,
+    mentionUserIds: string[],
+    image?: { blob: Blob; width: number; height: number }
+  ) => Promise<void>;
   onOpenPollCreator?: () => void;
 }
 
@@ -20,13 +33,46 @@ export default function MessageComposer({
   const [newMsg, setNewMsg] = useState("");
   const [chatMentionQuery, setChatMentionQuery] = useState<string | null>(null);
   const [chatMentionIdx, setChatMentionIdx] = useState(-1);
+  const [pendingImage, setPendingImage] = useState<PendingImage | null>(null);
+  const [preparingImage, setPreparingImage] = useState(false);
+  const [sending, setSending] = useState(false);
   const msgInputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const otherMembers = members.filter((m) => m.name !== "You");
 
+  useEffect(() => {
+    return () => {
+      if (pendingImage) URL.revokeObjectURL(pendingImage.previewUrl);
+    };
+  }, [pendingImage]);
+
+  const clearPendingImage = () => {
+    if (pendingImage) URL.revokeObjectURL(pendingImage.previewUrl);
+    setPendingImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handlePickImage = async (file: File) => {
+    setPreparingImage(true);
+    try {
+      const { blob, width, height } = await resizeImageForChat(file);
+      if (pendingImage) URL.revokeObjectURL(pendingImage.previewUrl);
+      setPendingImage({ blob, width, height, previewUrl: URL.createObjectURL(blob) });
+    } catch (err) {
+      logError("resizeImage", err);
+      alert("Couldn't prepare that image. Try a different one?");
+    } finally {
+      setPreparingImage(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  };
+
+  const canSend = (newMsg.trim().length > 0 || !!pendingImage) && !sending && !preparingImage;
+
   const handleSend = async () => {
+    if (!canSend) return;
     const text = newMsg.trim();
-    if (!text) return;
 
     const mentionedNames = [...text.matchAll(/@(\S+)/g)].map((m) => m[1].toLowerCase());
     const mentionedIds = otherMembers
@@ -36,12 +82,25 @@ export default function MessageComposer({
       .map((m) => m.userId)
       .filter((id): id is string => !!id);
 
+    const imagePayload = pendingImage
+      ? { blob: pendingImage.blob, width: pendingImage.width, height: pendingImage.height }
+      : undefined;
+
     setNewMsg("");
     setChatMentionQuery(null);
     setChatMentionIdx(-1);
     if (msgInputRef.current) msgInputRef.current.style.height = "auto";
+    // Clear preview state but keep the blob reference we captured above
+    if (pendingImage) URL.revokeObjectURL(pendingImage.previewUrl);
+    setPendingImage(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
 
-    await onSend(text, mentionedIds);
+    setSending(true);
+    try {
+      await onSend(text, mentionedIds, imagePayload);
+    } finally {
+      setSending(false);
+    }
   };
 
   return (
@@ -79,11 +138,51 @@ export default function MessageComposer({
           </div>
         );
       })()}
+      {/* Image preview */}
+      {pendingImage && (
+        <div className="px-5 pt-2 bg-surface">
+          <div className="relative inline-block">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={pendingImage.previewUrl}
+              alt="attachment preview"
+              className="rounded-lg object-cover"
+              style={{ width: 88, height: 88 }}
+            />
+            <button
+              onClick={clearPendingImage}
+              aria-label="Remove image"
+              className="absolute -top-1.5 -right-1.5 bg-black/80 border border-border-mid text-white rounded-full w-5 h-5 flex items-center justify-center font-mono cursor-pointer"
+              style={{ fontSize: 11, lineHeight: 1 }}
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
       {/* Input row */}
       <div
         className="flex gap-2 items-end"
         style={{ padding: "12px 20px" }}
       >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handlePickImage(file);
+          }}
+        />
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          disabled={preparingImage}
+          aria-label="Attach image"
+          className="bg-none border-none p-0 opacity-60 cursor-pointer leading-none mb-2"
+        >
+          <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor"><path d="M208,56H180.28L166.65,35.56A8,8,0,0,0,160,32H96a8,8,0,0,0-6.65,3.56L75.71,56H48A24,24,0,0,0,24,80V192a24,24,0,0,0,24,24H208a24,24,0,0,0,24-24V80A24,24,0,0,0,208,56Zm8,136a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V80a8,8,0,0,1,8-8H80a8,8,0,0,0,6.66-3.56L100.28,48h55.43l13.63,20.44A8,8,0,0,0,176,72h32a8,8,0,0,1,8,8ZM128,88a44,44,0,1,0,44,44A44.05,44.05,0,0,0,128,88Zm0,72a28,28,0,1,1,28-28A28,28,0,0,1,128,160Z"/></svg>
+        </button>
         {(!activePoll || activePoll.status === 'closed') && onOpenPollCreator && (
           <button
             onClick={onOpenPollCreator}
@@ -123,7 +222,7 @@ export default function MessageComposer({
             }
           }}
           enterKeyHint="send"
-          placeholder="Message..."
+          placeholder={pendingImage ? "Add a caption..." : "Message..."}
           rows={1}
           className="flex-1 bg-card border border-border-mid rounded-[20px] text-primary font-mono outline-none resize-none max-h-[120px] overflow-y-auto"
           style={{
@@ -135,15 +234,15 @@ export default function MessageComposer({
         <button
           onMouseDown={(e) => e.preventDefault()}
           onClick={handleSend}
-          disabled={!newMsg.trim()}
+          disabled={!canSend}
           className="border-none rounded-full w-10 h-10 font-bold text-base"
           style={{
-            background: newMsg.trim() ? color.accent : color.borderMid,
-            color: newMsg.trim() ? "var(--color-on-accent)" : color.dim,
-            cursor: newMsg.trim() ? "pointer" : "default",
+            background: canSend ? color.accent : color.borderMid,
+            color: canSend ? "var(--color-on-accent)" : color.dim,
+            cursor: canSend ? "pointer" : "default",
           }}
         >
-          ↑
+          {preparingImage || sending ? "…" : "↑"}
         </button>
       </div>
     </>

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -19,7 +19,7 @@ interface SquadChatProps {
   onSquadUpdate: (updater: Squad[] | ((prev: Squad[]) => Squad[])) => void;
   onChatOpen?: (open: boolean) => void;
   onViewProfile?: (userId: string) => void;
-  onSendMessage?: (squadDbId: string, text: string, mentions?: string[]) => Promise<void>;
+  onSendMessage?: (squadDbId: string, text: string, mentions?: string[], image?: { blob: Blob; width: number; height: number }) => Promise<void>;
   onLeaveSquad?: (squadDbId: string) => Promise<void>;
   onSetSquadDate?: (squadDbId: string, date: string, time?: string | null, locked?: boolean) => Promise<void>;
   onClearSquadDate?: (squadDbId: string) => Promise<void>;
@@ -58,6 +58,9 @@ const SquadChat = ({
 
   // Local messages state (decoupled from squad prop for realtime updates)
   const [messages, setMessages] = useState(squad.messages);
+  // path -> signed URL for chat image attachments
+  const [imageUrls, setImageUrls] = useState<Map<string, string>>(new Map());
+  const [fullscreenImage, setFullscreenImage] = useState<string | null>(null);
 
   // Local squad state for non-message fields (members, sizes, dates, etc.)
   const [localSquad, setLocalSquad] = useState(squad);
@@ -312,11 +315,16 @@ const SquadChat = ({
       const msgs = raw.map((msg) => ({
         id: msg.id,
         sender: msg.is_system || !msg.sender_id ? "system" : (msg.sender_id === userId ? "You" : (msg.sender?.display_name ?? "Unknown")),
-        text: msg.text,
+        text: msg.text ?? "",
         time: formatTimeAgo(new Date(msg.created_at)),
         isYou: msg.sender_id === userId,
         ...(msg.message_type === 'date_confirm' ? { messageType: 'date_confirm' as const, messageId: msg.id } : {}),
         ...(msg.message_type === 'poll' ? { messageType: 'poll' as const, messageId: msg.id } : {}),
+        ...(msg.image_path ? {
+          imagePath: msg.image_path,
+          imageWidth: msg.image_width ?? undefined,
+          imageHeight: msg.image_height ?? undefined,
+        } : {}),
       }));
       const last = msgs.length > 0 ? msgs[msgs.length - 1] : null;
       // Merge: keep any realtime messages that arrived before this fetch completed
@@ -326,16 +334,41 @@ const SquadChat = ({
         const merged = [...msgs, ...realtimeOnly];
         return merged;
       });
+      const previewForLast = (m: typeof msgs[number]) => {
+        const body = m.text && m.text.length > 0 ? m.text : (m.imagePath ? "📷" : "");
+        return m.sender === "system" ? body : `${m.sender}: ${body}`;
+      };
       onSquadUpdateRef.current((prev) =>
         prev.map((s) =>
           s.id === localSquad.id
-            ? { ...s, messages: msgs, lastMsg: last ? (last.sender === "system" ? last.text : `${last.sender}: ${last.text}`) : s.lastMsg }
+            ? { ...s, messages: msgs, lastMsg: last ? previewForLast(last) : s.lastMsg }
             : s
         )
       );
     }).catch(() => {});
     return () => { stale = true; };
   }, [localSquad.id, userId]);
+
+  // Batch-fetch signed URLs for any new image paths. Signed URLs expire after
+  // 1h; if a chat stays open longer than that, the page will reload or
+  // re-enter, which re-runs this effect against the fresh message list.
+  useEffect(() => {
+    const needed = messages
+      .map((m) => m.imagePath)
+      .filter((p): p is string => !!p && !imageUrls.has(p));
+    if (needed.length === 0) return;
+    const unique = Array.from(new Set(needed));
+    let stale = false;
+    db.getChatImageSignedUrls(unique).then((urls) => {
+      if (stale || urls.size === 0) return;
+      setImageUrls((prev) => {
+        const next = new Map(prev);
+        for (const [k, v] of urls) next.set(k, v);
+        return next;
+      });
+    }).catch((err) => logError("getChatImageSignedUrls", err));
+    return () => { stale = true; };
+  }, [messages, imageUrls]);
 
   // Subscribe to realtime messages for the squad
   useEffect(() => {
@@ -348,11 +381,16 @@ const SquadChat = ({
       const msg = {
         id: newMessage.id,
         sender: senderName,
-        text: newMessage.text,
+        text: newMessage.text ?? "",
         time: "now",
         isYou: false,
         ...(newMessage.message_type === 'date_confirm' ? { messageType: 'date_confirm' as const, messageId: newMessage.id } : {}),
         ...(newMessage.message_type === 'poll' ? { messageType: 'poll' as const, messageId: newMessage.id } : {}),
+        ...(newMessage.image_path ? {
+          imagePath: newMessage.image_path,
+          imageWidth: newMessage.image_width ?? undefined,
+          imageHeight: newMessage.image_height ?? undefined,
+        } : {}),
       };
       // Refresh poll data when a poll message arrives
       if (newMessage.message_type === 'poll' && localSquad.id) {
@@ -370,7 +408,10 @@ const SquadChat = ({
           }
         }).catch(() => {});
       }
-      const lastMsgPreview = isSystem ? newMessage.text : `${senderName}: ${newMessage.text}`;
+      const bodyPreview = newMessage.text && newMessage.text.length > 0
+        ? newMessage.text
+        : (newMessage.image_path ? "📷" : "");
+      const lastMsgPreview = isSystem ? bodyPreview : `${senderName}: ${bodyPreview}`;
       setMessages((prev) => {
         if (prev.some((m) => m.id && m.id === msg.id)) return prev;
         return [...prev, msg];
@@ -389,9 +430,25 @@ const SquadChat = ({
     };
   }, [localSquad.id, userId]);
 
-  const handleSend = async (text: string, mentionIds: string[]) => {
-    const newMsgObj = { sender: "You", text, time: "now", isYou: true };
-    const lastMsgPreview = `You: ${text}`;
+  const handleSend = async (
+    text: string,
+    mentionIds: string[],
+    image?: { blob: Blob; width: number; height: number },
+  ) => {
+    const previewUrl = image ? URL.createObjectURL(image.blob) : undefined;
+    const newMsgObj = {
+      sender: "You",
+      text,
+      time: "now",
+      isYou: true,
+      ...(image ? {
+        imagePath: `pending-${Date.now()}`,
+        imageWidth: image.width,
+        imageHeight: image.height,
+        imagePreviewUrl: previewUrl,
+      } : {}),
+    };
+    const lastMsgPreview = image && !text ? "You: 📷" : `You: ${text}`;
     const now = new Date().toISOString();
 
     setMessages((prev) => [...prev, newMsgObj]);
@@ -406,9 +463,8 @@ const SquadChat = ({
       return updated;
     });
 
-    // Persist to DB
     if (localSquad.id && onSendMessage) {
-      onSendMessage(localSquad.id, text, mentionIds.length > 0 ? mentionIds : undefined).catch((err) =>
+      onSendMessage(localSquad.id, text, mentionIds.length > 0 ? mentionIds : undefined, image).catch((err) =>
         logError("sendMessage", err, { squadId: localSquad.id })
       );
     }
@@ -751,6 +807,8 @@ const SquadChat = ({
               <ChatMessage
                 key={i}
                 msg={msg}
+                imageUrl={msg.imagePath ? imageUrls.get(msg.imagePath) : undefined}
+                onOpenImage={(url) => setFullscreenImage(url)}
                 isFirstInGroup={!sameSenderAsPrev}
                 isLastInGroup={!sameSenderAsNext}
                 isLastConfirm={i === lastConfirmIdx}
@@ -916,6 +974,21 @@ const SquadChat = ({
           onSquadUpdate={onSquadUpdate}
           onLocalSquadUpdate={setLocalSquad}
         />
+      )}
+
+      {/* Fullscreen image viewer */}
+      {fullscreenImage && (
+        <div
+          onClick={() => setFullscreenImage(null)}
+          className="fixed inset-0 bg-black/95 flex items-center justify-center z-[10000] cursor-zoom-out"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={fullscreenImage}
+            alt="attachment"
+            className="max-w-full max-h-full object-contain"
+          />
+        </div>
       )}
 
       {/* Poll creation modal */}

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -157,11 +157,16 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
       const messages = sortedRawMessages.map((msg) => ({
           id: msg.id,
           sender: msg.is_system ? "system" : (msg.sender_id === userId ? "You" : (msg.sender?.display_name ?? "Unknown")),
-          text: msg.text,
+          text: msg.text ?? "",
           time: formatTimeAgo(new Date(msg.created_at)),
           isYou: msg.sender_id === userId,
           ...(msg.message_type === 'date_confirm' ? { messageType: 'date_confirm' as const, messageId: msg.id } : {}),
           ...(msg.message_type === 'poll' ? { messageType: 'poll' as const, messageId: msg.id } : {}),
+          ...(msg.image_path ? {
+            imagePath: msg.image_path,
+            imageWidth: msg.image_width ?? undefined,
+            imageHeight: msg.image_height ?? undefined,
+          } : {}),
         }));
       const lastMessage = messages.length > 0 ? messages[messages.length - 1] : null;
       return {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1292,7 +1292,12 @@ export async function createSquad(
 // MESSAGES (with realtime)
 // ============================================================================
 
-export async function sendMessage(squadId: string, text: string, mentions: string[] = []): Promise<Message> {
+export async function sendMessage(
+  squadId: string,
+  text: string,
+  mentions: string[] = [],
+  image?: { path: string; width: number; height: number }
+): Promise<Message> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
@@ -1303,12 +1308,38 @@ export async function sendMessage(squadId: string, text: string, mentions: strin
       sender_id: user.id,
       text,
       mentions,
+      image_path: image?.path ?? null,
+      image_width: image?.width ?? null,
+      image_height: image?.height ?? null,
     })
     .select('*, sender:profiles(*)')
     .single();
 
   if (error) throw error;
   return data;
+}
+
+export async function uploadChatImage(squadId: string, blob: Blob): Promise<string> {
+  const ext = blob.type === 'image/png' ? 'png' : blob.type === 'image/webp' ? 'webp' : 'jpg';
+  const path = `${squadId}/${crypto.randomUUID()}.${ext}`;
+  const { error } = await supabase.storage
+    .from('squad-chat-images')
+    .upload(path, blob, { contentType: blob.type || 'image/jpeg', upsert: false });
+  if (error) throw error;
+  return path;
+}
+
+export async function getChatImageSignedUrls(paths: string[]): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  if (paths.length === 0) return out;
+  const { data, error } = await supabase.storage
+    .from('squad-chat-images')
+    .createSignedUrls(paths, 3600);
+  if (error) throw error;
+  for (const entry of data ?? []) {
+    if (entry.path && entry.signedUrl) out.set(entry.path, entry.signedUrl);
+  }
+  return out;
 }
 
 export function subscribeToMessages(

--- a/src/lib/imageResize.ts
+++ b/src/lib/imageResize.ts
@@ -1,0 +1,39 @@
+export async function resizeImageForChat(
+  file: File,
+  maxEdge = 1600,
+  quality = 0.85,
+): Promise<{ blob: Blob; width: number; height: number }> {
+  const source = await createImageBitmap(file);
+  try {
+    const scale = Math.min(1, maxEdge / Math.max(source.width, source.height));
+    const width = Math.max(1, Math.round(source.width * scale));
+    const height = Math.max(1, Math.round(source.height * scale));
+
+    let blob: Blob;
+    if (typeof OffscreenCanvas !== 'undefined') {
+      const canvas = new OffscreenCanvas(width, height);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('2D canvas unavailable');
+      ctx.drawImage(source, 0, 0, width, height);
+      blob = await canvas.convertToBlob({ type: 'image/jpeg', quality });
+    } else {
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('2D canvas unavailable');
+      ctx.drawImage(source, 0, 0, width, height);
+      blob = await new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob(
+          (b) => (b ? resolve(b) : reject(new Error('Canvas encode failed'))),
+          'image/jpeg',
+          quality,
+        );
+      });
+    }
+
+    return { blob, width, height };
+  } finally {
+    source.close?.();
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -175,10 +175,13 @@ export interface Message {
   id: string;
   squad_id: string;
   sender_id: string | null;
-  text: string;
+  text: string | null;
   created_at: string;
   is_system: boolean;
   message_type: string;
+  image_path: string | null;
+  image_width: number | null;
+  image_height: number | null;
   // Joined data
   sender?: Profile;
 }

--- a/src/lib/ui-types.ts
+++ b/src/lib/ui-types.ts
@@ -115,7 +115,7 @@ export interface Squad {
   waitlistedMembers?: { name: string; avatar: string; userId: string }[];
   downResponders?: { name: string; avatar: string; userId: string }[];
   dateStatus?: 'proposed' | 'locked';
-  messages: { id?: string; sender: string; text: string; time: string; isYou?: boolean; messageType?: 'date_confirm' | 'poll'; messageId?: string }[];
+  messages: { id?: string; sender: string; text: string; time: string; isYou?: boolean; messageType?: 'date_confirm' | 'poll'; messageId?: string; imagePath?: string; imageWidth?: number; imageHeight?: number; imagePreviewUrl?: string }[];
   lastMsg: string;
   time: string;
   meetingSpot?: string;

--- a/supabase/migrations/20260420000002_squad_chat_images.sql
+++ b/supabase/migrations/20260420000002_squad_chat_images.sql
@@ -1,0 +1,42 @@
+-- Squad chat image attachments
+-- Adds optional image columns to messages and a private storage bucket
+-- whose access is gated to squad members of the path's leading squad_id.
+
+ALTER TABLE public.messages
+  ADD COLUMN IF NOT EXISTS image_path TEXT,
+  ADD COLUMN IF NOT EXISTS image_width INTEGER,
+  ADD COLUMN IF NOT EXISTS image_height INTEGER;
+
+-- Allow empty text for image-only messages
+ALTER TABLE public.messages ALTER COLUMN text DROP NOT NULL;
+
+-- Private bucket (public = false). 5 MB cap, common web image MIME types only.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'squad-chat-images',
+  'squad-chat-images',
+  false,
+  5242880,
+  ARRAY['image/jpeg', 'image/png', 'image/webp']
+)
+ON CONFLICT (id) DO UPDATE SET
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- Paths are formatted "{squad_id}/{uuid}.{ext}"; the first folder is the squad id.
+CREATE POLICY "Squad members can read chat images"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'squad-chat-images'
+    AND public.is_squad_member((storage.foldername(name))[1]::uuid, auth.uid())
+  );
+
+CREATE POLICY "Squad members can upload chat images"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'squad-chat-images'
+    AND public.is_squad_member((storage.foldername(name))[1]::uuid, auth.uid())
+  );


### PR DESCRIPTION
## Summary
- Camera button in `MessageComposer` picks an image (JPEG/PNG/WebP/HEIC). Client-side resize to 1600px max edge, re-encoded as JPEG at 85% quality via OffscreenCanvas / `<canvas>` fallback (`src/lib/imageResize.ts`).
- Images can be sent alone or with a caption. Image bubble renders above the caption, capped to 240×320 while preserving aspect ratio from server-provided dimensions (no layout shift).
- Fullscreen image viewer on tap.
- Private `squad-chat-images` Supabase Storage bucket (5 MB cap, JPEG/PNG/WebP MIMEs). RLS uses the existing `is_squad_member()` helper on the leading `squad_id` folder — only squad members can read or upload. `messages` gains nullable `image_path`, `image_width`, `image_height` columns and `text` becomes nullable for image-only messages.
- `SquadChat` batches signed URL fetches (1h TTL) keyed by `image_path` and re-runs when the message list changes.
- Last-message preview shows "📷" for image-only messages so squad rows don't render blank previews.

## Test plan
- [ ] Send a text-only message → still works
- [ ] Tap camera, pick image, send with no caption → renders as image-only bubble with correct aspect; squad row preview shows "📷"
- [ ] Send image with caption → image above caption, same bubble grouping
- [ ] Tap an image → opens fullscreen; tap again to dismiss
- [ ] Try a >5 MB image → upload should fail with Supabase error (bucket cap)
- [ ] Try uploading from a non-member account via raw API → storage RLS denies
- [ ] Portrait / landscape / square images all render without layout shift
- [ ] Chat stays open >1h → signed URL expires, refresh restores images

🤖 Generated with [Claude Code](https://claude.com/claude-code)