### PR TITLE
fix: replace optimistic chat message with server row after send

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -923,7 +923,8 @@ export default function Home() {
               const path = await db.uploadChatImage(squadDbId, image.blob);
               imageMeta = { path, width: image.width, height: image.height };
             }
-            await db.sendMessage(squadDbId, text, mentions, imageMeta);
+            const saved = await db.sendMessage(squadDbId, text, mentions, imageMeta);
+            return { id: saved.id, image_path: saved.image_path };
           }}
           onLeaveSquad={async (squadDbId) => {
             await db.leaveSquad(squadDbId);

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -126,7 +126,9 @@ export default function ChatMessage({
     );
   }
 
-  const hasImage = !!msg.imagePath;
+  // An optimistic message has imagePreviewUrl before it has imagePath, so
+  // check either so the bubble renders during upload too.
+  const hasImage = !!msg.imagePath || !!msg.imagePreviewUrl;
   const hasText = !!msg.text && msg.text.length > 0;
   const displayUrl = msg.imagePreviewUrl ?? imageUrl;
   // Cap preview to a reasonable max so portrait shots don't hog the viewport.

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -19,7 +19,7 @@ interface SquadChatProps {
   onSquadUpdate: (updater: Squad[] | ((prev: Squad[]) => Squad[])) => void;
   onChatOpen?: (open: boolean) => void;
   onViewProfile?: (userId: string) => void;
-  onSendMessage?: (squadDbId: string, text: string, mentions?: string[], image?: { blob: Blob; width: number; height: number }) => Promise<void>;
+  onSendMessage?: (squadDbId: string, text: string, mentions?: string[], image?: { blob: Blob; width: number; height: number }) => Promise<{ id: string; image_path?: string | null } | void>;
   onLeaveSquad?: (squadDbId: string) => Promise<void>;
   onSetSquadDate?: (squadDbId: string, date: string, time?: string | null, locked?: boolean) => Promise<void>;
   onClearSquadDate?: (squadDbId: string) => Promise<void>;
@@ -436,13 +436,16 @@ const SquadChat = ({
     image?: { blob: Blob; width: number; height: number },
   ) => {
     const previewUrl = image ? URL.createObjectURL(image.blob) : undefined;
+    // Client-generated id so we can find this exact message later to swap in
+    // server data (real id + image_path) or remove on failure.
+    const tempId = `tmp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const newMsgObj = {
+      id: tempId,
       sender: "You",
       text,
       time: "now",
       isYou: true,
       ...(image ? {
-        imagePath: `pending-${Date.now()}`,
         imageWidth: image.width,
         imageHeight: image.height,
         imagePreviewUrl: previewUrl,
@@ -464,9 +467,52 @@ const SquadChat = ({
     });
 
     if (localSquad.id && onSendMessage) {
-      onSendMessage(localSquad.id, text, mentionIds.length > 0 ? mentionIds : undefined, image).catch((err) =>
-        logError("sendMessage", err, { squadId: localSquad.id })
-      );
+      try {
+        const saved = await onSendMessage(
+          localSquad.id,
+          text,
+          mentionIds.length > 0 ? mentionIds : undefined,
+          image,
+        );
+        if (saved) {
+          // Swap the optimistic entry for server truth (real id + image_path).
+          // Keep imagePreviewUrl so the image stays visible until a signed URL
+          // resolves (effect in useEffect below picks up the new imagePath).
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === tempId
+                ? { ...m, id: saved.id, imagePath: saved.image_path ?? undefined }
+                : m
+            )
+          );
+          onSquadUpdate((prev) =>
+            prev.map((s) =>
+              s.id !== localSquad.id
+                ? s
+                : {
+                    ...s,
+                    messages: s.messages.map((m) =>
+                      m.id === tempId
+                        ? { ...m, id: saved.id, imagePath: saved.image_path ?? undefined }
+                        : m
+                    ),
+                  }
+            )
+          );
+        }
+      } catch (err) {
+        logError("sendMessage", err, { squadId: localSquad.id });
+        // Roll back the optimistic message and free the blob URL.
+        if (previewUrl) URL.revokeObjectURL(previewUrl);
+        setMessages((prev) => prev.filter((m) => m.id !== tempId));
+        onSquadUpdate((prev) =>
+          prev.map((s) =>
+            s.id !== localSquad.id
+              ? s
+              : { ...s, messages: s.messages.filter((m) => m.id !== tempId) }
+          )
+        );
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
Follow-up to #380. Optimistic chat messages had no `id` and carried a fake `imagePath: "pending-{timestamp}"` that leaked into the signed-URL batch fetch.

- Generate a stable `tempId` as the optimistic message's id so we can find and replace it later.
- After `onSendMessage` resolves, swap the optimistic entry in with the server's real `id` and `image_path`. Keep `imagePreviewUrl` so the image stays visible until the signed URL effect catches up.
- On send failure, roll back the optimistic entry and revoke the blob URL (no orphan preview in the UI).
- `ChatMessage` now treats `imagePreviewUrl` alone as "has image" so uploads render before the server row comes back.
- `page.tsx`'s `onSendMessage` returns `{ id, image_path }` from the saved row.

## Test plan
- [ ] Send an image → bubble appears immediately with local preview
- [ ] After upload completes, image stays visible (now via signed URL); no flicker
- [ ] Kill network between `uploadChatImage` and `sendMessage` → optimistic bubble disappears and the blob URL is freed (check memory/devtools)
- [ ] Send a text-only message → still works, dedups correctly on re-hydrate
- [ ] Another user sends into the same chat → realtime still adds their message; no duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)