### PR TITLE
fix: drop supabase lock-stolen AbortError from Sentry

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -7,15 +7,19 @@ Sentry.init({
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
   release: process.env.NEXT_PUBLIC_BUILD_ID,
   tracesSampleRate: 0.1,
-  // Transient network failures (user lost wifi, cellular hiccup, request aborted).
-  // Not actionable — the app already catches and retries on refocus.
+  // Transient failures the app already recovers from — not actionable as bugs.
   ignoreErrors: [
+    // Network drops / aborted requests (user lost wifi, cellular hiccup, tab backgrounded).
     "Load failed", // Safari / WebKit
     "Failed to fetch", // Chrome, Firefox, Edge
     "NetworkError when attempting to fetch resource", // Firefox
     "The network connection was lost", // iOS
     "The Internet connection appears to be offline", // iOS
     "cancelled", // Safari aborted request
+    // Supabase auth lock stolen between tabs / across Strict Mode remounts.
+    // The stealing side recovers (supabase-js/locks.ts); the stolen side's
+    // in-flight query rejects with this AbortError and re-runs on next refresh.
+    "Lock broken by another request with the 'steal' option",
   ],
   beforeSend(event) {
     // Defensive: strip free-text fields (event notes, scraped captions) that


### PR DESCRIPTION
## Summary
- Sentry issue [DOWNTO-3](https://downto.sentry.io/issues/7428465707/) is `AbortError: Lock broken by another request with the 'steal' option.` from `loadRealData`. Root cause lives in `@supabase/auth-js/src/lib/locks.ts`: when a lock holder is slow (React Strict Mode remount, another tab, slow request), auth-js falls back to `navigator.locks.request({ steal: true })` which forcibly releases the current holder. The stealing side recovers; the stolen side's in-flight callback promise rejects with this AbortError.
- The app already handles the rejection via `loadRealData`'s catch + the normal refresh cycle, so it's noise, not a code bug — mirrors the network-error filtering from #378.

## Test plan
- [ ] Confirm DOWNTO-3 stays resolved after deploy (marked resolved-in-release; auto-reopens on regression)
- [ ] Real Supabase auth errors (invalid JWT, RLS denial) still reach Sentry — only this specific AbortError message is filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)