### PR TITLE
Friendship graph metrics on admin dashboard (#43)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,7 +16,7 @@ interface PushFailure {
   error: string | null;
 }
 
-type AdminTab = "users" | "engagement" | "push" | "versions" | "themes";
+type AdminTab = "users" | "engagement" | "push" | "versions" | "themes" | "friendships";
 
 interface Metrics {
   totalUsers: number;
@@ -45,6 +45,17 @@ interface Metrics {
   themes: {
     distribution: { theme: string; users: number; pings24h: number; userNames: string[] }[];
     usersReporting: number;
+  };
+  friendships: {
+    accepted: number;
+    pending: number;
+    blocked: number;
+    connectedUsers: number;
+    isolatedUsers: number;
+    avgFriends: number;
+    medianFriends: number;
+    maxFriends: number;
+    mostConnected: { name: string; count: number }[];
   };
   engagement: {
     active7d: number;
@@ -163,6 +174,7 @@ export default function AdminPage() {
     { key: "push", label: "Push" },
     { key: "versions", label: "Versions" },
     { key: "themes", label: "Themes" },
+    { key: "friendships", label: "Friends" },
   ];
 
   return (
@@ -539,6 +551,76 @@ export default function AdminPage() {
               No theme data yet. Ship the ping and wait for users to load the app.
             </p>
           )}
+        </>
+      )}
+
+      {/* Friendships tab */}
+      {tab === "friendships" && (
+        <>
+          {/* Totals */}
+          <div className="grid grid-cols-3 gap-2 mb-4">
+            {[
+              { label: "Accepted", value: metrics.friendships.accepted },
+              { label: "Pending", value: metrics.friendships.pending },
+              { label: "Blocked", value: metrics.friendships.blocked },
+            ].map((s) => (
+              <div key={s.label} className="p-3 rounded-lg border border-border bg-card">
+                <div className="font-mono text-tiny text-dim uppercase" style={{ letterSpacing: "0.15em" }}>
+                  {s.label}
+                </div>
+                <div className="font-serif text-2xl text-primary font-normal mt-1">
+                  {s.value}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Per-user stats */}
+          <div className="p-3 rounded-lg border border-border bg-card mb-4">
+            <div className="font-mono text-tiny text-dim uppercase mb-2" style={{ letterSpacing: "0.15em" }}>
+              Per user
+            </div>
+            <div className="grid grid-cols-2 gap-y-1 gap-x-3 font-mono text-xs">
+              <span className="text-dim">Connected users</span>
+              <span className="text-primary text-right">
+                <span className="text-dt font-bold">{metrics.friendships.connectedUsers}</span>
+                <span className="text-faint"> / {metrics.totalUsers}</span>
+              </span>
+              <span className="text-dim">Isolated (0 friends)</span>
+              <span className="text-primary text-right">{metrics.friendships.isolatedUsers}</span>
+              <span className="text-dim">Avg friends</span>
+              <span className="text-primary text-right">{metrics.friendships.avgFriends}</span>
+              <span className="text-dim">Median friends</span>
+              <span className="text-primary text-right">{metrics.friendships.medianFriends}</span>
+              <span className="text-dim">Max friends</span>
+              <span className="text-primary text-right">{metrics.friendships.maxFriends}</span>
+            </div>
+          </div>
+
+          {/* Most connected */}
+          <div className="p-3 rounded-lg border border-border bg-card">
+            <div className="font-mono text-tiny text-dim uppercase mb-2" style={{ letterSpacing: "0.15em" }}>
+              Most connected
+            </div>
+            {metrics.friendships.mostConnected.length > 0 ? (
+              <div className="flex flex-col gap-1.5">
+                {metrics.friendships.mostConnected.map((u, i) => (
+                  <div key={`${u.name}-${i}`} className="flex justify-between items-center font-mono text-xs">
+                    <span className="text-primary">
+                      <span className="text-faint mr-2">{i + 1}.</span>
+                      {u.name}
+                    </span>
+                    <span>
+                      <span className="text-dt font-bold">{u.count}</span>
+                      <span className="text-dim"> friends</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-faint font-mono text-xs">No friendships yet</p>
+            )}
+          </div>
         </>
       )}
     </div>

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
   // Run queries in parallel
-  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes, dauRpcRes, pushSubscribersRes] = await Promise.all([
+  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes, dauRpcRes, pushSubscribersRes, friendshipsRes, pendingCountRes, blockedCountRes] = await Promise.all([
     admin.from('profiles').select('*', { count: 'exact', head: true }),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', true),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', false),
@@ -58,6 +58,13 @@ export async function GET(request: NextRequest) {
     admin.rpc('get_dau', { p_since: since30d, p_tz: tz }),
     admin.from('push_subscriptions')
       .select('user_id'),
+    // All accepted friendship edges — used to compute per-user degree, avg, top
+    admin.from('friendships')
+      .select('requester_id, addressee_id, created_at')
+      .eq('status', 'accepted')
+      .limit(100000),
+    admin.from('friendships').select('*', { count: 'exact', head: true }).eq('status', 'pending'),
+    admin.from('friendships').select('*', { count: 'exact', head: true }).eq('status', 'blocked'),
   ]);
 
   // DAU from RPC — already grouped by date
@@ -184,6 +191,49 @@ export async function GET(request: NextRequest) {
     .sort((a, b) => b.users - a.users);
   const themeUsersReporting = latestThemeByUser.size;
 
+  // Friendship graph — count accepted edges, compute per-user degree, avg,
+  // median, and the most-connected users. Pending/blocked counts come from
+  // dedicated HEAD queries above.
+  const acceptedEdges = (friendshipsRes.data ?? []) as { requester_id: string; addressee_id: string; created_at: string }[];
+  const degreeByUser = new Map<string, number>();
+  for (const edge of acceptedEdges) {
+    degreeByUser.set(edge.requester_id, (degreeByUser.get(edge.requester_id) || 0) + 1);
+    degreeByUser.set(edge.addressee_id, (degreeByUser.get(edge.addressee_id) || 0) + 1);
+  }
+  const degrees = Array.from(degreeByUser.values()).sort((a, b) => a - b);
+  const totalUsers = totalRes.count ?? 0;
+  const connectedUsers = degreeByUser.size;
+  const isolatedUsers = Math.max(0, totalUsers - connectedUsers);
+  const avgFriends = connectedUsers > 0
+    ? +(degrees.reduce((s, d) => s + d, 0) / connectedUsers).toFixed(2)
+    : 0;
+  const medianFriends = degrees.length > 0
+    ? degrees[Math.floor(degrees.length / 2)]
+    : 0;
+  const maxFriends = degrees.length > 0 ? degrees[degrees.length - 1] : 0;
+  // Top 10 most-connected users. Display name looked up via the profile map
+  // already loaded (fall back to id slice).
+  const mostConnected = Array.from(degreeByUser.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  // Fetch any missing display names for the top-10 that weren't already loaded
+  const topUserIds = mostConnected.map(([id]) => id);
+  const missingTopIds = topUserIds.filter(id => !profileNames.has(id));
+  if (missingTopIds.length > 0) {
+    const { data: topProfiles } = await admin.from('profiles')
+      .select('id, display_name, username')
+      .in('id', missingTopIds);
+    if (topProfiles) {
+      for (const p of topProfiles) {
+        profileNames.set(p.id, p.display_name || p.username || p.id.slice(0, 8));
+      }
+    }
+  }
+  const mostConnectedUsers = mostConnected.map(([id, count]) => ({
+    name: profileNames.get(id) || id.slice(0, 8),
+    count,
+  }));
+
   // Engagement metrics (7d)
   const [checksRes, responsesRes, commentsRes, messagesRes] = await Promise.all([
     admin.from('interest_checks')
@@ -289,6 +339,17 @@ export async function GET(request: NextRequest) {
     themes: {
       distribution: themeDistribution,
       usersReporting: themeUsersReporting,
+    },
+    friendships: {
+      accepted: acceptedEdges.length,
+      pending: pendingCountRes.count ?? 0,
+      blocked: blockedCountRes.count ?? 0,
+      connectedUsers,
+      isolatedUsers,
+      avgFriends,
+      medianFriends,
+      maxFriends,
+      mostConnected: mostConnectedUsers,
     },
     engagement: {
       active7d: activeUserIds.size,


### PR DESCRIPTION
## Summary
Adds the social-graph half of #43 to `/admin`.

**Backend (`/api/admin/metrics`)**
- Fetch all `status='accepted'` rows from `friendships`; compute per-user degree by counting each user on both sides of the edge.
- Return a `friendships` section: `accepted`, `pending`, `blocked` counts; `connectedUsers` vs `isolatedUsers`; `avgFriends`, `medianFriends`, `maxFriends`; and top 10 `mostConnected` users (name + count).

**Admin UI (`/admin` → Friends tab)**
Three blocks:
1. **Status totals** — accepted / pending / blocked
2. **Per-user stats** — connected vs isolated (of total), avg / median / max
3. **Most connected** — top 10 users with friend counts

## Scope
Issue #43 also asks for squads metrics — leaving those as a follow-up PR (different schema surface, easier isolated). This closes the friendship half.

## Test plan
- [ ] Load `/admin` → Friends tab renders without errors
- [ ] Accepted + pending + blocked counts match `SELECT count(*) FROM friendships WHERE status = ...` in SQL editor
- [ ] Spot-check avg friends: `connectedUsers * avg ≈ accepted * 2`
- [ ] Most connected user matches the user with the most accepted friendships in SQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)