### PR TITLE
Expanded friendship + squads metrics (#43)

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,7 +16,7 @@ interface PushFailure {
   error: string | null;
 }
 
-type AdminTab = "users" | "engagement" | "push" | "versions" | "themes" | "friendships";
+type AdminTab = "users" | "engagement" | "push" | "versions" | "themes" | "friendships" | "squads";
 
 interface Metrics {
   totalUsers: number;
@@ -56,6 +56,19 @@ interface Metrics {
     medianFriends: number;
     maxFriends: number;
     mostConnected: { name: string; count: number }[];
+    acceptanceRate: number;
+    blockRate: number;
+    newByDate: Record<string, number>;
+    medianTimeToFirstFriend: number | null;
+    activeButIsolated: number;
+    activeButIsolatedNames: string[];
+  };
+  squads: {
+    totalActive: number;
+    newLast7d: number;
+    activeByMessages7d: number;
+    avgSize: number;
+    mostActive: { name: string; members: number; messages7d: number }[];
   };
   engagement: {
     active7d: number;
@@ -175,6 +188,7 @@ export default function AdminPage() {
     { key: "versions", label: "Versions" },
     { key: "themes", label: "Themes" },
     { key: "friendships", label: "Friends" },
+    { key: "squads", label: "Squads" },
   ];
 
   return (
@@ -597,6 +611,73 @@ export default function AdminPage() {
             </div>
           </div>
 
+          {/* Quality signals */}
+          <div className="p-3 rounded-lg border border-border bg-card mb-4">
+            <div className="font-mono text-tiny text-dim uppercase mb-2" style={{ letterSpacing: "0.15em" }}>
+              Quality
+            </div>
+            <div className="grid grid-cols-2 gap-y-1 gap-x-3 font-mono text-xs">
+              <span className="text-dim">Acceptance rate</span>
+              <span className="text-primary text-right">{metrics.friendships.acceptanceRate}%</span>
+              <span className="text-dim">Block rate</span>
+              <span className={`text-right ${metrics.friendships.blockRate > 5 ? "text-danger" : "text-primary"}`}>
+                {metrics.friendships.blockRate}%
+              </span>
+              <span className="text-dim">Median time-to-first-friend</span>
+              <span className="text-primary text-right">
+                {metrics.friendships.medianTimeToFirstFriend !== null
+                  ? `${metrics.friendships.medianTimeToFirstFriend}d`
+                  : "—"}
+              </span>
+              <span className="text-dim">Active-but-isolated (7d)</span>
+              <span className={`text-right ${metrics.friendships.activeButIsolated > 0 ? "text-danger" : "text-primary"}`}>
+                {metrics.friendships.activeButIsolated}
+              </span>
+            </div>
+            {metrics.friendships.activeButIsolatedNames.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-2">
+                {metrics.friendships.activeButIsolatedNames.map((n) => (
+                  <span key={n} className="font-mono text-tiny text-muted bg-border-light px-2 py-0.5 rounded-md">
+                    {n}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* New friendships per day (30d) */}
+          {(() => {
+            const days: { date: string; count: number }[] = [];
+            for (let i = 29; i >= 0; i--) {
+              const d = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
+              const key = localDateKey(d);
+              days.push({ date: key, count: metrics.friendships.newByDate[key] || 0 });
+            }
+            const maxN = Math.max(...days.map((d) => d.count), 1);
+            return (
+              <div className="p-3 rounded-lg border border-border bg-card mb-4">
+                <div className="font-mono text-tiny text-dim uppercase mb-2" style={{ letterSpacing: "0.15em" }}>
+                  New friendships (30d)
+                </div>
+                {days.map(({ date, count }) => (
+                  <div key={date} className="flex items-center gap-2 mb-0.5">
+                    <span className="font-mono text-tiny text-dim w-10 shrink-0">{date.slice(5)}</span>
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className="h-3 bg-dt rounded-sm"
+                        style={{
+                          width: count > 0 ? `${(count / maxN) * 100}%` : 0,
+                          minWidth: count > 0 ? 4 : 0,
+                        }}
+                      />
+                    </div>
+                    {count > 0 && <span className="font-mono text-tiny text-muted shrink-0">{count}</span>}
+                  </div>
+                ))}
+              </div>
+            );
+          })()}
+
           {/* Most connected */}
           <div className="p-3 rounded-lg border border-border bg-card">
             <div className="font-mono text-tiny text-dim uppercase mb-2" style={{ letterSpacing: "0.15em" }}>
@@ -619,6 +700,55 @@ export default function AdminPage() {
               </div>
             ) : (
               <p className="text-faint font-mono text-xs">No friendships yet</p>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Squads tab */}
+      {tab === "squads" && (
+        <>
+          {/* Totals */}
+          <div className="grid grid-cols-2 gap-2 mb-4">
+            {[
+              { label: "Total active", value: metrics.squads.totalActive },
+              { label: "New (7d)", value: metrics.squads.newLast7d },
+              { label: "Active by msg (7d)", value: metrics.squads.activeByMessages7d },
+              { label: "Avg size", value: metrics.squads.avgSize },
+            ].map((s) => (
+              <div key={s.label} className="p-3 rounded-lg border border-border bg-card">
+                <div className="font-mono text-tiny text-dim uppercase" style={{ letterSpacing: "0.15em" }}>
+                  {s.label}
+                </div>
+                <div className="font-serif text-2xl text-primary font-normal mt-1">
+                  {s.value}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Most active */}
+          <div className="p-3 rounded-lg border border-border bg-card">
+            <div className="font-mono text-tiny text-dim uppercase mb-2" style={{ letterSpacing: "0.15em" }}>
+              Most active (7d messages)
+            </div>
+            {metrics.squads.mostActive.length > 0 ? (
+              <div className="flex flex-col gap-1.5">
+                {metrics.squads.mostActive.map((s, i) => (
+                  <div key={`${s.name}-${i}`} className="flex justify-between items-center font-mono text-xs gap-2">
+                    <span className="text-primary min-w-0 truncate">
+                      <span className="text-faint mr-2">{i + 1}.</span>
+                      {s.name}
+                    </span>
+                    <span className="shrink-0">
+                      <span className="text-dt font-bold">{s.messages7d}</span>
+                      <span className="text-dim"> msgs · {s.members} members</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-faint font-mono text-xs">No active squads</p>
             )}
           </div>
         </>

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
   // Run queries in parallel
-  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes, dauRpcRes, pushSubscribersRes, friendshipsRes, pendingCountRes, blockedCountRes] = await Promise.all([
+  const [totalRes, onboardedRes, notOnboardedRes, recentRes, signupsRes, pushSentRes, pushFailedRes, pushStaleRes, pushRecentFailures, versionPingsRes, dauRpcRes, pushSubscribersRes, friendshipsRes, pendingCountRes, blockedCountRes, allProfilesRes, squadsRes, squadMembersRes, squadMessages7dRes] = await Promise.all([
     admin.from('profiles').select('*', { count: 'exact', head: true }),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', true),
     admin.from('profiles').select('*', { count: 'exact', head: true }).eq('onboarded', false),
@@ -65,6 +65,18 @@ export async function GET(request: NextRequest) {
       .limit(100000),
     admin.from('friendships').select('*', { count: 'exact', head: true }).eq('status', 'pending'),
     admin.from('friendships').select('*', { count: 'exact', head: true }).eq('status', 'blocked'),
+    // All profile created_at timestamps — for time-to-first-friend
+    admin.from('profiles').select('id, created_at').not('created_at', 'is', null).limit(100000),
+    // Squads (all, we filter active/archived in-memory)
+    admin.from('squads').select('id, created_at, archived_at, expires_at, name').limit(100000),
+    // Squad memberships — for avg size + top-squad sizes
+    admin.from('squad_members').select('squad_id, user_id').limit(200000),
+    // Non-system messages in last 7d — for active-squad classification
+    admin.from('messages')
+      .select('squad_id, created_at')
+      .eq('is_system', false)
+      .gte('created_at', since7d)
+      .limit(100000),
   ]);
 
   // DAU from RPC — already grouped by date
@@ -234,6 +246,98 @@ export async function GET(request: NextRequest) {
     count,
   }));
 
+  // Acceptance / decline / block rates (as percentages)
+  const pendingCount = pendingCountRes.count ?? 0;
+  const blockedCount = blockedCountRes.count ?? 0;
+  const totalFriendshipRows = acceptedEdges.length + pendingCount + blockedCount;
+  const acceptanceRate = totalFriendshipRows > 0
+    ? Math.round((acceptedEdges.length / totalFriendshipRows) * 100)
+    : 0;
+  const blockRate = totalFriendshipRows > 0
+    ? Math.round((blockedCount / totalFriendshipRows) * 100)
+    : 0;
+
+  // New-friendships-per-day (30d) — accepted edges grouped by local date
+  const newFriendshipsByDate: Record<string, number> = {};
+  for (const edge of acceptedEdges) {
+    if (edge.created_at >= since30d) {
+      const d = toLocalDate(edge.created_at, tz);
+      newFriendshipsByDate[d] = (newFriendshipsByDate[d] || 0) + 1;
+    }
+  }
+
+  // Time-to-first-friend — median days between profile.created_at and
+  // a user's first accepted friendship edge.
+  const signupByUser = new Map<string, string>();
+  for (const p of (allProfilesRes.data ?? []) as { id: string; created_at: string }[]) {
+    signupByUser.set(p.id, p.created_at);
+  }
+  const firstFriendshipByUser = new Map<string, string>();
+  // acceptedEdges aren't guaranteed sorted; sort ascending so we capture first
+  const edgesAsc = [...acceptedEdges].sort((a, b) => a.created_at.localeCompare(b.created_at));
+  for (const edge of edgesAsc) {
+    if (!firstFriendshipByUser.has(edge.requester_id)) {
+      firstFriendshipByUser.set(edge.requester_id, edge.created_at);
+    }
+    if (!firstFriendshipByUser.has(edge.addressee_id)) {
+      firstFriendshipByUser.set(edge.addressee_id, edge.created_at);
+    }
+  }
+  const timeToFirstDays: number[] = [];
+  for (const [uid, firstAt] of firstFriendshipByUser.entries()) {
+    const signup = signupByUser.get(uid);
+    if (!signup) continue;
+    const days = (new Date(firstAt).getTime() - new Date(signup).getTime()) / (24 * 60 * 60 * 1000);
+    if (days >= 0) timeToFirstDays.push(days);
+  }
+  timeToFirstDays.sort((a, b) => a - b);
+  const medianTimeToFirstFriend = timeToFirstDays.length > 0
+    ? +timeToFirstDays[Math.floor(timeToFirstDays.length / 2)].toFixed(1)
+    : null;
+
+  // Squads metrics — filter active (not archived, not expired) in-memory
+  const nowIso = new Date().toISOString();
+  const squadsAll = (squadsRes.data ?? []) as { id: string; created_at: string; archived_at: string | null; expires_at: string | null; name: string }[];
+  const activeSquads = squadsAll.filter(s =>
+    !s.archived_at && (!s.expires_at || s.expires_at > nowIso)
+  );
+  const activeSquadIds = new Set(activeSquads.map(s => s.id));
+
+  // Members per squad (active squads only)
+  const membersBySquad = new Map<string, number>();
+  for (const m of (squadMembersRes.data ?? []) as { squad_id: string; user_id: string }[]) {
+    if (activeSquadIds.has(m.squad_id)) {
+      membersBySquad.set(m.squad_id, (membersBySquad.get(m.squad_id) || 0) + 1);
+    }
+  }
+  const sizes = Array.from(membersBySquad.values());
+  const avgSquadSize = sizes.length > 0
+    ? +(sizes.reduce((s, n) => s + n, 0) / sizes.length).toFixed(2)
+    : 0;
+
+  // Squads with any non-system message in last 7d = active-by-activity
+  const activeByMessages = new Set<string>();
+  const messagesBySquad = new Map<string, number>();
+  for (const m of (squadMessages7dRes.data ?? []) as { squad_id: string; created_at: string }[]) {
+    if (!activeSquadIds.has(m.squad_id)) continue;
+    activeByMessages.add(m.squad_id);
+    messagesBySquad.set(m.squad_id, (messagesBySquad.get(m.squad_id) || 0) + 1);
+  }
+  const newSquads7d = activeSquads.filter(s => s.created_at >= since7d).length;
+
+  // Top 10 most-active squads by message count in last 7d
+  const mostActiveSquads = Array.from(messagesBySquad.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([id, msgs]) => {
+      const s = activeSquads.find(x => x.id === id);
+      return {
+        name: s?.name || id.slice(0, 8),
+        members: membersBySquad.get(id) || 0,
+        messages7d: msgs,
+      };
+    });
+
   // Engagement metrics (7d)
   const [checksRes, responsesRes, commentsRes, messagesRes] = await Promise.all([
     admin.from('interest_checks')
@@ -273,6 +377,23 @@ export async function GET(request: NextRequest) {
   // Lurkers: active but not engaged
   const lurkerIds = [...activeUserIds].filter(id => !engagedUserIds.has(id));
   const lurkerNames: string[] = lurkerIds.map(id => profileNames.get(id) || id.slice(0, 8));
+
+  // Active-but-isolated: loaded the app in last 7d AND have 0 accepted friends.
+  // These are high-churn candidates who'd benefit from a friend-nudge.
+  const activeIsolatedIds = [...activeUserIds].filter(id => !degreeByUser.has(id));
+  // Fetch display names for any we didn't already look up
+  const missingIsolatedIds = activeIsolatedIds.filter(id => !profileNames.has(id));
+  if (missingIsolatedIds.length > 0) {
+    const { data: extra } = await admin.from('profiles')
+      .select('id, display_name, username')
+      .in('id', missingIsolatedIds);
+    if (extra) {
+      for (const p of extra) {
+        profileNames.set(p.id, p.display_name || p.username || p.id.slice(0, 8));
+      }
+    }
+  }
+  const activeIsolatedNames = activeIsolatedIds.map(id => profileNames.get(id) || id.slice(0, 8));
 
   // Daily activity counts (grouped by local date)
   const checksByDate: Record<string, number> = {};
@@ -342,14 +463,27 @@ export async function GET(request: NextRequest) {
     },
     friendships: {
       accepted: acceptedEdges.length,
-      pending: pendingCountRes.count ?? 0,
-      blocked: blockedCountRes.count ?? 0,
+      pending: pendingCount,
+      blocked: blockedCount,
       connectedUsers,
       isolatedUsers,
       avgFriends,
       medianFriends,
       maxFriends,
       mostConnected: mostConnectedUsers,
+      acceptanceRate,
+      blockRate,
+      newByDate: newFriendshipsByDate,
+      medianTimeToFirstFriend, // days, null if no data
+      activeButIsolated: activeIsolatedIds.length,
+      activeButIsolatedNames: activeIsolatedNames,
+    },
+    squads: {
+      totalActive: activeSquads.length,
+      newLast7d: newSquads7d,
+      activeByMessages7d: activeByMessages.size,
+      avgSize: avgSquadSize,
+      mostActive: mostActiveSquads,
     },
     engagement: {
       active7d: activeUserIds.size,


### PR DESCRIPTION
## Summary
Closes issue #43.

### Friendship additions (all 5 nice-to-haves)
- **Acceptance rate** — `accepted / (accepted + pending + blocked)`
- **Block rate** — `blocked / total`; highlighted red if >5%
- **New friendships per day** — 30-day bar chart mirroring the DAU chart on the Users tab
- **Median time-to-first-friend** — days between a user's `profiles.created_at` and their first accepted friendship
- **Active-but-isolated** — users who loaded the app in the last 7d AND have 0 accepted friendships (high-churn candidates). Lists their names so you can nudge them.

### Squads metrics (the other half of #43)
- Total active squads (not archived, not expired)
- New squads in last 7d
- Active-by-messages — squads with ≥1 non-system message in the last 7d
- Avg squad size across active squads
- Top 10 most-active squads by 7-day message count (name, members, messages7d)

### Backend
4 new parallel queries added to `/api/admin/metrics`:
- `profiles(id, created_at)` — for time-to-first-friend
- `squads(*)` — filtered in-memory to active
- `squad_members(squad_id, user_id)` — for avg size + top-squad sizes
- `messages(squad_id, created_at)` limited to non-system and last 7d

### UI
- **Friends tab** gains a Quality block and a 30d bar chart; keeps Most-connected list.
- **Squads tab** (new): 4-tile summary grid + Most-active list.

## Test plan
- [ ] `/admin` → Friends tab shows all 5 new metrics without errors
- [ ] Acceptance rate ≈ `accepted / (accepted + pending + blocked)` verified via SQL
- [ ] Time-to-first-friend is null when there are no friendships, otherwise a reasonable number
- [ ] `/admin` → Squads tab renders totals + most-active list
- [ ] Squad avg size matches `(SELECT avg(n) FROM (SELECT count(*) n FROM squad_members GROUP BY squad_id))` on active squads

🤖 Generated with [Claude Code](https://claude.com/claude-code)