### PR TITLE
fix: filter Safari variant of Supabase lock-stolen AbortError

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -19,7 +19,9 @@ Sentry.init({
     // Supabase auth lock stolen between tabs / across Strict Mode remounts.
     // The stealing side recovers (supabase-js/locks.ts); the stolen side's
     // in-flight query rejects with this AbortError and re-runs on next refresh.
-    "Lock broken by another request with the 'steal' option",
+    // Chrome and Safari word this differently; match both.
+    "Lock broken by another request with the 'steal' option", // Chrome / V8
+    "Lock was stolen by another request", // Safari / WebKit
   ],
   beforeSend(event) {
     // Defensive: strip free-text fields (event notes, scraped captions) that


### PR DESCRIPTION
## Summary
- Sentry issue [DOWNTO-5](https://downto.sentry.io/issues/7434552343/) is the WebKit-phrased sibling of [DOWNTO-3](https://downto.sentry.io/issues/7428465707/). Same Web Locks API event (`auth-js/locks.ts` forcibly preempts a slow lock holder with `{ steal: true }`), but Chrome throws `"Lock broken by another request with the 'steal' option."` while Safari throws `"Lock was stolen by another request"`.
- PR #382's `ignoreErrors` entry only matched Chrome, so Safari users still shipped the error. Adds the WebKit string alongside the existing one.

## Test plan
- [ ] Confirm DOWNTO-5 stays resolved after deploy (marked resolved-in-release; auto-reopens on regression)
- [ ] Real Supabase auth errors still reach Sentry — only these two specific AbortError messages are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)