### PR TITLE
Surface pending friend requests (sticky banner + You-tab dot)

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -31,10 +31,12 @@ const BottomNav = ({
   tab,
   onTabChange,
   hasSquadsUnread,
+  hasProfileUnread,
 }: {
   tab: Tab;
   onTabChange: (t: Tab) => void;
   hasSquadsUnread: boolean;
+  hasProfileUnread?: boolean;
 }) => {
   const prevTab = useRef(tab);
   const highlightRef = useRef<HTMLDivElement>(null);
@@ -132,6 +134,12 @@ const BottomNav = ({
             {t === "squads" && hasSquadsUnread && (
               <div
                 data-testid="squads-unread-dot"
+                className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
+              />
+            )}
+            {t === "profile" && hasProfileUnread && (
+              <div
+                data-testid="profile-unread-dot"
                 className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
               />
             )}

--- a/src/app/components/FriendRequestBanner.tsx
+++ b/src/app/components/FriendRequestBanner.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { HEADER_HEIGHT_PX } from "./Header";
+
+/**
+ * Sticky banner that sits just below the Header when the viewer has pending
+ * friend requests. Tapping opens the Friends modal on the friends tab (where
+ * the incoming-requests list lives). Visible until every request has been
+ * accepted or rejected (count drops to 0).
+ */
+export default function FriendRequestBanner({
+  count,
+  onOpen,
+}: {
+  count: number;
+  onOpen: () => void;
+}) {
+  if (count <= 0) return null;
+  const label = `${count} friend request${count === 1 ? "" : "s"} waiting`;
+  return (
+    <button
+      onClick={onOpen}
+      data-testid="friend-request-banner"
+      className="fixed left-0 right-0 z-30 max-w-[420px] mx-auto px-3 bg-transparent border-none cursor-pointer"
+      style={{
+        top: `calc(env(safe-area-inset-top, 16px) + ${HEADER_HEIGHT_PX}px)`,
+      }}
+    >
+      <div className="bg-dt text-on-accent rounded-xl flex items-center justify-between gap-2 px-4 py-2.5"
+        style={{ boxShadow: "0 4px 14px rgba(254, 68, 255, 0.35)" }}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-2 h-2 rounded-full bg-on-accent shrink-0 animate-pulse" />
+          <span className="font-mono text-xs font-bold uppercase tracking-[0.08em] truncate">
+            {label}
+          </span>
+        </div>
+        <span className="font-mono text-xs font-bold shrink-0">→</span>
+      </div>
+    </button>
+  );
+}
+
+/** Height contributed to the top of the scroll container when the banner is visible. */
+export const FRIEND_REQUEST_BANNER_HEIGHT_PX = 48;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ import SquadChat from "@/features/squads/components/SquadChat";
 import ProfileView from "@/features/profile/components/ProfileView";
 import Header, { HEADER_HEIGHT_PX, HEADER_HEIGHT_WITH_TABS_PX, HEADER_OFFSET_PX } from "@/app/components/Header";
 import BottomNav from "@/app/components/BottomNav";
+import FriendRequestBanner, { FRIEND_REQUEST_BANNER_HEIGHT_PX } from "@/app/components/FriendRequestBanner";
 import Toast from "@/app/components/Toast";
 import NotificationsPanel from "@/features/notifications/components/NotificationsPanel";
 import { useAuth } from "@/features/auth/hooks/useAuth";
@@ -691,6 +692,11 @@ export default function Home() {
 
   if (onboarding.onboardingScreen) return onboarding.onboardingScreen;
 
+  // Count incoming (pending inbound) friend requests — drives the sticky
+  // banner + the profile-tab dot.
+  const pendingFriendRequestCount = friendsHook.suggestions.filter(
+    (s) => s.status === "incoming",
+  ).length;
 
   return (
     <FeedContext.Provider value={{
@@ -732,6 +738,16 @@ export default function Home() {
         scrolled={scrolledDown}
       />
 
+      {/* Sticky banner: surfaces pending incoming friend requests. Stays visible
+          on every tab until the viewer has accepted / rejected all of them. */}
+      <FriendRequestBanner
+        count={pendingFriendRequestCount}
+        onOpen={() => {
+          friendsHook.setFriendsInitialTab("friends");
+          friendsHook.setFriendsOpen(true);
+        }}
+      />
+
       {/* Scroll area with fade edges */}
       <div className="flex-1 relative overflow-hidden">
         {/* Top fade — visible when scrolled */}
@@ -748,7 +764,7 @@ export default function Home() {
         <div
           ref={scrollRef}
           className="h-full overflow-y-auto"
-          style={{ paddingTop: `calc(env(safe-area-inset-top, 16px) + ${(HEADER_HEIGHT_PX) + HEADER_OFFSET_PX}px)`, paddingBottom: "calc(72px + env(safe-area-inset-bottom, 0px))" }}
+          style={{ paddingTop: `calc(env(safe-area-inset-top, 16px) + ${(HEADER_HEIGHT_PX) + HEADER_OFFSET_PX + (pendingFriendRequestCount > 0 ? FRIEND_REQUEST_BANNER_HEIGHT_PX : 0)}px)`, paddingBottom: "calc(72px + env(safe-area-inset-bottom, 0px))" }}
           onScroll={() => {
             const scrolled = (scrollRef.current?.scrollTop ?? 0) > 0;
             if (scrolled !== scrolledDown) setScrolledDown(scrolled);
@@ -960,6 +976,7 @@ export default function Home() {
             if (t !== "feed") checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: null });
           }}
           hasSquadsUnread={squadsHook.squads.some((s) => s.hasUnread) || notificationsHook.notifications.some((n) => n.type === "squad_invite" && !n.is_read)}
+          hasProfileUnread={pendingFriendRequestCount > 0}
         />
       </div>
 


### PR DESCRIPTION
## Context
48 pending friend requests were sitting in inboxes, 22 of them more than 30 days old. The top receivers (8 pending for `boyixu65`, 5 each for `nic`, `chui.luke99`, `mindip`) clearly weren't seeing them in the current UI.

## Changes
Two visibility signals so users can't miss an incoming request:

- **Sticky banner** just below the Header on every tab when there's ≥1 incoming request. Shows "N friend request(s) waiting →". Tap → opens Friends modal on the Friends tab (where the incoming-requests list lives). Stays visible until the count hits 0 — the user has to accept or reject every request to clear it.
- **Red dot on the "You" bottom-nav tab** using the same pattern as the squads-unread dot. Visible even when the user is on another tab and the banner isn't in view (e.g., scrolled past).

Scroll container's `paddingTop` adds `FRIEND_REQUEST_BANNER_HEIGHT_PX` when the banner is visible so nothing gets hidden behind it.

## Test plan
- [ ] Sign in as a user with pending incoming friend requests → banner appears below the Header with the right count, red dot on the "You" tab
- [ ] Tap banner → Friends modal opens on the Friends tab showing the incoming-requests list
- [ ] Accept one request → count decrements; banner stays if still >0
- [ ] Accept/reject all → banner disappears, dot clears
- [ ] Sign in as a user with 0 pending → no banner, no dot (unchanged layout)
- [ ] Banner doesn't overlap content on any tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)