### PR TITLE
Friend-request banner opens the Add tab, not Friends

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -739,11 +739,12 @@ export default function Home() {
       />
 
       {/* Sticky banner: surfaces pending incoming friend requests. Stays visible
-          on every tab until the viewer has accepted / rejected all of them. */}
+          on every tab until the viewer has accepted / rejected all of them.
+          Incoming-requests list renders on the "add" tab, so jump there directly. */}
       <FriendRequestBanner
         count={pendingFriendRequestCount}
         onOpen={() => {
-          friendsHook.setFriendsInitialTab("friends");
+          friendsHook.setFriendsInitialTab("add");
           friendsHook.setFriendsOpen(true);
         }}
       />


### PR DESCRIPTION
## Summary
`FriendsModal` renders the **incoming-requests** list inside the **Add** tab (`tab === "add"` branch, next to Share-invite-link and the search-to-add-friends UI). The banner I added in #389 pointed at the Friends tab, which hides the requests — tapping the pill did the wrong thing.

Point the banner at `"add"` so tapping "N friend requests waiting" lands the user directly on the Accept/Decline buttons.

## Test plan
- [ ] Sign in as a user with pending incoming friend requests
- [ ] Tap the banner → Friends modal opens on the **Add** tab
- [ ] "Friend Requests (N)" section is visible immediately with Accept/Decline buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)