### PR TITLE
Remove You-tab red dot for pending friend requests

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -31,12 +31,10 @@ const BottomNav = ({
   tab,
   onTabChange,
   hasSquadsUnread,
-  hasProfileUnread,
 }: {
   tab: Tab;
   onTabChange: (t: Tab) => void;
   hasSquadsUnread: boolean;
-  hasProfileUnread?: boolean;
 }) => {
   const prevTab = useRef(tab);
   const highlightRef = useRef<HTMLDivElement>(null);
@@ -134,12 +132,6 @@ const BottomNav = ({
             {t === "squads" && hasSquadsUnread && (
               <div
                 data-testid="squads-unread-dot"
-                className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
-              />
-            )}
-            {t === "profile" && hasProfileUnread && (
-              <div
-                data-testid="profile-unread-dot"
                 className="absolute top-1 right-2 w-[7px] h-[7px] rounded-full bg-[#ff3b30]"
               />
             )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -977,7 +977,6 @@ export default function Home() {
             if (t !== "feed") checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: null });
           }}
           hasSquadsUnread={squadsHook.squads.some((s) => s.hasUnread) || notificationsHook.notifications.some((n) => n.type === "squad_invite" && !n.is_read)}
-          hasProfileUnread={pendingFriendRequestCount > 0}
         />
       </div>
 


### PR DESCRIPTION
## Summary
Removes the red dot on the "You" bottom-nav tab introduced in #389. The sticky banner at the top already covers the surfacing job; the extra dot is redundant.

- Drop the `hasProfileUnread` prop from `BottomNav` and the profile-tab dot render.
- Stop passing `hasProfileUnread={pendingFriendRequestCount > 0}` from `page.tsx`.

The banner + the friend-request management inside the You-tab's profile view remain unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)