### PR TITLE
fix: allow posting an undated interest check

### DIFF
--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -747,7 +747,7 @@ const AddModal = ({
                   onChange={(e) => setWhenInput(e.target.value)}
                   className="w-full py-2.5 px-3 bg-deep rounded-lg font-mono text-xs text-primary outline-none box-border"
                   style={{
-                    border: `1px solid ${idea.trim() && !parsedDate ? '#ff6b6b44' : '#333'}`,
+                    border: `1px solid ${whenInput.trim() && !parsedDate && !parsedTime ? '#ff6b6b44' : '#333'}`,
                   }}
                 />
               </div>
@@ -767,12 +767,12 @@ const AddModal = ({
                 {whenPreview}
               </div>
             )}
-            {!whenPreview && idea.trim() && !parsedDate && (
+            {!whenPreview && whenInput.trim() && (
               <div className="font-mono text-tiny text-danger mb-2" style={{ paddingLeft: 2 }}>
-                add a date (e.g. &quot;fri&quot;, &quot;3/14&quot;, &quot;next sat&quot;)
+                couldn&apos;t read that — try &quot;fri&quot;, &quot;3/14&quot;, &quot;next sat&quot;
               </div>
             )}
-            {!whenPreview && (!idea.trim() || parsedDate) && <div className="mb-2" />}
+            {!whenPreview && !whenInput.trim() && <div className="mb-2" />}
             {/* Movie preview from detected Letterboxd link */}
             {checkMovieLoading && (
               <div className="flex items-center gap-2 mb-3 py-2.5 px-3 bg-deep rounded-lg border border-border-light">
@@ -957,10 +957,10 @@ const AddModal = ({
                   close();
                 }
               }}
-              disabled={!idea.trim() || !parsedDate}
+              disabled={!idea.trim()}
               className={cn(
                 'w-full border-none rounded-xl py-3.5 font-mono text-sm font-bold uppercase',
-                idea.trim() && parsedDate
+                idea.trim()
                   ? 'bg-dt text-on-accent cursor-pointer'
                   : 'bg-border-mid text-dim cursor-not-allowed'
               )}


### PR DESCRIPTION
## Summary
- The idea-mode Send button in `CreateModal` required a parseable date, so users couldn't post a check without one — contrary to `specs/interest-check-flow.md:17` which lists event date/time as optional.
- Drops `!parsedDate` from the submit-disabled gate so any check with idea text can be sent.
- Red border and warning now only fire when the user typed something into the when input that failed to parse (instead of any dateless idea). Copy softened from "add a date" to "couldn't read that".

Paste mode is unchanged — still date-gated because the scraped event post is expected to carry a date.

## Test plan
- [ ] Open the create modal in idea mode, type an idea only (no when/where), confirm the Send Interest Check button is enabled and posts a check with `event_date = null`.
- [ ] Type a when string that parses (e.g. "tmr 7pm") — preview shows, border stays neutral, Send works.
- [ ] Type an unparseable when string (e.g. "sometime") — border goes red, "couldn't read that" warning shows, Send is still enabled and posts the check with `event_date = null`.
- [ ] Clear the when input — warning disappears, border back to neutral.
- [ ] Paste-mode scrape with no date still shows the disabled "No date found" variant.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_