### PR TITLE
fix: compare event_date against viewer's local today, not UTC

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -717,6 +717,11 @@ export async function getFofAnnotations(): Promise<{ check_id: string; via_frien
 }
 
 export async function getActiveChecks(): Promise<(InterestCheck & { author: Profile; responses: (CheckResponse & { user: Profile })[]; squads: { id: string; archived_at: string | null; members: { id: string }[] }[]; co_authors: (CheckCoAuthor & { user: Profile })[] })[]> {
+  const now = new Date();
+  const nowIso = now.toISOString();
+  // Local-timezone YYYY-MM-DD — using UTC here dropped checks for "today" from
+  // users west of UTC once it rolled past midnight server-side.
+  const todayLocal = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const { data, error } = await supabase
     .from('interest_checks')
     .select(`
@@ -726,8 +731,8 @@ export async function getActiveChecks(): Promise<(InterestCheck & { author: Prof
       squads(id, archived_at, members:squad_members(id, user_id, role)),
       co_authors:check_co_authors(*, user:profiles!user_id(*))
     `)
-    .or(`expires_at.gt.${new Date().toISOString()},expires_at.is.null,event_date.gte.${new Date().toISOString().slice(0, 10)}`)
-    .or(`event_date.gte.${new Date().toISOString().slice(0, 10)},event_date.is.null`)
+    .or(`expires_at.gt.${nowIso},expires_at.is.null,event_date.gte.${todayLocal}`)
+    .or(`event_date.gte.${todayLocal},event_date.is.null`)
     .is('archived_at', null)
     .order('created_at', { ascending: false });
 


### PR DESCRIPTION
## Summary
- `getActiveChecks` built its `event_date >= today` filter from `new Date().toISOString().slice(0, 10)`, which is **UTC**. For a viewer west of UTC (e.g. US Eastern), that meant checks dated for their local "today" got filtered out as soon as UTC rolled past midnight, even though the check still had hours of `expires_at` left.
- Switch to a locally-formatted `YYYY-MM-DD` so the filter matches the date the viewer actually picked when posting.

## Reproducer
- Viewer in US Eastern at ~10pm local (02:00 UTC next day).
- Friend posted a check earlier today with `event_date = 2026-04-23` (their local today).
- Before fix: the check disappears from the feed at 20:00 EDT (00:00 UTC) even though everyone still considers it "tonight".
- After fix: the check stays visible as long as it's still 2026-04-23 in the viewer's local clock.

## Caveat (out of scope)
`archive_past_date_checks()` on the server still uses `CURRENT_DATE` (UTC on Supabase), so a late-night Eastern check can get auto-archived by the daily cron the following UTC morning. Proper fix needs per-user TZ or a grace period in the cron — tracked separately.

## Test plan
- [ ] Set your laptop TZ to UTC-4, system clock to 23:30 local (03:30 UTC next day).
- [ ] Have a friend post a check with `event_date = today (local)`.
- [ ] Confirm the check appears in your feed.
- [ ] Shift system clock to 00:30 local next day; confirm check disappears (event_date now yesterday locally too).

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_