### PR TITLE
ci: auto-push Supabase migrations to prod on merge to main

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -1,0 +1,31 @@
+name: DB Migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+concurrency:
+  group: db-migrations-prod
+  cancel-in-progress: false
+
+jobs:
+  push:
+    name: Push Supabase migrations to prod
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+      - name: Push migrations
+        run: supabase db push --include-all --yes


### PR DESCRIPTION
## Summary
New GitHub Actions workflow that auto-pushes Supabase migrations to prod after a PR merges to `main`, so migration files in the repo stop drifting from the deployed schema.

- Triggers on `push` to `main` when `supabase/migrations/**` changes (plus `workflow_dispatch` for manual replays).
- Uses `supabase/setup-cli@v1`, links to the prod project, runs `supabase db push --include-all --yes`.
- `environment: production` — set required reviewers on that environment in repo settings if you want a manual approval gate before each push hits prod.
- `concurrency: db-migrations-prod` — only one migration push runs at a time; later pushes queue instead of racing.

## Required secrets (repo Settings → Secrets and variables → Actions)
- `SUPABASE_ACCESS_TOKEN` — personal access token from https://supabase.com/dashboard/account/tokens
- `SUPABASE_PROJECT_REF` — the prod project ref (20-char id)
- `SUPABASE_DB_PASSWORD` — the DB password for the prod project

## Caveats
- If any migration was applied to prod out-of-band (e.g. via the dashboard SQL editor) and the migrations table diverges from the repo, `db push` will error out. Fix with a one-time `supabase migration repair` against prod.
- First run will try to apply every migration in `supabase/migrations/`. Already-applied ones are skipped (tracked in `supabase_migrations.schema_migrations`), but a mismatched history will fail the run — expected, and a signal to reconcile.
- Prefer **not** merging this before the secrets are set, or the first run will fail loudly.

## Test plan
- [ ] Add the three secrets to the repo.
- [ ] (Optional but recommended) Set `production` as a protected environment with required reviewers.
- [ ] Merge this PR with no migration changes — the job should not trigger (path filter).
- [ ] Add a trivial no-op migration (e.g. `-- no-op`) in a follow-up PR, merge, confirm the workflow runs and succeeds.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_