### PR TITLE
fix: stop duplicating the viewer's own check response

### DIFF
--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -127,7 +127,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
           if (via) c.viaFriendName = via;
         }
       }
-      dispatch({ type: CheckActionType.SYNC_CHECKS, checks: transformedChecks });
+      dispatch({ type: CheckActionType.SYNC_CHECKS, checks: transformedChecks, userId });
     } catch (err) {
       logWarn("loadChecks", "Failed to load checks", { error: err });
     }
@@ -164,19 +164,20 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
       hiddenIds,
       responses: restoredResponses,
       avatarLetter: profile?.avatar_letter,
+      userId,
     });
   }, [userId]);
 
   const respondToCheck = (checkId: string) => {
     const check = checks.find((c) => c.id === checkId);
-    dispatch({ type: CheckActionType.SET_RESPONSE, checkId, status: "down", avatarLetter: profile?.avatar_letter ?? "?" });
+    dispatch({ type: CheckActionType.SET_RESPONSE, checkId, status: "down", avatarLetter: profile?.avatar_letter ?? "?", userId });
     showToast("You're down! ✦");
     if (check?.id) {
       dispatch({ type: CheckActionType.SET_PENDING, checkId, pending: true });
       db.respondToCheck(check.id, 'down')
         .then(async (result) => {
           if (result.response === 'waitlist') {
-            dispatch({ type: CheckActionType.SET_RESPONSE, checkId, status: "waitlist", avatarLetter: profile?.avatar_letter ?? "?" });
+            dispatch({ type: CheckActionType.SET_RESPONSE, checkId, status: "waitlist", avatarLetter: profile?.avatar_letter ?? "?", userId });
             showToast("Check is full — you're on the waitlist");
           }
           if (onDownResponse) await onDownResponse();
@@ -319,7 +320,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
   }, [respondToCheck]);
 
   const clearResponse = (checkId: string) => {
-    dispatch({ type: CheckActionType.CLEAR_RESPONSE, checkId });
+    dispatch({ type: CheckActionType.CLEAR_RESPONSE, checkId, userId });
   };
 
   const hideCheck = async (checkId: string) => {

--- a/src/features/checks/reducers/checksReducer.ts
+++ b/src/features/checks/reducers/checksReducer.ts
@@ -40,15 +40,15 @@ export const CheckActionType = {
 
 export type ChecksAction =
   // Serves both loadChecks (checks-only) and hydrateChecks (checks + hiddenIds + responses)
-  | { type: typeof CheckActionType.SYNC_CHECKS; checks: InterestCheck[]; hiddenIds?: string[]; responses?: Record<string, "down" | "waitlist">; avatarLetter?: string }
+  | { type: typeof CheckActionType.SYNC_CHECKS; checks: InterestCheck[]; hiddenIds?: string[]; responses?: Record<string, "down" | "waitlist">; avatarLetter?: string; userId?: string | null }
   // Prepends if new id, shallow-merges if existing
   | { type: typeof CheckActionType.UPSERT_CHECK; check: InterestCheck }
   // Bulk patch — for syncing squad membership across multiple checks at once
   | { type: typeof CheckActionType.PATCH_CHECKS; patches: Array<{ id: string; patch: Partial<InterestCheck> }> }
   // Optimistic response — patches "You" into check.responses + myCheckResponses
-  | { type: typeof CheckActionType.SET_RESPONSE; checkId: string; status: "down" | "waitlist"; avatarLetter?: string }
+  | { type: typeof CheckActionType.SET_RESPONSE; checkId: string; status: "down" | "waitlist"; avatarLetter?: string; userId?: string | null }
   // Optimistic un-down — removes "You" from check.responses + myCheckResponses
-  | { type: typeof CheckActionType.CLEAR_RESPONSE; checkId: string }
+  | { type: typeof CheckActionType.CLEAR_RESPONSE; checkId: string; userId?: string | null }
   // Bulk response merge — for shared check injection
   | { type: typeof CheckActionType.MERGE_RESPONSES; responses: Record<string, "down" | "waitlist"> }
   // Pending spinner (pending: true = add, false = remove)
@@ -82,16 +82,21 @@ function mergeChecks(prev: InterestCheck[], next: InterestCheck[]): InterestChec
   });
 }
 
-// Re-apply "You" response if a realtime sync fires before the DB confirms your response
+// Re-apply "You" response if a realtime sync fires before the DB confirms your response.
+// Skip when the server already returned the viewer's row (matched via odbc === userId,
+// since transformCheck renders your own response under your display_name, not "You").
 function patchYouResponses(
   checks: InterestCheck[],
   myCheckResponses: Record<string, "down" | "waitlist">,
-  avatarLetter?: string
+  avatarLetter?: string,
+  userId?: string | null
 ): InterestCheck[] {
   return checks.map((c) => {
     const myStatus = myCheckResponses[c.id];
-    if (!myStatus || c.responses.some((r) => r.name === "You")) return c;
-    return { ...c, responses: [{ name: "You", avatar: avatarLetter ?? "?", status: myStatus }, ...c.responses] };
+    if (!myStatus) return c;
+    if (c.responses.some((r) => r.name === "You")) return c;
+    if (userId && c.responses.some((r) => r.odbc === userId)) return c;
+    return { ...c, responses: [{ name: "You", avatar: avatarLetter ?? "?", status: myStatus, odbc: userId ?? undefined }, ...c.responses] };
   });
 }
 
@@ -105,7 +110,7 @@ export function checksReducer(state: ChecksState, action: ChecksAction): ChecksS
       const responses = action.responses
         ? action.responses
         : state.myCheckResponses;
-      const checks = patchYouResponses(mergeChecks(state.checks, action.checks), responses, action.avatarLetter);
+      const checks = patchYouResponses(mergeChecks(state.checks, action.checks), responses, action.avatarLetter, action.userId);
       return {
         ...state,
         checks,
@@ -129,22 +134,22 @@ export function checksReducer(state: ChecksState, action: ChecksAction): ChecksS
       return { ...state, checks };
     }
     case CheckActionType.SET_RESPONSE: {
-      const { checkId, status, avatarLetter } = action;
+      const { checkId, status, avatarLetter, userId } = action;
       const checks = state.checks.map((c) => {
         if (c.id !== checkId) return c;
         const responses = [
-          { name: "You", avatar: avatarLetter ?? "?", status },
-          ...c.responses.filter((r) => r.name !== "You"),
+          { name: "You", avatar: avatarLetter ?? "?", status, odbc: userId ?? undefined },
+          ...c.responses.filter((r) => r.name !== "You" && (!userId || r.odbc !== userId)),
         ];
         return { ...c, responses };
       });
       return { ...state, checks, myCheckResponses: { ...state.myCheckResponses, [checkId]: status } };
     }
     case CheckActionType.CLEAR_RESPONSE: {
-      const { checkId } = action;
+      const { checkId, userId } = action;
       const checks = state.checks.map((c) => {
         if (c.id !== checkId) return c;
-        return { ...c, responses: c.responses.filter((r) => r.name !== "You") };
+        return { ...c, responses: c.responses.filter((r) => r.name !== "You" && (!userId || r.odbc !== userId)) };
       });
       const { [checkId]: _, ...rest } = state.myCheckResponses;
       return { ...state, checks, myCheckResponses: rest };
@@ -170,8 +175,8 @@ export function checksReducer(state: ChecksState, action: ChecksAction): ChecksS
         );
         if (!accepted) return { ...c, pendingTagForYou: false, coAuthors };
         const responses = [
-          { name: "You", avatar: avatarLetter ?? "?", status: "down" as const },
-          ...c.responses.filter((r) => r.name !== "You"),
+          { name: "You", avatar: avatarLetter ?? "?", status: "down" as const, odbc: userId },
+          ...c.responses.filter((r) => r.name !== "You" && r.odbc !== userId),
         ];
         return { ...c, isCoAuthor: true, pendingTagForYou: false, coAuthors, responses };
       });


### PR DESCRIPTION
## Summary
After clicking "Down" on a check, the viewer's row showed up twice — once as "You" and once under their real display_name.

Root cause in `checksReducer.ts`:
- `SET_RESPONSE` inserts `{name: "You", …}` optimistically.
- On the next server sync, `transformCheck` returns the viewer's row under their real `display_name` (with `odbc === userId`), not `"You"`.
- `patchYouResponses` dedups only by `name === "You"`, doesn't find one, and re-adds the "You" entry on top of the real row.

## Fix
- Thread `userId` through `SYNC_CHECKS`, `SET_RESPONSE`, and `CLEAR_RESPONSE` actions.
- `patchYouResponses` now skips if any response already has `odbc === userId`.
- Optimistic `"You"` entries carry `odbc: userId`, so the next sync collapses them into the real server row cleanly.
- `CLEAR_RESPONSE` filters by both `name === "You"` and `odbc === userId` so un-down works whether the response is the optimistic entry or the persisted one.
- Same treatment for the `SET_CO_AUTHOR` branch that injects a "You" down response on accept.

## Test plan
- [ ] Click "Down" on a check. Confirm your row shows once ("You is down") immediately.
- [ ] Wait for the server sync (or trigger any reload). Confirm your row still shows once — not twice.
- [ ] Un-down. Confirm the row is removed in both the optimistic window and after the sync.
- [ ] Accept a co-author tag. Confirm you appear once in the down list, not twice after sync.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_