### PR TITLE
test: assert dateless idea-only check stays visible to its author

### DIFF
--- a/supabase/tests/check_visibility.sql
+++ b/supabase/tests/check_visibility.sql
@@ -6,7 +6,7 @@
 -- immediately notice. Everything else (FoF, expiry, archive) is downstream.
 
 BEGIN;
-SELECT plan(11);
+SELECT plan(14);
 
 -- =============================================================================
 -- Fixture setup: 4 profiles, friend graph, and 4 checks in different states.
@@ -63,6 +63,25 @@ INSERT INTO public.interest_checks (id, author_id, text, expires_at, event_tz) V
    now() - interval '1 hour',
    'America/New_York');
 
+-- A dateless idea-only check (no event_date, no expires_at). This is the
+-- shape emitted when a user types just the idea and hits Send — the minimum
+-- viable interest check per specs/interest-check-flow.md.
+INSERT INTO public.interest_checks (id, author_id, text, expires_at, event_date, event_tz) VALUES
+  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+   '11111111-1111-1111-1111-111111111111',
+   'dateless idea-only',
+   NULL, NULL, 'America/New_York');
+
+-- A dateless check with a 24h expiry (the default when user picks no date
+-- but leaves the timer at 24h).
+INSERT INTO public.interest_checks (id, author_id, text, expires_at, event_date, event_tz) VALUES
+  ('ffffffff-ffff-ffff-ffff-ffffffffffff',
+   '11111111-1111-1111-1111-111111111111',
+   'dateless 24h',
+   now() + interval '24 hours',
+   NULL,
+   'America/New_York');
+
 
 -- =============================================================================
 -- THE CORE INVARIANT: author sees their own freshly-posted check.
@@ -74,6 +93,18 @@ SET LOCAL "request.jwt.claims" TO '{"sub":"11111111-1111-1111-1111-111111111111"
 SELECT ok(
   EXISTS (SELECT 1 FROM public.interest_checks WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
   'CORE: author sees their own freshly-posted check (event_date = today in author tz)'
+);
+
+-- CORE invariant #2 + #3: the minimum-viable interest check is just an idea —
+-- no date, no place. Both dateless flavors (no expiry, 24h expiry) must be
+-- visible to the author immediately after posting.
+SELECT ok(
+  EXISTS (SELECT 1 FROM public.interest_checks WHERE id = 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee'),
+  'CORE: author sees their own dateless idea-only check (no event_date, no expires_at)'
+);
+SELECT ok(
+  EXISTS (SELECT 1 FROM public.interest_checks WHERE id = 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+  'CORE: author sees their own dateless 24h-expiry check'
 );
 
 


### PR DESCRIPTION
## Summary
Adds two CORE invariant assertions to the pgTAP contract test so the minimum-viable interest check (idea only — no date, no place) can't regress:

- `CORE: author sees their own dateless idea-only check (no event_date, no expires_at)` — the "downto catch the new Mubi release?" shape
- `CORE: author sees their own dateless 24h-expiry check` — default timer, no date

Also corrects `plan()` count: the original file declared `plan(11)` but had 12 `SELECT ok` assertions; new count is `plan(14)`.

## Why
- PR #393 unblocked submitting a dateless check (UI).
- PR #397 added `check_is_active()` which structurally keeps dateless checks visible (SQL).
- Neither had an explicit pgTAP assertion for the dateless case, so a future change to `check_is_active` could silently break "user posts idea, sees idea" without CI catching it.

## Test plan
- [ ] `supabase db reset && supabase test db` locally — confirm all 14 assertions pass, including the two new `CORE: ... dateless ...` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)