### PR TITLE
fix: restore client-side temporal filter + drop date gate on onboarding check

### DIFF
--- a/src/features/checks/components/FirstCheckScreen.tsx
+++ b/src/features/checks/components/FirstCheckScreen.tsx
@@ -64,7 +64,7 @@ const FirstCheckScreen = ({
           onChange={(e) => setWhenInput(e.target.value)}
           className={cn(
             "flex-1 min-w-0 py-2.5 px-3 bg-deep rounded-lg font-mono text-xs text-primary outline-none box-border border",
-            idea.trim() && !parsedDate ? "border-danger/25" : "border-border-mid"
+            whenInput.trim() && !parsedDate ? "border-danger/25" : "border-border-mid"
           )}
         />
         <input
@@ -81,12 +81,12 @@ const FirstCheckScreen = ({
           {whenPreview}
         </div>
       )}
-      {!whenPreview && idea.trim() && !parsedDate && (
+      {!whenPreview && whenInput.trim() && !parsedDate && (
         <div className="font-mono text-tiny text-danger mb-2" style={{ paddingLeft: 2 }}>
-          add a date (e.g. &quot;fri&quot;, &quot;3/14&quot;, &quot;next sat&quot;)
+          couldn&apos;t read that — try &quot;fri&quot;, &quot;3/14&quot;, &quot;next sat&quot;
         </div>
       )}
-      {!whenPreview && (!idea.trim() || parsedDate) && <div className="mb-2" />}
+      {!whenPreview && !whenInput.trim() && <div className="mb-2" />}
 
       {/* Timer picker */}
       <div className="mb-4">
@@ -161,10 +161,10 @@ const FirstCheckScreen = ({
             onComplete(title, checkTimer, eventDate, squadSize === 0 ? null : squadSize, eventTime, true, true, location);
           }
         }}
-        disabled={!idea.trim() || !parsedDate}
+        disabled={!idea.trim()}
         className={cn(
           "w-full p-4 border-none rounded-xl font-mono text-sm font-bold mb-4",
-          idea.trim() && parsedDate
+          idea.trim()
             ? "bg-dt text-bg cursor-pointer"
             : "bg-border-mid text-dim cursor-default"
         )}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -717,9 +717,14 @@ export async function getFofAnnotations(): Promise<{ check_id: string; via_frien
 }
 
 export async function getActiveChecks(): Promise<(InterestCheck & { author: Profile; responses: (CheckResponse & { user: Profile })[]; squads: { id: string; archived_at: string | null; members: { id: string }[] }[]; co_authors: (CheckCoAuthor & { user: Profile })[] })[]> {
-  // Activeness (archived_at, expires_at, event_date) and visibility (friend/FoF/
-  // co-author) are both enforced by RLS via public.check_is_active + the SELECT
-  // policy. See migration 20260424000001.
+  // NOTE: this client-side temporal filter is intended to be removed once
+  // migration 20260424000001 lands in prod (it moves this logic into
+  // check_is_active() + the RLS SELECT policy). Until then the client must
+  // filter — otherwise expired/archived checks leak into the feed. Keeping
+  // it after the migration is redundant but harmless.
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const todayLocal = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
   const { data, error } = await supabase
     .from('interest_checks')
     .select(`
@@ -729,6 +734,9 @@ export async function getActiveChecks(): Promise<(InterestCheck & { author: Prof
       squads(id, archived_at, members:squad_members(id, user_id, role)),
       co_authors:check_co_authors(*, user:profiles!user_id(*))
     `)
+    .or(`expires_at.gt.${nowIso},expires_at.is.null,event_date.gte.${todayLocal}`)
+    .or(`event_date.gte.${todayLocal},event_date.is.null`)
+    .is('archived_at', null)
     .order('created_at', { ascending: false });
 
   if (error) throw error;


### PR DESCRIPTION
## Summary
Two bugs, one PR:

1. **Feed was showing expired / past-event / archived checks.** PR #397 moved the temporal filter into RLS (`check_is_active`), but its merge commit landed on main **before** PR #395 (the migration-pushing workflow). The path-filtered `push` trigger can't fire on a commit that predates the workflow file, so the migration never auto-applied. The client portion of #397 did ship — and once the client stopped filtering, every non-deleted RLS-visible row leaked into the feed. The migration has since been applied manually (secret needed fixing too), but this PR restores the client `.or()` filter as belt-and-suspenders: redundant now but guards against the same "client ships before migration" skew if it happens again.

2. **`FirstCheckScreen` (onboarding) still required a date.** PR #393 fixed the same gate in `CreateModal` but missed the onboarding screen — `disabled={!idea.trim() || !parsedDate}` still blocked idea-only checks. Now matches CreateModal: only requires idea, only flags the when input red if the user typed something unparseable, warning copy softened to "couldn't read that" instead of "add a date".

## Test plan
- [ ] Hit `/` without having posted anything → onboarding first-check screen → type just an idea → Send is enabled and posts
- [ ] Same screen: type "asdf" in the when input → red border + "couldn't read that" warning, Send still enabled
- [ ] Feed: confirm Steven's two expired McCarren checks no longer appear (both sides — RLS on server + client .or() as defense)

## Followup (not in this PR)
- Once the migration CI is verified end-to-end (single test migration merges and auto-deploys), remove the client-side `.or()` filter from `getActiveChecks` — RLS is the source of truth going forward.
- Investigate why PR #395's workflow merged in-between #397's merge and made the trigger miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)