### PR TITLE
chore: smoke test DB Migrations CI pipeline with a no-op migration

### DIFF
--- a/supabase/migrations/20260424000002_ci_smoke_test.sql
+++ b/supabase/migrations/20260424000002_ci_smoke_test.sql
@@ -1,0 +1,8 @@
+-- CI smoke test: confirm the DB Migrations GitHub Actions workflow
+-- auto-applies migrations on merge to main.
+--
+-- No schema impact — a pure no-op. If this lands in prod via the workflow
+-- without manual intervention, the pipeline works end-to-end. The earlier
+-- consolidation migration (20260424000001) had to be applied via
+-- workflow_dispatch because it merged before the workflow file existed.
+SELECT 1;


### PR DESCRIPTION
## Summary
A pure `SELECT 1;` migration to verify that the DB Migrations workflow auto-applies migrations on merge to main. No schema impact.

The previous migration (`20260424000001_check_visibility_consolidation`) had to be applied via `workflow_dispatch` because it merged before the workflow file existed — GitHub's path-filter push trigger can't fire on a commit that predates the workflow itself. This PR confirms the pipeline works from here on.

## Test plan
- [ ] Merge this PR
- [ ] Confirm `DB Migrations` workflow runs automatically (triggered by push, not workflow_dispatch)
- [ ] Workflow succeeds
- [ ] `supabase_migrations.schema_migrations` table in prod records `20260424000002`

🤖 Generated with [Claude Code](https://claude.com/claude-code)