### PR TITLE
feat: block + report UI (App Store 1.2 compliance)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1116,6 +1116,7 @@ export default function Home() {
           onFriendAction={() => {
             if (userId) loadRealData();
           }}
+          showToast={showToast}
         />
       )}
     </div>

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -9,6 +9,7 @@ import { useCheckComments } from "@/features/checks/hooks/useCheckComments";
 import InlineCommentsBox from "@/shared/components/InlineCommentsBox";
 import CheckDetailSheet from "./CheckDetailSheet";
 import EditCheckModal from "./EditCheckModal";
+import ReportSheet from "@/shared/components/ReportSheet";
 import { useFeedContext } from "@/features/checks/context/FeedContext";
 
 function Linkify({ children, dimmed, coAuthors, onViewProfile }: { children: string; dimmed?: boolean; coAuthors?: { name: string; userId?: string }[]; onViewProfile?: (userId: string) => void }) {
@@ -108,6 +109,7 @@ export default function CheckCard({
   useEffect(() => { openComments(); }, [check.id]);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
+  const [showReport, setShowReport] = useState(false);
 
   const { comments, commentCount, openComments, postComment } = useCheckComments({
     checkId: check.id,
@@ -248,11 +250,19 @@ export default function CheckCard({
                   </span>
                 )}
                 {!check.isYours && !check.isCoAuthor && (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); hideCheck(check.id); }}
-                    className="bg-transparent border-none text-dim py-0.5 px-1 font-mono text-xs cursor-pointer leading-none"
-                    title="Hide this check"
-                  >✕</button>
+                  <>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); setShowReport(true); }}
+                      className="bg-transparent border-none text-dim py-0.5 px-1 font-mono text-xs cursor-pointer leading-none"
+                      title="Report this check"
+                      aria-label="Report this check"
+                    >⚐</button>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); hideCheck(check.id); }}
+                      className="bg-transparent border-none text-dim py-0.5 px-1 font-mono text-xs cursor-pointer leading-none"
+                      title="Hide this check"
+                    >✕</button>
+                  </>
                 )}
               </div>
             </div>
@@ -426,6 +436,16 @@ export default function CheckCard({
           await loadRealData();
         }}
       />
+
+      {showReport && (
+        <ReportSheet
+          targetType="check"
+          targetId={check.id}
+          targetLabel="check"
+          onClose={() => setShowReport(false)}
+          onSubmitted={() => showToast("Report submitted — thanks")}
+        />
+      )}
     </>
   );
 }

--- a/src/features/friends/components/UserProfileOverlay.tsx
+++ b/src/features/friends/components/UserProfileOverlay.tsx
@@ -6,22 +6,27 @@ import type { Profile } from "@/lib/types";
 import * as db from "@/lib/db";
 import { logError } from "@/lib/logger";
 import cn from "@/lib/tailwindMerge";
+import ReportSheet from "@/shared/components/ReportSheet";
 
 const UserProfileOverlay = ({
   targetUserId,
   currentUserId,
   onClose,
   onFriendAction,
+  showToast,
 }: {
   targetUserId: string;
   currentUserId: string | null;
   onClose: () => void;
   onFriendAction: () => void;
+  showToast?: (msg: string) => void;
 }) => {
   const [profileData, setProfileData] = useState<Profile | null>(null);
   const [friendship, setFriendship] = useState<{ id: string; status: string; isRequester: boolean } | null>(null);
   const [loading, setLoading] = useState(true);
   const [acting, setActing] = useState(false);
+  const [blocked, setBlocked] = useState(false);
+  const [showReport, setShowReport] = useState(false);
 
   // Lock body scroll when open
   useEffect(() => {
@@ -34,13 +39,15 @@ const UserProfileOverlay = ({
     (async () => {
       setLoading(true);
       try {
-        const [p, f] = await Promise.all([
+        const [p, f, b] = await Promise.all([
           db.getProfileById(targetUserId),
           currentUserId ? db.getFriendshipWith(targetUserId) : Promise.resolve(null),
+          currentUserId && currentUserId !== targetUserId ? db.isBlocked(targetUserId) : Promise.resolve(false),
         ]);
         if (!cancelled) {
           setProfileData(p);
           setFriendship(f);
+          setBlocked(b);
         }
       } catch (err) {
         logError("loadProfile", err, { targetUserId });
@@ -76,6 +83,38 @@ const UserProfileOverlay = ({
       onFriendAction();
     } catch (err) {
       logError("friendAction", err, { targetUserId, friendStatus });
+    } finally {
+      setActing(false);
+    }
+  };
+
+  const handleToggleBlock = async () => {
+    if (!currentUserId || isSelf || acting) return;
+    const display = profileData?.display_name ?? "user";
+    setActing(true);
+    try {
+      if (blocked) {
+        await db.unblockUser(targetUserId);
+        setBlocked(false);
+        showToast?.(`Unblocked ${display}`);
+      } else {
+        const confirmed = typeof window !== "undefined"
+          ? window.confirm(`Block ${display}? You won't see their checks or messages, and they won't see yours.`)
+          : true;
+        if (!confirmed) { setActing(false); return; }
+        await db.blockUser(targetUserId);
+        setBlocked(true);
+        // Break any existing friendship so it doesn't linger
+        if (friendship && friendStatus !== "none") {
+          try { await db.removeFriend(friendship.id); } catch (err) { logError("removeFriendOnBlock", err); }
+          setFriendship(null);
+        }
+        showToast?.(`Blocked ${display}`);
+        onFriendAction();
+      }
+    } catch (err) {
+      logError("toggleBlock", err, { targetUserId, blocked });
+      showToast?.("Something went wrong");
     } finally {
       setActing(false);
     }
@@ -167,7 +206,7 @@ const UserProfileOverlay = ({
             </div>
 
             {/* Action button */}
-            {!isSelf && currentUserId && (
+            {!isSelf && currentUserId && !blocked && (
               <button
                 onClick={handleAction}
                 disabled={actionDisabled}
@@ -189,9 +228,42 @@ const UserProfileOverlay = ({
                 {acting ? "..." : actionLabel}
               </button>
             )}
+
+            {/* Block / Report row */}
+            {!isSelf && currentUserId && (
+              <div className="flex items-center justify-center gap-3 mt-4 font-mono text-tiny text-faint">
+                <button
+                  onClick={handleToggleBlock}
+                  disabled={acting}
+                  className="bg-transparent border-none text-faint cursor-pointer underline-offset-2 hover:underline disabled:opacity-60"
+                >
+                  {blocked ? "Unblock" : "Block"}
+                </button>
+                {!blocked && (
+                  <>
+                    <span className="text-faint">·</span>
+                    <button
+                      onClick={() => setShowReport(true)}
+                      className="bg-transparent border-none text-faint cursor-pointer underline-offset-2 hover:underline"
+                    >
+                      Report user
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
           </>
         )}
       </div>
+      {showReport && profileData && (
+        <ReportSheet
+          targetType="profile"
+          targetId={targetUserId}
+          targetLabel={`@${profileData.username}`}
+          onClose={() => setShowReport(false)}
+          onSubmitted={() => showToast?.("Report submitted — thanks")}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/profile/components/ProfileView.tsx
+++ b/src/features/profile/components/ProfileView.tsx
@@ -72,6 +72,24 @@ const ProfileView = ({
   const [igInput, setIgInput] = useState("");
   const [showArchived, setShowArchived] = useState(false);
   const [activeTheme, setActiveTheme] = useState<ThemeName | null>(null);
+  const [blockedUsers, setBlockedUsers] = useState<(Profile & { blocked_at: string })[]>([]);
+  const [showBlocked, setShowBlocked] = useState(false);
+
+  useEffect(() => {
+    db.listBlockedUsers()
+      .then(setBlockedUsers)
+      .catch(() => { /* silent — empty list is fine */ });
+  }, []);
+
+  const handleUnblock = async (userId: string, displayName: string) => {
+    try {
+      await db.unblockUser(userId);
+      setBlockedUsers((prev) => prev.filter((u) => u.id !== userId));
+      showToast?.(`Unblocked ${displayName}`);
+    } catch {
+      showToast?.("Couldn't unblock — try again");
+    }
+  };
 
   useEffect(() => {
     const stored = localStorage.getItem(THEME_STORAGE_KEY) as ThemeName | null;
@@ -435,6 +453,50 @@ const ProfileView = ({
                   className="bg-transparent border border-border-mid rounded-xl py-1.5 px-3 font-mono text-xs text-primary cursor-pointer shrink-0"
                 >
                   Restore
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )}
+
+    {blockedUsers.length > 0 && (
+      <div className="mt-8">
+        <button
+          onClick={() => setShowBlocked((v) => !v)}
+          className="w-full bg-transparent border-none p-0 flex items-center justify-between cursor-pointer mb-3"
+        >
+          <span
+            className="font-mono text-tiny uppercase text-faint"
+            style={{ letterSpacing: "0.15em" }}
+          >
+            Blocked ({blockedUsers.length})
+          </span>
+          <span className="font-mono text-tiny text-faint">{showBlocked ? "hide" : "show"}</span>
+        </button>
+        {showBlocked && (
+          <div className="flex flex-col gap-2">
+            {blockedUsers.map((u) => (
+              <div
+                key={u.id}
+                className="flex items-center justify-between py-2 px-3 rounded-xl bg-card border border-border"
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <div className="w-7 h-7 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-xs font-bold">
+                    {u.avatar_letter}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="font-mono text-xs text-primary truncate">{u.display_name}</div>
+                    <div className="font-mono text-tiny text-dim truncate">@{u.username}</div>
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleUnblock(u.id, u.display_name)}
+                  className="bg-transparent border border-border-mid rounded-lg py-1.5 px-3 font-mono text-tiny uppercase text-primary cursor-pointer"
+                  style={{ letterSpacing: "0.08em" }}
+                >
+                  Unblock
                 </button>
               </div>
             ))}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1942,3 +1942,88 @@ export async function getMyPendingJoinRequests(eventId: string): Promise<{ squad
     .filter((r) => r.squads?.event_id === eventId)
     .map((r) => ({ squad_id: r.squad_id }));
 }
+
+
+// =============================================================================
+// Block + report (App Store 1.2)
+// Schema: migration 20260424000003_block_and_report.sql
+// =============================================================================
+
+export type ReportTargetType = 'profile' | 'check' | 'squad_message' | 'event_comment' | 'check_comment';
+export type ReportReason = 'harassment' | 'spam' | 'impersonation' | 'inappropriate' | 'threats' | 'other';
+
+export async function blockUser(targetUserId: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+  if (user.id === targetUserId) throw new Error("Can't block yourself");
+
+  const { error } = await supabase
+    .from('blocked_users')
+    .insert({ blocker_id: user.id, blocked_id: targetUserId });
+  // Unique constraint conflict = already blocked; treat as success
+  if (error && error.code !== '23505') throw error;
+}
+
+export async function unblockUser(targetUserId: string): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { error } = await supabase
+    .from('blocked_users')
+    .delete()
+    .eq('blocker_id', user.id)
+    .eq('blocked_id', targetUserId);
+  if (error) throw error;
+}
+
+export async function isBlocked(targetUserId: string): Promise<boolean> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return false;
+
+  // Only checks the direction the viewer controls (their outgoing blocks).
+  // RLS prevents reading blocks where they're the blocked party, which is
+  // intentional — see migration comment.
+  const { data, error } = await supabase
+    .from('blocked_users')
+    .select('blocker_id')
+    .eq('blocker_id', user.id)
+    .eq('blocked_id', targetUserId)
+    .maybeSingle();
+  if (error) throw error;
+  return !!data;
+}
+
+export async function listBlockedUsers(): Promise<(Profile & { blocked_at: string })[]> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from('blocked_users')
+    .select('created_at, blocked:profiles!blocked_id(*)')
+    .eq('blocker_id', user.id)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return ((data ?? []) as unknown as { created_at: string; blocked: Profile }[])
+    .map((r) => ({ ...r.blocked, blocked_at: r.created_at }));
+}
+
+export async function reportContent(
+  targetType: ReportTargetType,
+  targetId: string,
+  reason: ReportReason,
+  details: string | null = null,
+): Promise<void> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const { error } = await supabase
+    .from('reported_content')
+    .insert({
+      reporter_id: user.id,
+      target_type: targetType,
+      target_id: targetId,
+      reason,
+      details,
+    });
+  if (error) throw error;
+}

--- a/src/shared/components/ReportSheet.tsx
+++ b/src/shared/components/ReportSheet.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import * as db from "@/lib/db";
+import type { ReportReason, ReportTargetType } from "@/lib/db";
+import { logError } from "@/lib/logger";
+import cn from "@/lib/tailwindMerge";
+
+const REASONS: { value: ReportReason; label: string }[] = [
+  { value: "harassment",    label: "Harassment or bullying" },
+  { value: "spam",          label: "Spam" },
+  { value: "impersonation", label: "Impersonation" },
+  { value: "inappropriate", label: "Inappropriate content" },
+  { value: "threats",       label: "Threats or violence" },
+  { value: "other",         label: "Something else" },
+];
+
+interface ReportSheetProps {
+  targetType: ReportTargetType;
+  targetId: string;
+  targetLabel?: string;
+  onClose: () => void;
+  onSubmitted?: () => void;
+}
+
+const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }: ReportSheetProps) => {
+  const [reason, setReason] = useState<ReportReason | null>(null);
+  const [details, setDetails] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, []);
+
+  const submit = async () => {
+    if (!reason || submitting) return;
+    setSubmitting(true);
+    try {
+      await db.reportContent(targetType, targetId, reason, details.trim() || null);
+      onSubmitted?.();
+      onClose();
+    } catch (err) {
+      logError("reportContent", err, { targetType, targetId });
+      setSubmitting(false);
+    }
+  };
+
+  const title = targetLabel ? `Report ${targetLabel}` : "Report";
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-end justify-center">
+      <div
+        onClick={onClose}
+        className="absolute inset-0"
+        style={{ background: "rgba(0,0,0,0.7)", backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)" }}
+      />
+      <div
+        className="relative bg-surface w-full max-w-[420px] px-6 pt-4 pb-8 flex flex-col animate-slide-up"
+        style={{ borderRadius: "24px 24px 0 0", maxHeight: "80vh" }}
+      >
+        <div className="w-10 h-1 rounded-sm mx-auto mb-4" style={{ background: "#444" }} />
+        <h2 className="font-serif text-[22px] text-primary mb-4">{title}</h2>
+
+        <div className="font-mono text-tiny uppercase text-dim mb-2" style={{ letterSpacing: "0.15em" }}>
+          Reason
+        </div>
+        <div className="flex flex-col gap-1.5 mb-4">
+          {REASONS.map((r) => (
+            <button
+              key={r.value}
+              onClick={() => setReason(r.value)}
+              className={cn(
+                "text-left rounded-lg py-2.5 px-3 font-mono text-xs border cursor-pointer transition-colors",
+                reason === r.value
+                  ? "bg-dt text-on-accent border-dt font-bold"
+                  : "bg-card text-primary border-border-mid"
+              )}
+            >
+              {r.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="font-mono text-tiny uppercase text-dim mb-2" style={{ letterSpacing: "0.15em" }}>
+          Details <span className="lowercase text-faint normal-case">(optional)</span>
+        </div>
+        <textarea
+          value={details}
+          onChange={(e) => setDetails(e.target.value.slice(0, 500))}
+          maxLength={500}
+          placeholder="Anything else we should know?"
+          className="w-full bg-card border border-border-mid rounded-xl py-2.5 px-3 text-primary font-mono text-xs outline-none resize-none mb-5 box-border"
+          style={{ height: 72 }}
+        />
+
+        <div className="flex gap-2.5">
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="flex-1 bg-transparent border border-border-mid rounded-xl py-3 font-mono text-xs font-bold uppercase text-primary cursor-pointer"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submit}
+            disabled={!reason || submitting}
+            className={cn(
+              "flex-1 border-none rounded-xl py-3 font-mono text-xs font-bold uppercase",
+              reason && !submitting
+                ? "bg-dt text-on-accent cursor-pointer"
+                : "bg-border-mid text-dim cursor-not-allowed"
+            )}
+            style={{ letterSpacing: "0.08em" }}
+          >
+            {submitting ? "Sending..." : "Submit report"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReportSheet;


### PR DESCRIPTION
## Summary
Wires the SQL from #401 into the app. Minimum viable surface to clear App Review for a social app — deeper coverage can follow if Apple asks for it.

## What's in

**`db.ts` wrappers**
- `blockUser` / `unblockUser` / `isBlocked` / `listBlockedUsers`
- `reportContent(targetType, targetId, reason, details)`

**`ReportSheet` (new shared component)**
- Bottom-sheet modal, reason picker (harassment / spam / impersonation / inappropriate / threats / other) + optional details textarea. Reused anywhere we need to report something.

**`UserProfileOverlay`**
- "Block" / "Unblock" link under the friend action button
- "Report user" opens the ReportSheet
- When blocked, hides the friend action button and breaks any existing friendship so it doesn't linger
- `showToast` threaded through from `page.tsx`

**`CheckCard`**
- Small ⚐ flag button next to the existing ✕ hide button for non-owned checks. Opens ReportSheet.

**`ProfileView`**
- New "Blocked (N)" collapsible section above Settings. Only renders when you've blocked someone — zero visual weight otherwise.

## Explicitly NOT in v1
- **Per-squad-message reporting** — routes through the sender's profile overlay (tap avatar → Block/Report). Apple 1.2 requires a block+report *path*, not per-surface UX.
- **Filtering blocked users out of friend lists / FoF / search** — RLS already hides their content; names lingering in lists is cosmetic.
- **Event comment + check comment reporting** — tables already support it via `target_type`, just no UI yet.

## Test plan
- [ ] View another user's profile → "Block" appears → confirm dialog → user blocked → toast shown
- [ ] Blocked state: friend action button hidden, only "Unblock" + "Report user" visible
- [ ] "Report user" → sheet opens → pick reason → submit → toast "Report submitted"
- [ ] Your own profile → scroll to "Blocked (N)" section → expand → unblock → user removed from list
- [ ] On a check you didn't author, tap ⚐ → ReportSheet opens → submit works
- [ ] After blocking someone, their checks + responses disappear from feed (RLS, verified in #401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)