### PR TITLE
fix: make URLs clickable in inline comments

### DIFF
--- a/src/shared/components/InlineCommentsBox.tsx
+++ b/src/shared/components/InlineCommentsBox.tsx
@@ -70,11 +70,32 @@ export default function InlineCommentsBox({
                 {c.userName}
               </span>
               <span className="font-mono text-tiny text-primary min-w-0 break-words leading-snug">
-                {c.text.split(/(@\S+)/g).map((part, pi) =>
-                  part.startsWith("@") ? (
-                    <span key={pi} className="text-dt font-bold">{part}</span>
-                  ) : part
-                )}
+                {c.text.split(/(https?:\/\/[^\s),]+|@\S+)/g).map((part, pi) => {
+                  if (/^https?:\/\//.test(part)) {
+                    const display = (() => {
+                      try {
+                        const u = new URL(part);
+                        let d = u.host.replace(/^www\./, "") + u.pathname.replace(/\/$/, "");
+                        if (d.length > 40) d = d.slice(0, 37) + "…";
+                        return d;
+                      } catch { return part; }
+                    })();
+                    return (
+                      <a
+                        key={pi}
+                        href={part}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="text-dt underline underline-offset-2 break-all"
+                      >{display}</a>
+                    );
+                  }
+                  if (part.startsWith("@")) {
+                    return <span key={pi} className="text-dt font-bold">{part}</span>;
+                  }
+                  return part;
+                })}
               </span>
             </div>
           ))}


### PR DESCRIPTION
## Summary
Comment text in `InlineCommentsBox` only split on `@mentions`, so http(s) URLs rendered as plain strings — no anchor, no click target. And even if they had been, the outer card's `onClick` toggle would have swallowed the click.

Matches the `Linkify` pattern already in `CheckCard.tsx`: split on `(URL | @mention)` in one regex, wrap URLs in `<a target="_blank" rel="noopener noreferrer">` with display-shortened text, and `stopPropagation` on the link click so it doesn't toggle the comment input.

## Test plan
- [ ] Post a comment containing `https://example.com/some/path` — URL renders as an underlined link
- [ ] Tapping the link opens it in a new tab and does NOT toggle the comment input
- [ ] Long URLs get ellipsis-truncated past 40 chars of `host + path`
- [ ] Mentions like `@kat` still render bold and yellow
- [ ] Plain text with no URL or mention still renders fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)