### PR TITLE
feat: notify down-ees + commenters when a check's title is edited

### DIFF
--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -246,7 +246,7 @@ const NotificationsPanel = ({
                     }
                     onClose();
                     onNavigate({ type: "feed", checkId: n.related_check_id ?? undefined });
-                  } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated") {
+                  } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated" || n.type === "check_text_updated") {
                     // Mark single notification as read (except check_tag — cleared on accept/decline)
                     if (!n.is_read && n.type !== "check_tag") {
                       if (userId) db.markNotificationRead(n.id);
@@ -278,6 +278,7 @@ const NotificationsPanel = ({
                       : n.type === "event_down" ? "#E8FF5A22"
                       : n.type === "friend_event" ? "#E8FF5A22"
                       : n.type === "check_date_updated" ? "#E8FF5A22"
+                      : n.type === "check_text_updated" ? "#E8FF5A22"
                       : n.type === "event_date_updated" ? "#E8FF5A22"
                       : n.type === "event_comment" ? "#5AC8FA22"
                       : "#5856D622",
@@ -317,6 +318,9 @@ const NotificationsPanel = ({
                       case "event_date_updated":
                         // Clock / calendar
                         return <svg {...iconProps}><path d="M208,32H184V24a8,8,0,0,0-16,0v8H88V24a8,8,0,0,0-16,0v8H48A16,16,0,0,0,32,48V208a16,16,0,0,0,16,16H208a16,16,0,0,0,16-16V48A16,16,0,0,0,208,32Zm0,176H48V96H208V208ZM48,80V48H72v8a8,8,0,0,0,16,0V48h80v8a8,8,0,0,0,16,0V48h24V80Zm84,56v32l27.58,15.76a8,8,0,0,1-7.94,13.87l-32-18.29a8,8,0,0,1-4-6.95V136a8,8,0,0,1,16,0Z"/></svg>;
+                      case "check_text_updated":
+                        // Pencil
+                        return <svg {...iconProps}><path d="M227.31,73.37,182.63,28.68a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H92.69A15.86,15.86,0,0,0,104,219.31L227.31,96a16,16,0,0,0,0-22.63ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.68,147.31,64l24-24L216,84.68Z"/></svg>;
                       default:
                         // ChatTeardrop
                         return <svg {...iconProps}><path d="M132,24A100.11,100.11,0,0,0,32,124v84a16,16,0,0,0,16,16h84a100,100,0,0,0,0-200Zm0,184H48V124a84,84,0,1,1,84,84Z"/></svg>;

--- a/supabase/migrations/20260424000004_notify_on_check_text_update.sql
+++ b/supabase/migrations/20260424000004_notify_on_check_text_update.sql
@@ -1,0 +1,70 @@
+-- Notify interested users when an interest check's title/text is edited.
+-- Recipients: union of "down" responders + people who commented on the check,
+-- minus the author, deduped.
+
+
+-- 1. Extend the notifications.type constraint with 'check_text_updated'.
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN (
+    'friend_request', 'friend_accepted', 'check_response',
+    'squad_message', 'squad_invite', 'friend_check', 'date_confirm',
+    'check_tag', 'check_comment', 'poll_created', 'squad_join_request',
+    'squad_mention', 'comment_mention', 'friend_event', 'event_reminder',
+    'event_down', 'check_date_updated', 'event_date_updated',
+    'check_text_updated'
+  ));
+
+
+-- 2. Trigger function — fires when text actually changes, notifies the
+-- union (down responders ∪ commenters) minus the author, deduped.
+CREATE OR REPLACE FUNCTION public.notify_check_text_updated()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_author_name TEXT;
+  v_body TEXT;
+  v_recipient UUID;
+BEGIN
+  IF NEW.text IS NOT DISTINCT FROM OLD.text THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT display_name INTO v_author_name
+  FROM public.profiles WHERE id = NEW.author_id;
+  v_author_name := COALESCE(v_author_name, 'Someone');
+
+  v_body := LEFT(COALESCE(NEW.text, 'an interest check'), 120);
+
+  FOR v_recipient IN
+    SELECT uid FROM (
+      SELECT cr.user_id AS uid
+        FROM public.check_responses cr
+        WHERE cr.check_id = NEW.id
+          AND cr.response = 'down'
+      UNION
+      SELECT cc.user_id AS uid
+        FROM public.check_comments cc
+        WHERE cc.check_id = NEW.id
+    ) recipients
+    WHERE uid <> NEW.author_id
+  LOOP
+    INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_check_id)
+    VALUES (
+      v_recipient,
+      'check_text_updated',
+      v_author_name || ' updated the check',
+      v_body,
+      NEW.author_id,
+      NEW.id
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+DROP TRIGGER IF EXISTS on_check_text_updated ON public.interest_checks;
+CREATE TRIGGER on_check_text_updated
+  AFTER UPDATE ON public.interest_checks
+  FOR EACH ROW EXECUTE FUNCTION public.notify_check_text_updated();


### PR DESCRIPTION
## Summary
Mirrors the `notify_check_date_updated` pattern from #389 but fires on `interest_checks.text` changes instead of date/time.

**Recipients** (union, deduped, excluding author):
- Everyone who responded **down** on the check
- Everyone who **commented** on the check

**Notification shape**: `"<author> updated the check"` + body = first 120 chars of the new text.

## Changes
- `supabase/migrations/20260424000004_notify_on_check_text_update.sql`:
  - Adds `'check_text_updated'` to the `notifications.type` CHECK constraint
  - `notify_check_text_updated()` trigger with `IS DISTINCT FROM` guard on `text`, plus `UNION` of down responders and commenters
  - Wires the trigger to `AFTER UPDATE` on `interest_checks`
- `src/features/notifications/components/NotificationsPanel.tsx`: three one-line extensions — click handler routes to feed with the check, yellow pill color, pencil icon (distinct from the calendar used for date updates).

## Test plan
- [ ] User A posts a check. User B responds "down". User C comments. Neither is the author.
- [ ] A edits the check's text → B and C each receive a single `check_text_updated` notification
- [ ] A also edits the date in a separate save → each also receives a `check_date_updated` (both triggers fire with their own guards)
- [ ] Edit the text twice back-to-back → two notifications (expected; we don't debounce)
- [ ] Author does NOT receive a notification for their own edit
- [ ] Clicking the notification opens the feed with the check in view

## Note
Both `notify_check_date_updated` and `notify_check_text_updated` fire on `AFTER UPDATE` of `interest_checks`. Each has its own `IS NOT DISTINCT FROM` early return, so editing only text won't fire the date trigger and vice versa — no cross-firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)