### PR TITLE
fix: make 'where' input styling match 'when' in CreateModal

### DIFF
--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -758,7 +758,8 @@ const AddModal = ({
                   placeholder="location"
                   value={whereInput}
                   onChange={(e) => setWhereInput(e.target.value)}
-                  className="w-full py-2.5 px-3 bg-deep border border-border-mid rounded-lg font-mono text-xs text-primary outline-none box-border"
+                  className="w-full py-2.5 px-3 bg-deep rounded-lg font-mono text-xs text-primary outline-none box-border"
+                  style={{ border: '1px solid #333' }}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
The 'when' input used an inline `border: 1px solid #333` while 'where' used Tailwind `border border-border-mid` (also #333). Both should render the same, but different CSS paths can produce subtly different visual weight depending on Tailwind compile order / theme hydration. Normalizing 'where' to use the same inline pattern guarantees pixel-for-pixel parity.

Goal: both inputs read as equally "optional, not required" — no visual emphasis on one vs the other.

`EditCheckModal` and `FirstCheckScreen` already have matching patterns on both inputs; only `CreateModal` was mismatched.

## Test plan
- [ ] Open event/check create modal → 'when' and 'where' inputs should look identical (same border weight + color) when both are empty
- [ ] Type something unparseable in 'when' → red border appears on 'when' only (existing behavior, unchanged)
- [ ] 'where' stays neutral regardless of content (existing behavior, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)