### PR TITLE
fix: drop the event's poster from the 'is down' row on event cards

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -222,9 +222,17 @@ const EventCard = ({
           {/* Responders + down button on same line */}
           <div className="flex items-center justify-between gap-2">
             <span className="font-mono text-tiny text-muted min-w-0 truncate">
-              {event.socialLoaded && event.peopleDown.length > 0 ? (() => {
-                const first = event.peopleDown[0];
-                const othersCount = event.peopleDown.length - 1;
+              {(() => {
+                if (!event.socialLoaded) return null;
+                // Hide the event's poster from this row — their name already
+                // appears elsewhere on the card, so "Kat is down" on Kat's
+                // own event reads as redundant.
+                const othersDown = event.createdBy
+                  ? event.peopleDown.filter((p) => p.userId !== event.createdBy)
+                  : event.peopleDown;
+                if (othersDown.length === 0) return null;
+                const first = othersDown[0];
+                const othersCount = othersDown.length - 1;
                 return (
                   <>
                     <span className="text-dt font-semibold">{first.name}</span>
@@ -235,7 +243,7 @@ const EventCard = ({
                     )}
                   </>
                 );
-              })() : null}
+              })()}
             </span>
             <button
               onClick={onToggleDown}


### PR DESCRIPTION
## Summary
On event cards, the inline "X is down" row next to the DOWN button would show the event's poster — redundant since the poster's name already appears elsewhere on the card (e.g. "via @kat" attribution). Filter `event.peopleDown` by `event.createdBy` for this one span.

The avatar stack and the full EventLobby list still show the complete set; this is purely the terse one-liner.

If no one else is down, the row now collapses to nothing (previously it would have shown the poster alone — the exact redundancy that prompted this).

## Test plan
- [ ] As the poster, view your own event card → "is down" row is empty (nothing there) instead of showing your own name
- [ ] When a friend marks down → row shows the friend's name only
- [ ] When multiple others mark down → "Alice + 2 others down" (poster not counted)
- [ ] Avatar stack + EventLobby still include the poster

🤖 Generated with [Claude Code](https://claude.com/claude-code)