### PR TITLE
fix: swipe-to-dismiss on ReportSheet + spec event-card dedupe rule

### DIFF
--- a/specs/events-flow.md
+++ b/specs/events-flow.md
@@ -1,0 +1,25 @@
+# Events Flow Spec
+
+## Context
+
+Events are scraped from links (Instagram, Resident Advisor, Letterboxd) or created directly. They're shown in feed, calendar, and event detail views. Users can mark "down" to signal interest, which surfaces friends-of-friends social signal and kicks off squad-forming flows.
+
+---
+
+## Event card display
+
+Event cards appear in the feed and "saved" list. They show poster attribution, metadata (date/time/venue/vibe), a DOWN ?/DOWN toggle, an "X is down" responders row, and (when expanded) an avatar stack of people who are down.
+
+### Poster attribution
+
+The event's poster is shown once, in the attribution area near the top of the card (`posterName` + `posterAvatar`). This is the canonical place we surface "who posted this."
+
+### "Is down" responders row
+
+The inline responders row (next to the DOWN button) summarizes who's interested — e.g. "Alice is down" or "Alice + 3 others down".
+
+**Rule**: the event's poster is excluded from this row — they're already shown in the poster attribution area above. Showing them again in "Kat is down" on Kat's own event reads as redundant.
+
+Implementation: filter `event.peopleDown` by `event.createdBy` when computing the first responder and the `othersCount`. The avatar stack and the full EventLobby list are not affected — those show the complete set (including the poster).
+
+If no one else is down, the responders row collapses to nothing. Previously it would have shown the poster alone — the exact redundancy this rule prevents.

--- a/src/shared/components/ReportSheet.tsx
+++ b/src/shared/components/ReportSheet.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as db from "@/lib/db";
 import type { ReportReason, ReportTargetType } from "@/lib/db";
 import { logError } from "@/lib/logger";
 import cn from "@/lib/tailwindMerge";
+import { useModalTransition } from "@/shared/hooks/useModalTransition";
 
 const REASONS: { value: ReportReason; label: string }[] = [
   { value: "harassment",    label: "Harassment or bullying" },
@@ -24,14 +25,35 @@ interface ReportSheetProps {
 }
 
 const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }: ReportSheetProps) => {
+  const { visible, entering, closing, close } = useModalTransition(true, onClose);
   const [reason, setReason] = useState<ReportReason | null>(null);
   const [details, setDetails] = useState("");
   const [submitting, setSubmitting] = useState(false);
 
+  // Swipe-to-dismiss — mirrors DetailSheet. 60px downward closes.
+  const touchStartY = useRef(0);
+  const [dragOffset, setDragOffset] = useState(0);
+  const isDragging = useRef(false);
+
+  const handleSwipeStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+    isDragging.current = false;
+  };
+  const handleSwipeMove = (e: React.TouchEvent) => {
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
+  };
+  const handleSwipeEnd = () => {
+    if (dragOffset > 60) { setDragOffset(0); close(); }
+    else { setDragOffset(0); }
+    isDragging.current = false;
+  };
+
   useEffect(() => {
+    if (!visible) return;
     document.body.style.overflow = "hidden";
     return () => { document.body.style.overflow = ""; };
-  }, []);
+  }, [visible]);
 
   const submit = async () => {
     if (!reason || submitting) return;
@@ -39,83 +61,107 @@ const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }
     try {
       await db.reportContent(targetType, targetId, reason, details.trim() || null);
       onSubmitted?.();
-      onClose();
+      close();
     } catch (err) {
       logError("reportContent", err, { targetType, targetId });
       setSubmitting(false);
     }
   };
 
+  if (!visible) return null;
+
   const title = targetLabel ? `Report ${targetLabel}` : "Report";
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-end justify-center">
       <div
-        onClick={onClose}
-        className="absolute inset-0"
-        style={{ background: "rgba(0,0,0,0.7)", backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)" }}
+        onClick={close}
+        className="absolute inset-0 transition-[opacity,backdrop-filter] duration-300 ease-in-out"
+        style={{
+          background: "rgba(0,0,0,0.7)",
+          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          opacity: (entering || closing) ? 0 : 1,
+        }}
       />
       <div
-        className="relative bg-surface w-full max-w-[420px] px-6 pt-4 pb-8 flex flex-col animate-slide-up"
-        style={{ borderRadius: "24px 24px 0 0", maxHeight: "80vh" }}
+        className="relative bg-surface w-full max-w-[420px] flex flex-col"
+        style={{
+          borderRadius: "24px 24px 0 0",
+          maxHeight: "80vh",
+          animation: closing ? undefined : "slideUp 0.3s ease-out",
+          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
+          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+        }}
       >
-        <div className="w-10 h-1 rounded-sm mx-auto mb-4" style={{ background: "#444" }} />
-        <h2 className="font-serif text-[22px] text-primary mb-4">{title}</h2>
-
-        <div className="font-mono text-tiny uppercase text-dim mb-2" style={{ letterSpacing: "0.15em" }}>
-          Reason
+        {/* Drag handle — touch target for swipe-to-dismiss */}
+        <div
+          onTouchStart={handleSwipeStart}
+          onTouchMove={handleSwipeMove}
+          onTouchEnd={handleSwipeEnd}
+          className="touch-none pt-3 pb-1 flex justify-center"
+        >
+          <div className="w-10 h-1 rounded-sm" style={{ background: "#444" }} />
         </div>
-        <div className="flex flex-col gap-1.5 mb-4">
-          {REASONS.map((r) => (
+
+        <div className="px-6 pb-8 overflow-y-auto flex flex-col">
+          <h2 className="font-serif text-[22px] text-primary mb-4">{title}</h2>
+
+          <div className="font-mono text-tiny uppercase text-dim mb-2" style={{ letterSpacing: "0.15em" }}>
+            Reason
+          </div>
+          <div className="flex flex-col gap-1.5 mb-4">
+            {REASONS.map((r) => (
+              <button
+                key={r.value}
+                onClick={() => setReason(r.value)}
+                className={cn(
+                  "text-left rounded-lg py-2.5 px-3 font-mono text-xs border cursor-pointer transition-colors",
+                  reason === r.value
+                    ? "bg-dt text-on-accent border-dt font-bold"
+                    : "bg-card text-primary border-border-mid"
+                )}
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="font-mono text-tiny uppercase text-dim mb-2" style={{ letterSpacing: "0.15em" }}>
+            Details <span className="lowercase text-faint normal-case">(optional)</span>
+          </div>
+          <textarea
+            value={details}
+            onChange={(e) => setDetails(e.target.value.slice(0, 500))}
+            maxLength={500}
+            placeholder="Anything else we should know?"
+            className="w-full bg-card border border-border-mid rounded-xl py-2.5 px-3 text-primary font-mono text-xs outline-none resize-none mb-5 box-border"
+            style={{ height: 72 }}
+          />
+
+          <div className="flex gap-2.5">
             <button
-              key={r.value}
-              onClick={() => setReason(r.value)}
-              className={cn(
-                "text-left rounded-lg py-2.5 px-3 font-mono text-xs border cursor-pointer transition-colors",
-                reason === r.value
-                  ? "bg-dt text-on-accent border-dt font-bold"
-                  : "bg-card text-primary border-border-mid"
-              )}
+              onClick={close}
+              disabled={submitting}
+              className="flex-1 bg-transparent border border-border-mid rounded-xl py-3 font-mono text-xs font-bold uppercase text-primary cursor-pointer"
+              style={{ letterSpacing: "0.08em" }}
             >
-              {r.label}
+              Cancel
             </button>
-          ))}
-        </div>
-
-        <div className="font-mono text-tiny uppercase text-dim mb-2" style={{ letterSpacing: "0.15em" }}>
-          Details <span className="lowercase text-faint normal-case">(optional)</span>
-        </div>
-        <textarea
-          value={details}
-          onChange={(e) => setDetails(e.target.value.slice(0, 500))}
-          maxLength={500}
-          placeholder="Anything else we should know?"
-          className="w-full bg-card border border-border-mid rounded-xl py-2.5 px-3 text-primary font-mono text-xs outline-none resize-none mb-5 box-border"
-          style={{ height: 72 }}
-        />
-
-        <div className="flex gap-2.5">
-          <button
-            onClick={onClose}
-            disabled={submitting}
-            className="flex-1 bg-transparent border border-border-mid rounded-xl py-3 font-mono text-xs font-bold uppercase text-primary cursor-pointer"
-            style={{ letterSpacing: "0.08em" }}
-          >
-            Cancel
-          </button>
-          <button
-            onClick={submit}
-            disabled={!reason || submitting}
-            className={cn(
-              "flex-1 border-none rounded-xl py-3 font-mono text-xs font-bold uppercase",
-              reason && !submitting
-                ? "bg-dt text-on-accent cursor-pointer"
-                : "bg-border-mid text-dim cursor-not-allowed"
-            )}
-            style={{ letterSpacing: "0.08em" }}
-          >
-            {submitting ? "Sending..." : "Submit report"}
-          </button>
+            <button
+              onClick={submit}
+              disabled={!reason || submitting}
+              className={cn(
+                "flex-1 border-none rounded-xl py-3 font-mono text-xs font-bold uppercase",
+                reason && !submitting
+                  ? "bg-dt text-on-accent cursor-pointer"
+                  : "bg-border-mid text-dim cursor-not-allowed"
+              )}
+              style={{ letterSpacing: "0.08em" }}
+            >
+              {submitting ? "Sending..." : "Submit report"}
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Two follow-ups bundled:

### 1. ReportSheet can now be swiped down to dismiss
The other bottom sheets (`DetailSheet`, `EventLobby`, `NotificationsPanel`) already support the 60px-swipe-down gesture per CLAUDE.md's design rules, but ReportSheet (added in #402) didn't. Users on iOS/Capacitor expected it.

Port the same pattern from `DetailSheet`:
- `useModalTransition` for proper enter/close animations (replaces the immediate `onClose` on submit/cancel)
- `touchStart/Move/End` on the drag handle with 60px downward threshold
- Transform-based drag offset during the gesture
- Animated close transitions (fade backdrop + slide panel)

### 2. New spec: `specs/events-flow.md`
CLAUDE.md says product behavior specs live in `specs/`, but only `interest-check-flow` and `date-confirm-flow` existed — events had nothing documented. Start `events-flow.md` with the event-card display rules, including the "poster excluded from the 'is down' responders row" rule shipped in #406. Keeps scope tight; future event behavior (save, scrape, crew pool) can land in the same file.

## Test plan
- [ ] Open ReportSheet (⚐ on a check, or Report user from profile)
- [ ] Swipe down from the drag handle → sheet slides off, then unmounts
- [ ] Tap backdrop → same behavior
- [ ] Submit a report → animated close instead of abrupt unmount
- [ ] `specs/events-flow.md` renders on GitHub as a readable doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)