### PR TITLE
feat: move hide + report into a bottom-sheet menu on check cards

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -10,6 +10,7 @@ import InlineCommentsBox from "@/shared/components/InlineCommentsBox";
 import CheckDetailSheet from "./CheckDetailSheet";
 import EditCheckModal from "./EditCheckModal";
 import ReportSheet from "@/shared/components/ReportSheet";
+import CheckActionsSheet from "@/shared/components/CheckActionsSheet";
 import { useFeedContext } from "@/features/checks/context/FeedContext";
 
 function Linkify({ children, dimmed, coAuthors, onViewProfile }: { children: string; dimmed?: boolean; coAuthors?: { name: string; userId?: string }[]; onViewProfile?: (userId: string) => void }) {
@@ -110,6 +111,7 @@ export default function CheckCard({
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [showReport, setShowReport] = useState(false);
+  const [showActions, setShowActions] = useState(false);
 
   const { comments, commentCount, openComments, postComment } = useCheckComments({
     checkId: check.id,
@@ -250,19 +252,12 @@ export default function CheckCard({
                   </span>
                 )}
                 {!check.isYours && !check.isCoAuthor && (
-                  <>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); setShowReport(true); }}
-                      className="bg-transparent border-none text-dim py-0.5 px-1 font-mono text-xs cursor-pointer leading-none"
-                      title="Report this check"
-                      aria-label="Report this check"
-                    >⚐</button>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); hideCheck(check.id); }}
-                      className="bg-transparent border-none text-dim py-0.5 px-1 font-mono text-xs cursor-pointer leading-none"
-                      title="Hide this check"
-                    >✕</button>
-                  </>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); setShowActions(true); }}
+                    className="bg-transparent border-none text-dim py-0.5 px-1 font-mono text-base cursor-pointer leading-none"
+                    title="More"
+                    aria-label="More actions"
+                  >⋯</button>
                 )}
               </div>
             </div>
@@ -436,6 +431,14 @@ export default function CheckCard({
           await loadRealData();
         }}
       />
+
+      {showActions && (
+        <CheckActionsSheet
+          onHide={() => hideCheck(check.id)}
+          onReport={() => setShowReport(true)}
+          onClose={() => setShowActions(false)}
+        />
+      )}
 
       {showReport && (
         <ReportSheet

--- a/src/shared/components/CheckActionsSheet.tsx
+++ b/src/shared/components/CheckActionsSheet.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useModalTransition } from "@/shared/hooks/useModalTransition";
+
+/**
+ * Small action sheet for a non-owned check in the feed. Opens from the
+ * card's ⋯ kebab. Surfaces Hide + Report in a bottom sheet so the card
+ * itself stays visually quiet.
+ *
+ * Mirrors the ReportSheet shell (backdrop, transitions, 60px swipe-to-dismiss).
+ */
+interface CheckActionsSheetProps {
+  onHide: () => void;
+  onReport: () => void;
+  onClose: () => void;
+}
+
+const CheckActionsSheet = ({ onHide, onReport, onClose }: CheckActionsSheetProps) => {
+  const { visible, entering, closing, close } = useModalTransition(true, onClose);
+
+  const touchStartY = useRef(0);
+  const [dragOffset, setDragOffset] = useState(0);
+  const isDragging = useRef(false);
+
+  const handleSwipeStart = (e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+    isDragging.current = false;
+  };
+  const handleSwipeMove = (e: React.TouchEvent) => {
+    const dy = e.touches[0].clientY - touchStartY.current;
+    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
+  };
+  const handleSwipeEnd = () => {
+    if (dragOffset > 60) { setDragOffset(0); close(); }
+    else { setDragOffset(0); }
+    isDragging.current = false;
+  };
+
+  useEffect(() => {
+    if (!visible) return;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, [visible]);
+
+  if (!visible) return null;
+
+  const actOn = (fn: () => void) => {
+    fn();
+    close();
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-end justify-center">
+      <div
+        onClick={close}
+        className="absolute inset-0 transition-[opacity,backdrop-filter] duration-300 ease-in-out"
+        style={{
+          background: "rgba(0,0,0,0.7)",
+          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          opacity: (entering || closing) ? 0 : 1,
+        }}
+      />
+      <div
+        className="relative bg-surface w-full max-w-[420px] flex flex-col"
+        style={{
+          borderRadius: "24px 24px 0 0",
+          animation: closing ? undefined : "slideUp 0.3s ease-out",
+          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
+          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+        }}
+      >
+        <div
+          onTouchStart={handleSwipeStart}
+          onTouchMove={handleSwipeMove}
+          onTouchEnd={handleSwipeEnd}
+          className="touch-none pt-3 pb-1 flex justify-center"
+        >
+          <div className="w-10 h-1 rounded-sm" style={{ background: "#444" }} />
+        </div>
+
+        <div className="px-6 pb-6 pt-2 flex flex-col gap-2">
+          <button
+            onClick={() => actOn(onHide)}
+            className="w-full bg-card border border-border-mid rounded-xl py-3.5 font-mono text-xs font-bold uppercase text-primary cursor-pointer"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            Hide this check
+          </button>
+          <button
+            onClick={() => actOn(onReport)}
+            className="w-full bg-card border border-border-mid rounded-xl py-3.5 font-mono text-xs font-bold uppercase text-primary cursor-pointer"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            Report
+          </button>
+          <button
+            onClick={close}
+            className="w-full bg-transparent border-none rounded-xl py-3 font-mono text-xs uppercase text-faint cursor-pointer mt-1"
+            style={{ letterSpacing: "0.08em" }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CheckActionsSheet;


### PR DESCRIPTION
## Summary
The inline `⚐` (report) + `✕` (hide) pair on non-owned check cards was getting noisy alongside the timer pill + "new" badge. Replace with a single `⋯` kebab that opens a small bottom sheet listing Hide + Report.

## Changes
- **`CheckActionsSheet`** (new shared component) — same shell pattern as `ReportSheet` (useModalTransition, backdrop fade, 60px swipe-to-dismiss). Lives in `src/shared/components/` so it can grow (mute author, save to calendar, etc).
- **`CheckCard`** — inline `⚐ + ✕` replaced with `⋯`. `showActions` state controls the new sheet. Hide routes through the existing `hideCheck(check.id)` callback; Report opens the existing ReportSheet (unchanged).

Card is visually quieter — one glyph instead of two. Users pay one extra tap to hide/report, which is fine for low-frequency actions and consistent with iOS action-sheet conventions.

## Test plan
- [ ] On a non-owned check card, the `⋯` button appears in the top-right row (no more `⚐` or `✕` inline)
- [ ] Tap `⋯` → bottom sheet slides up with Hide / Report / Cancel
- [ ] Swipe the sheet down 60px+ → dismisses
- [ ] Tap backdrop → dismisses
- [ ] Tap Hide → sheet closes, check is hidden (matches previous behavior)
- [ ] Tap Report → sheet closes, ReportSheet opens, submit works end-to-end
- [ ] Own checks + co-authored checks still have no ⋯ button (correct — they get the Edit modal via tap-card-open instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)