### PR TITLE
fix: move '(time) left' to author row, right-aligned

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -211,12 +211,17 @@ export default function CheckCard({
             <div className="w-5 h-5 rounded-full bg-border-light text-dim flex items-center justify-center font-mono text-[9px] font-bold shrink-0">
               {check.author[0]?.toUpperCase()}
             </div>
-            <span className="font-mono text-tiny text-muted min-w-0 truncate">
+            <span className="font-mono text-tiny text-muted min-w-0 truncate flex-1">
               <span className="text-dt font-semibold">{check.author}</span>
               {check.viaFriendName && (
                 <span className="font-normal text-dim">{" "}via {check.viaFriendName}</span>
               )}
             </span>
+            {check.expiresIn !== "open" && (
+              <span className={`font-mono text-tiny shrink-0 ${check.expiryPercent > 75 ? "text-danger" : "text-dim"}`}>
+                {check.expiresIn === "expired" ? "expired" : `${check.expiresIn} left`}
+              </span>
+            )}
           </div>
 
           {/* Co-author tag prompt */}
@@ -245,11 +250,6 @@ export default function CheckCard({
               <div className="flex items-center gap-1 shrink-0 mt-1">
                 {isNew && (
                   <span className="bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full leading-none">new</span>
-                )}
-                {check.expiresIn !== "open" && (
-                  <span className={`font-mono text-tiny ${check.expiryPercent > 75 ? "text-danger" : "text-dim"}`}>
-                    {check.expiresIn === "expired" ? "expired" : `${check.expiresIn} left`}
-                  </span>
                 )}
                 {!check.isYours && !check.isCoAuthor && (
                   <button


### PR DESCRIPTION
## Summary
The expiry pill used to sit in the check-text row next to the 'new' badge and the `⋯` kebab — three small mono tags crowding the serif check title area. Move it up to the author row, right-aligned on the same line as the author name + via-annotation.

## Why
- Declutters the serif title so it stands on its own
- Author + expiry on one symmetric top line reads naturally: *who is it from, how long do you have to respond*
- The 'new' badge and `⋯` kebab stay in the check-text row since they relate to the content/actions surface, not the author

Expiry color logic unchanged — `text-danger` when >75% elapsed, else `text-dim`.

## Test plan
- [ ] Fresh check (just posted) → author line shows `[avatar] Name · 23h left` (or similar) on the right
- [ ] Check with `expiresIn === "open"` → no expiry pill (unchanged behavior)
- [ ] Near-expiry check (>75% elapsed) → expiry pill shows in danger-red color, still right-aligned
- [ ] Expired check → shows "expired"
- [ ] FoF check ("via Friend") + expiry → name truncates via `flex-1 min-w-0 truncate`, expiry stays visible on the right

🤖 Generated with [Claude Code](https://claude.com/claude-code)