### PR TITLE
ci + seed: keep staging DB aligned with the previewing PR

### DIFF
--- a/.github/workflows/db-migrations-staging.yml
+++ b/.github/workflows/db-migrations-staging.yml
@@ -1,0 +1,40 @@
+name: DB Migrations (Staging)
+
+# Pushes Supabase migrations to the staging project on every branch push that
+# touches supabase/migrations/**. Keeps the staging DB in sync with whichever
+# branch is currently previewing, so Vercel Preview URLs never hit a schema
+# that lags behind the code.
+#
+# Companion to db-migrations.yml which pushes to PROD on merge to main.
+
+on:
+  push:
+    branches-ignore: [main]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+concurrency:
+  # Only one staging push at a time; later pushes from any branch queue
+  # behind the in-flight one.
+  group: db-migrations-staging
+  cancel-in-progress: false
+
+jobs:
+  push:
+    name: Push Supabase migrations to staging
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+      - name: Push migrations
+        run: supabase db push --include-all --yes

--- a/supabase/seed-staging.sql
+++ b/supabase/seed-staging.sql
@@ -1,0 +1,89 @@
+-- Seed the staging DB with enough relational data to demo every major feed
+-- surface in Vercel Preview deployments: feed, saved events, squads.
+--
+-- Idempotent — every INSERT is guarded by ON CONFLICT or a NOT EXISTS check,
+-- so you can re-run after `supabase db push` without blowing up.
+--
+-- Run against staging:
+--   psql "$STAGING_DB_URL" -f supabase/seed-staging.sql
+--
+-- Prerequisites: profiles, events, interest_checks, and friendships already
+-- populated (staging currently has 19 profiles / 2 events / 5 checks, plenty).
+
+
+-- =============================================================================
+-- 1. Saved events — mark a few profiles "down" on the existing events so the
+--    calendar / saved view isn't empty.
+-- =============================================================================
+INSERT INTO public.saved_events (user_id, event_id, is_down, saved_at)
+SELECT p.id, e.id, TRUE, now() - (INTERVAL '1 day' * random() * 5)
+FROM (SELECT id FROM public.profiles ORDER BY created_at LIMIT 5) p
+CROSS JOIN public.events e
+ON CONFLICT (user_id, event_id) DO NOTHING;
+
+
+-- =============================================================================
+-- 2. Squads — create one squad per active interest check that doesn't already
+--    have one, using the check's author as creator. Add the author + up to
+--    two "down" responders as members.
+-- =============================================================================
+DO $$
+DECLARE
+  v_check RECORD;
+  v_squad_id UUID;
+  v_responder UUID;
+BEGIN
+  FOR v_check IN
+    SELECT ic.id, ic.text, ic.author_id
+    FROM public.interest_checks ic
+    WHERE ic.archived_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.squads s WHERE s.check_id = ic.id)
+    LIMIT 2
+  LOOP
+    -- Create the squad
+    INSERT INTO public.squads (name, check_id, created_by)
+    VALUES (LEFT(v_check.text, 40), v_check.id, v_check.author_id)
+    RETURNING id INTO v_squad_id;
+
+    -- Author is always a member
+    INSERT INTO public.squad_members (squad_id, user_id)
+    VALUES (v_squad_id, v_check.author_id)
+    ON CONFLICT DO NOTHING;
+
+    -- Add up to 2 down responders (who aren't the author)
+    FOR v_responder IN
+      SELECT cr.user_id
+      FROM public.check_responses cr
+      WHERE cr.check_id = v_check.id
+        AND cr.response = 'down'
+        AND cr.user_id <> v_check.author_id
+      LIMIT 2
+    LOOP
+      INSERT INTO public.squad_members (squad_id, user_id)
+      VALUES (v_squad_id, v_responder)
+      ON CONFLICT DO NOTHING;
+    END LOOP;
+  END LOOP;
+END $$;
+
+
+-- =============================================================================
+-- 3. Squad chat — drop one opener message into each squad so the chat view
+--    renders something when a preview user taps in.
+-- =============================================================================
+INSERT INTO public.messages (squad_id, sender_id, text, created_at)
+SELECT s.id, s.created_by, 'who''s in? 👋', now() - interval '10 minutes'
+FROM public.squads s
+WHERE NOT EXISTS (SELECT 1 FROM public.messages m WHERE m.squad_id = s.id);
+
+
+-- =============================================================================
+-- Post-run sanity: row counts you should see now.
+-- =============================================================================
+-- SELECT 'profiles' AS t, count(*) FROM public.profiles
+--   UNION ALL SELECT 'events',         count(*) FROM public.events
+--   UNION ALL SELECT 'interest_checks',count(*) FROM public.interest_checks
+--   UNION ALL SELECT 'saved_events',   count(*) FROM public.saved_events
+--   UNION ALL SELECT 'squads',         count(*) FROM public.squads
+--   UNION ALL SELECT 'squad_members',  count(*) FROM public.squad_members
+--   UNION ALL SELECT 'messages',       count(*) FROM public.messages;


### PR DESCRIPTION
## Summary
Companion infrastructure for the staging Supabase project powering Vercel Preview deployments.

### 1. `.github/workflows/db-migrations-staging.yml`
Mirrors `db-migrations.yml` (prod) but fires on any branch push that touches `supabase/migrations/**` (except `main`). Runs `supabase db push` against staging so PR previews never hit a schema that lags the branch code.

Uses a fresh `staging` GitHub Actions environment to keep secrets separate from prod:
- `SUPABASE_ACCESS_TOKEN` — can reuse the prod PAT
- `SUPABASE_PROJECT_REF` — staging project ref (`tloixybibothbxzlnwrj`)
- `SUPABASE_DB_PASSWORD` — staging DB password

### 2. `supabase/seed-staging.sql`
Idempotent SQL script to top up staging with the relational data that makes preview UIs actually render something:
- `saved_events` for the first 5 profiles × every event
- 1 squad per active `interest_check` (author + up to 2 down responders as members)
- 1 opener message per squad

Run with: `psql "$STAGING_DB_URL" -f supabase/seed-staging.sql`

Intentionally does **not** add users / events / interest_checks — staging already has plenty (19 / 2 / 5 respectively). Just filling the zero-row tables (`saved_events`, `squads`, `squad_members`, `messages`).

## Prerequisites before this can run
In the GitHub repo Settings → Environments, create a new environment `staging` with these three secrets:
- `SUPABASE_ACCESS_TOKEN` (same PAT as `production` environment)
- `SUPABASE_PROJECT_REF` = `tloixybibothbxzlnwrj`
- `SUPABASE_DB_PASSWORD` = staging project's DB password (Settings → Database → Database password)

Without these set, the workflow will fail (harmlessly — no schema changes hit staging).

## Test plan
- [ ] Create the `staging` GH Actions environment + secrets
- [ ] Merge this PR — no migration changes, so the staging workflow shouldn't fire
- [ ] Open a follow-up PR that adds a trivial no-op migration to `supabase/migrations/` — confirm the staging workflow fires and `supabase db push` succeeds
- [ ] Run `psql … -f supabase/seed-staging.sql` against staging — confirm saved_events / squads / squad_members / messages are populated
- [ ] Open a Vercel Preview on any PR → Feed, Squads tab, and Saved calendar all render content instead of empty states

🤖 Generated with [Claude Code](https://claude.com/claude-code)