### PR TITLE
fix: skip image columns on text-only chat messages

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1314,17 +1314,21 @@ export async function sendMessage(
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
+  const row: Record<string, unknown> = {
+    squad_id: squadId,
+    sender_id: user.id,
+    text,
+    mentions,
+  };
+  if (image) {
+    row.image_path = image.path;
+    row.image_width = image.width;
+    row.image_height = image.height;
+  }
+
   const { data, error } = await supabase
     .from('messages')
-    .insert({
-      squad_id: squadId,
-      sender_id: user.id,
-      text,
-      mentions,
-      image_path: image?.path ?? null,
-      image_width: image?.width ?? null,
-      image_height: image?.height ?? null,
-    })
+    .insert(row)
     .select('*, sender:profiles(*)')
     .single();
 


### PR DESCRIPTION
## Summary
- Sentry caught a transient Supabase PostgREST schema-cache miss (`PGRST204`) on `messages.image_height` during `sendMessage`, ~2 days after the squad-chat-images migration shipped. The columns exist in prod; PostgREST just served a stale cache for a ~25s window (3 events, 1 user). Verified via `rest/v1/messages?select=id,text,image_path,image_width,image_height&limit=1` — no error today.
- The previous `sendMessage` always passed `null` into the new image columns, so even text-only chats tripped the cache. Now we only include `image_*` keys when an image is actually attached. Functionally identical (PostgREST defaults missing columns to `NULL`), but text-only chat stops depending on those columns being live in the schema cache.
- Sentry issue: https://downto.sentry.io/issues/7436873657/

## Test plan
- [ ] Send a text-only message in a squad chat — message appears, no error
- [ ] Send a message with an image attachment — image renders, row has `image_path/width/height`
- [ ] Send an image-only message (no caption) — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)