### PR TITLE
chore: no-op migration to verify DB Migrations (Staging) workflow

### DIFF
--- a/supabase/migrations/20260424000005_ci_smoke_test_staging.sql
+++ b/supabase/migrations/20260424000005_ci_smoke_test_staging.sql
@@ -1,0 +1,7 @@
+-- CI smoke test: confirm the DB Migrations (Staging) workflow auto-applies
+-- migrations on branch push. Companion to 20260424000002 which tested the
+-- prod workflow.
+--
+-- No schema impact — pure no-op. If this lands on staging via the workflow
+-- without manual intervention, the staging pipeline works end-to-end.
+SELECT 1;


### PR DESCRIPTION
## Summary
Smoke-test migration for the staging CI pipeline added in #411. Pure `SELECT 1;` — no schema impact.

## Verified working
- Triggered the `DB Migrations (Staging)` workflow on branch push
- Initial runs failed with `Invalid project ref format` → root cause was `echo -n | gh secret set --body -` storing trailing whitespace in secrets. Fixed by re-setting with `gh secret set --body "literal"`.
- Successful run: https://github.com/downtoxyz/downto/actions/runs/24903005835
- `20260424000005` is now recorded on staging's `schema_migrations`. Merging this records it in `main` too, keeping the two histories aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)