### PR TITLE
fix: treat friend-request duplicate-key as idempotent

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -445,7 +445,20 @@ export async function sendFriendRequest(userId: string): Promise<Friendship> {
     .select()
     .single();
 
-  if (error) throw error;
+  if (error) {
+    // Race with a concurrent sendFriendRequest (double-tap) or a pre-existing
+    // row we didn't match above (e.g. blocked). Treat as idempotent.
+    if ((error as { code?: string }).code === '23505') {
+      const { data: existing } = await supabase
+        .from('friendships')
+        .select('*')
+        .eq('requester_id', user.id)
+        .eq('addressee_id', userId)
+        .maybeSingle();
+      if (existing) return existing;
+    }
+    throw error;
+  }
   return data;
 }
 


### PR DESCRIPTION
## Summary
- Sentry caught a `23505` unique-constraint violation on `friendships_requester_id_addressee_id_key` during `sendFriendRequest` (1 user, 1 event so far). The function already checks for an existing outgoing row before inserting, but a fast double-tap fires two concurrent calls that both pass the check before either inserts — second insert loses the race.
- `FriendsModal` / `OnboardingFriendsPopup` gate the Add button on derived state (`f.status === "none"`) rather than an in-flight flag, so two taps before the optimistic state re-renders both fire. Fixing only the UI would still leave a window.
- Handle `23505` inside `db.sendFriendRequest`: re-fetch the row that won the race and return it. Also makes the function robust to a stale blocked-row the outgoing status-filter didn't match.
- Sentry: https://downto.sentry.io/issues/7437799501/ (DOWNTO-7)

## Test plan
- [ ] Tap "Add" on a suggestion — one request created, UI flips to "Requested"
- [ ] Rapidly double-tap "Add" — still one request, no error toast
- [ ] Send request to a user who previously blocked you (or was blocked by you) — resolves to the existing row without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)