### PR TITLE
fix: demote loadRealData 'Not authenticated' to warn

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -238,7 +238,12 @@ export default function Home() {
       notificationsHook.loadNotifications();
 
     } catch (err) {
-      logError("loadRealData", err);
+      // Session can drop mid-request; not a bug worth paging on.
+      if (err instanceof Error && err.message === "Not authenticated") {
+        logWarn("loadRealData", "auth lost mid-request", { error: err.message });
+      } else {
+        logError("loadRealData", err);
+      }
     } finally {
       isLoadingRef.current = false;
       setFeedLoaded(true);


### PR DESCRIPTION
## Summary
- Sentry caught a "Not authenticated" error surfaced as `action: loadRealData` (1 user, 1 event). The outer `if (!userId) return` guard only checks on entry — if the Supabase session drops between \`Promise.all\` starting and a db call resolving, unwrapped getters (\`getSavedEvents\`, \`getPublicEvents\`, \`getFriendsEvents\`, \`getFriends\`, \`getPendingRequests\`) throw "Not authenticated" and it ends up in Sentry.
- This is an expected transient condition (session expiry, signed-out-in-another-tab), not a bug. Demote to \`logWarn\` so it stops paging. All other errors still go to \`logError\`.
- Sentry: https://downto.sentry.io/issues/7439302999/ (DOWNTO-8)

## Test plan
- [ ] Normal feed load still reports real errors to Sentry (break one db call temporarily in dev to confirm)
- [ ] Signing out while feed is loading no longer creates a Sentry issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)