### PR TITLE
fix: gate Sentry to production (silence preview deploys)

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -2,9 +2,14 @@ import * as Sentry from "@sentry/nextjs";
 
 const SENSITIVE_KEYS = ["note", "rawCaption", "caption", "email", "password"];
 
+// Preview deploys race the staging Supabase migrations workflow, so they
+// produce transient schema-cache errors that aren't real bugs. Only page
+// from production; dev (no DSN) and preview both stay silent.
+const isProd = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN && isProd,
   release: process.env.NEXT_PUBLIC_BUILD_ID,
   tracesSampleRate: 0.1,
   // Transient failures the app already recovers from — not actionable as bugs.

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 
+const isProd = process.env.VERCEL_ENV === "production";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN && isProd,
   tracesSampleRate: 0.1,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 
+const isProd = process.env.VERCEL_ENV === "production";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN && isProd,
   tracesSampleRate: 0.1,
 });


### PR DESCRIPTION
## Summary
- Preview deploys race `db-migrations-staging.yml`: Vercel builds the preview ~15–30s before Supabase migrations finish pushing to the staging project. Anyone hitting the preview URL in that window sees `PGRST202` / `PGRST204` schema-cache misses (e.g. DOWNTO-9, "Could not find the function `public.get_friends_events`"). Structural to the race, not real bugs.
- Only enable the Sentry SDK when `VERCEL_ENV === "production"`. Dev (no DSN) and preview stay silent; prod reporting unchanged.
- Resolves: https://downto.sentry.io/issues/7439409281/ (DOWNTO-9)

## Test plan
- [ ] Next production deploy still sees its events in Sentry
- [ ] A preview deploy that triggers a known-error no longer appears in Sentry
- [ ] Dev (no DSN) still a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)