### PR TITLE
chore: add npm run dev:staging script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:prod": "bash -c '[ -f .env.development.local ] && mv .env.development.local .env.development.local.bak; trap \"[ -f .env.development.local.bak ] && mv .env.development.local.bak .env.development.local\" EXIT; next dev'",
+    "dev:staging": "bash -c 'if [ ! -f .env.staging.local ]; then echo \"missing .env.staging.local (create it with NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY for staging)\"; exit 1; fi; [ -f .env.development.local ] && mv .env.development.local .env.development.local.bak; cp .env.staging.local .env.development.local; trap \"rm -f .env.development.local; [ -f .env.development.local.bak ] && mv .env.development.local.bak .env.development.local\" EXIT; next dev'",
     "build": "next build",
     "build:capacitor": "bash scripts/build-capacitor.sh",
     "cap:sync": "npx cap sync ios",


### PR DESCRIPTION
## Summary
- Mirrors `dev:prod` but swaps in `.env.staging.local` so local dev can point at the staging Supabase project. Handy when debugging the exact schema preview deploys hit.
- Fails fast with a clear message if `.env.staging.local` doesn't exist.

## Test plan
- [ ] `npm run dev:staging` with no `.env.staging.local` → prints the "missing" message and exits 1
- [ ] With a valid `.env.staging.local` → `next dev` boots against the staging project, and on exit `.env.development.local` is restored from the backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)