### PR TITLE
fix: keep the Dates-poll Add button inside the modal

### DIFF
--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -1627,14 +1627,14 @@ const SquadChat = ({
                       onChange={(e) => setPollDateInput(e.target.value)}
                       onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addDateOption(); } }}
                       placeholder="fri 7pm"
-                      className="flex-1 bg-card border border-border-mid rounded-lg py-2 px-3 text-primary font-mono text-xs outline-none"
+                      className="min-w-0 flex-1 bg-card border border-border-mid rounded-lg py-2 px-3 text-primary font-mono text-xs outline-none"
                       disabled={pollDateOptions.length >= 10}
                     />
                     <button
                       onClick={addDateOption}
                       disabled={!pollDateInput.trim() || pollDateOptions.length >= 10}
                       className={cn(
-                        "border-none rounded-lg px-3 font-mono text-xs font-bold uppercase",
+                        "shrink-0 border-none rounded-lg px-3 font-mono text-xs font-bold uppercase",
                         (!pollDateInput.trim() || pollDateOptions.length >= 10)
                           ? "bg-card text-faint cursor-default"
                           : "bg-dt text-on-accent cursor-pointer"


### PR DESCRIPTION
## Summary
In the squad-chat poll creator, the DATES tab's Add button was rendering outside the modal's right border on narrow viewports (screenshot: iPhone with 5G status bar).

Same root cause as #422 fixed for the Grid tab's date inputs: an `<input>` has an intrinsic min-width that `flex-1` can't shrink below without `min-w-0`, which pushes a sibling flex item (the Add button) off the end of the row.

## Fix
- `min-w-0` on the `pollDateInput` text input so the flex item can shrink below its intrinsic width.
- `shrink-0` on the Add button so it holds its own width on the right side instead of being compressed.

Scoped to `SquadChat.tsx` DATES-poll variant only; Grid inputs already got the same treatment in #422.

## Test plan
- [ ] Open a squad chat on iPhone (or DevTools 390px width).
- [ ] Open the poll creator → Dates tab.
- [ ] Confirm the text input and Add button both sit fully inside the modal border.
- [ ] Confirm the input still grows to fill available space when the Add button is its normal size.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_