### PR TITLE
fix: grid poll over-max hint suggests actionable changes only

### DIFF
--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -1550,7 +1550,9 @@ const SquadChat = ({
                   </div>
                   {gridSlotsOverMax ? (
                     <p className="font-mono text-tiny text-[#ff4444] mb-4 text-center">
-                      {gridSlotCount} / {MAX_WHEN_SLOTS} slots — narrow the range, window, or granularity
+                      {gridSlotCount} / {MAX_WHEN_SLOTS} slots — {gridSlotMinutes === 30
+                        ? 'shorten the range, pick a smaller window, or switch to 1H slots'
+                        : 'shorten the range or pick a smaller window'}
                     </p>
                   ) : gridRangeValid ? (
                     <p className="font-mono text-tiny text-faint mb-4 text-center">


### PR DESCRIPTION
## Summary
The grid-poll over-max hint in the poll creator said `"narrow the range, window, or granularity"`, but that advice doesn't hold up:

- When the user is already on **1H** slots (the coarsest option, the default), "narrow granularity" has no effect — 30M would *double* the slot count. In the screenshot: 7 days × ALL DAY × 1H = 91 slots, and the copy tells them to adjust something that can't help.
- "Narrow" also reads as "make smaller," which in UX land means shorter slots = more slots = worse.

## Fix
Tailor the hint to the current slot setting:
- **30M selected**: "shorten the range, pick a smaller window, or switch to 1H slots" (switching to 1H halves the count — a real escape hatch).
- **1H selected**: "shorten the range or pick a smaller window" (no slot-size move helps; don't mislead).

One-line change in the `gridSlotsOverMax` branch.

## Test plan
- [ ] Open Grid tab → 7 days + ALL DAY + 1H → hint reads "shorten the range or pick a smaller window".
- [ ] Switch slot to 30M with same range/window → hint reads "shorten the range, pick a smaller window, or switch to 1H slots".
- [ ] Pick a valid config (weekend + evenings + 1H) → normal `"N / 50 slots · tap to paint once created"` message.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_