### PR TITLE
fix: bump when-poll slot cap from 50 to 200

### DIFF
--- a/src/app/api/squads/create-poll/route.ts
+++ b/src/app/api/squads/create-poll/route.ts
@@ -36,8 +36,8 @@ export async function POST(req: NextRequest) {
 
   if (pollType === 'when') {
     const { slots, collectionStyle: cs } = body as { slots?: unknown; collectionStyle?: unknown };
-    if (!Array.isArray(slots) || slots.length < 1 || slots.length > 50) {
-      return NextResponse.json({ error: 'slots must be 1–50 entries' }, { status: 400 });
+    if (!Array.isArray(slots) || slots.length < 1 || slots.length > 200) {
+      return NextResponse.json({ error: 'slots must be 1–200 entries' }, { status: 400 });
     }
     if (cs !== 'preference' && cs !== 'availability') {
       return NextResponse.json({ error: "collectionStyle must be 'preference' or 'availability'" }, { status: 400 });

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -1270,8 +1270,8 @@ const SquadChat = ({
           return d.toLocaleDateString('en-US', { weekday: 'short', month: 'numeric', day: 'numeric' });
         };
 
-        // Server caps when-poll slots at 50; the grid emits one slot per cell.
-        const MAX_WHEN_SLOTS = 50;
+        // Server caps when-poll slots at 200; the grid emits one slot per cell.
+        const MAX_WHEN_SLOTS = 200;
         const computeGridSlotCount = (): number => {
           const dates = computeGridDates();
           if (!dates) return 0;
@@ -1325,7 +1325,7 @@ const SquadChat = ({
               await db.createWhenPoll(localSquad.id, slots, 'preference');
             } else if (pollVariant === 'grid') {
               // Availability-style 'when' poll: enumerate every (day, slot) cell
-              // as a slot with concrete startMin/endMin. Server caps at 50 slots.
+              // as a slot with concrete startMin/endMin. Server caps at 200 slots.
               const g = computeGridParams();
               if (!g) return;
               const slots: WhenSlot[] = [];


### PR DESCRIPTION
## Summary
The when-poll slot cap was 50, which ruled out a normal week-long when2meet (7 days × all-day × 30M = 182 slots) — the obvious shape for "when can everyone meet next week?". The escape hatch added in #424 ("switch to 1H slots") only gets you to 91 in that case, also over. Users land on the GRID tab and bounce off the cap with no realistic way out.

## Fix
Bump the cap from 50 → 200, in lockstep on both sides:
- Server: `src/app/api/squads/create-poll/route.ts:39` (validator + error string)
- Client: `src/features/squads/components/SquadChat.tsx:1274` (`MAX_WHEN_SLOTS`)
- Two stale "50 slots" comments updated to match.

## What 200 buys us
| Combo | Slots | Status |
|---|---|---|
| 7 days × all-day × 30M | 182 | ✓ now allowed |
| 7 days × all-day × 1H | 91 | ✓ |
| 14 days × evenings × 30M | 140 | ✓ |
| 14 days × all-day × 1H | 182 | ✓ |
| weekend × all-day × 30M | 52 | ✓ |
| 14 days × all-day × 30M | 364 | ✗ still capped — borderline unfillable anyway |

## Storage doesn't care
Slots live as a JSONB array (`squad_polls.options`); votes are one row per painted cell in `squad_poll_votes`. JSONB and the votes table both scale far past 200; the cap is purely a soft validator on the create endpoint. No schema migration.

## Test plan
- [ ] Open Grid tab → 7 days + ALL DAY + 30M (182 slots).
- [ ] Counter reads `182 / 200 slots · tap to paint once created` (no red error).
- [ ] CREATE button is enabled and posts the poll.
- [ ] Open the resulting poll, confirm the 182-cell grid renders without obvious lag.
- [ ] Try 14d × all-day × 30M (364) — still capped, hint shows correctly.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_