### PR TITLE
fix(GridPollMessage): compact headers when grid spans more than a week

### DIFF
--- a/src/features/squads/components/GridPollMessage.tsx
+++ b/src/features/squads/components/GridPollMessage.tsx
@@ -46,11 +46,20 @@ function formatSlotLabel(hourStart: number, slotIndex: number, slotMinutes: numb
   return m === 0 ? `${h12}${ampm}` : `${h12}:${m.toString().padStart(2, '0')}${ampm}`;
 }
 
-function formatDayHeader(dateIso: string): { top: string; bottom: string } {
+function formatDayHeader(dateIso: string, compact: boolean): { top: string; bottom: string; title: string } {
   const d = new Date(dateIso + 'T00:00:00');
+  const title = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  if (compact) {
+    return {
+      top: d.toLocaleDateString('en-US', { weekday: 'narrow' }),
+      bottom: String(d.getDate()),
+      title,
+    };
+  }
   return {
     top: d.toLocaleDateString('en-US', { weekday: 'short' }),
     bottom: d.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' }),
+    title,
   };
 }
 
@@ -216,15 +225,17 @@ export default function GridPollMessage({
           onPointerMove={handlePointerMove}
           className="select-none"
         >
-          {/* Header row: day labels */}
+          {/* Header row: day labels. Past 7 days the columns get too narrow
+              for "Sat 4/25" — collapse to single-letter weekday + day number
+              and stash the full date in title= so hover recovers it. */}
           <div className="flex">
             <div className="shrink-0 w-10" />
             {Array.from({ length: days }, (_, d) => {
-              const h = formatDayHeader(poll.gridDates[d]);
+              const h = formatDayHeader(poll.gridDates[d], days > 7);
               return (
-                <div key={d} className="flex-1 min-w-0 text-center px-0.5">
-                  <div className="font-mono text-tiny text-dim leading-none">{h.top}</div>
-                  <div className="font-mono text-tiny text-faint leading-tight">{h.bottom}</div>
+                <div key={d} title={h.title} className="flex-1 min-w-0 text-center px-0.5 overflow-hidden">
+                  <div className="font-mono text-tiny text-dim leading-none truncate">{h.top}</div>
+                  <div className="font-mono text-tiny text-faint leading-tight truncate">{h.bottom}</div>
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary
The 14-day "happy hour at the applebees in times square" grid in the screenshot has its headers crammed into illegibility — "SatSunMonTueWedThuFri…" running together because each column is ~22px and "Sat 4/25" is ~30px. With `flex-1 min-w-0`, text overflows neighbors at center-align with nothing to stop it.

This is the obvious failure mode of the slot-cap bump in #426 — once 14×13×1H polls are creatable, they need to render.

## Fix
Compact header format when `days > 7`:
- Weekday: narrow → single letter ("S", "M", "T")
- Date: bare day-of-month ("25", not "4/25")
- Full "Sat, Apr 25" goes into `title=` so hover/long-press recovers the disambiguating month
- Belt-and-suspenders: `overflow-hidden` + `truncate` on the cells so a mis-sized label can never bleed sideways again

For ≤7-day grids (the common case) nothing changes — same "Sat / 4/25" stack as before.

## What about the magenta?
The screenshot's hot-pink borders look loud but are intentional — the user is on the `dragonfruit` theme (`src/lib/themes/dragonfruit.ts`), whose comment literally reads *"vivid magenta. Meant to be seen."* Out of scope here.

## Test plan
- [ ] 14-day × ALL DAY × 1H grid: headers read as "S 25 / S 26 / M 27 …" without collisions.
- [ ] Hover (or long-press on touch) a column → tooltip shows "Sat, Apr 25" etc.
- [ ] 7-day grid still shows "Sat / 4/25" (unchanged).
- [ ] Month-rollover columns (e.g. 4/30 → 5/1 renders as "30" then "1") — counting still works thanks to weekday context.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_