### PR TITLE
feat: in-app account deletion (App Store 5.1.1(v))

### DIFF
--- a/src/app/api/account/delete/route.ts
+++ b/src/app/api/account/delete/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequest, isAuthError } from '@/lib/api-auth';
+import { getServiceClient } from '@/lib/supabase-admin';
+
+/**
+ * Hard-delete the requesting user's account.
+ *
+ * App Store guideline 5.1.1(v) requires apps that allow account creation
+ * to support in-app account deletion. The privacy policy promises full
+ * deletion within 30 days; this endpoint executes it immediately.
+ *
+ * What gets deleted:
+ *   - profiles row → FK CASCADE wipes friendships, interest_checks, check_responses,
+ *     check_comments, check_co_authors, saved_events, squad_members, messages,
+ *     blocked_users, reported_content, push tokens, calendar tokens, notifications.
+ *   - auth.users row via the admin API.
+ *
+ * Side effect to be aware of: squad chat history loses the user's messages
+ * entirely (CASCADE). v1 trade-off — see PR description for context. We can
+ * swap to anonymization (sender_id → "[deleted]" placeholder) later if it
+ * causes confusion in shared squads.
+ */
+export async function POST(request: Request) {
+  const auth = await authenticateRequest(request);
+  if (isAuthError(auth)) return auth.error;
+
+  const userId = auth.user.id;
+  const admin = getServiceClient();
+
+  // 1. Delete profile row — FK CASCADE handles all the user's content.
+  const { error: profileErr } = await admin
+    .from('profiles')
+    .delete()
+    .eq('id', userId);
+
+  if (profileErr) {
+    return NextResponse.json(
+      { error: 'Failed to delete profile data', details: profileErr.message },
+      { status: 500 },
+    );
+  }
+
+  // 2. Delete auth.users row. If this fails, the user has no profile but
+  // can still log in to a now-empty account — they'd need to retry the
+  // delete or contact support. Logging the failure for visibility.
+  const { error: authErr } = await admin.auth.admin.deleteUser(userId);
+  if (authErr) {
+    console.error('account.delete: auth.users deletion failed', { userId, error: authErr.message });
+    return NextResponse.json(
+      { error: 'Profile deleted but auth record removal failed — contact support to finish', details: authErr.message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/features/profile/components/ProfileView.tsx
+++ b/src/features/profile/components/ProfileView.tsx
@@ -74,6 +74,9 @@ const ProfileView = ({
   const [activeTheme, setActiveTheme] = useState<ThemeName | null>(null);
   const [blockedUsers, setBlockedUsers] = useState<(Profile & { blocked_at: string })[]>([]);
   const [showBlocked, setShowBlocked] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     db.listBlockedUsers()
@@ -88,6 +91,22 @@ const ProfileView = ({
       showToast?.(`Unblocked ${displayName}`);
     } catch {
       showToast?.("Couldn't unblock — try again");
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await db.deleteMyAccount();
+      // onLogout clears local auth state; the auth.users row is already gone
+      // server-side, so any future request would 401 anyway.
+      onLogout();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Couldn't delete account";
+      showToast?.(msg);
+      setDeleting(false);
+      setShowDeleteConfirm(false);
     }
   };
 
@@ -654,7 +673,67 @@ const ProfileView = ({
         <span>Log out</span>
         <span className="text-danger">→</span>
       </div>
+      <div
+        onClick={() => { setDeleteConfirmText(""); setShowDeleteConfirm(true); }}
+        className="py-3.5 font-mono text-xs text-danger flex justify-between cursor-pointer border-t border-border"
+      >
+        <span>Delete account</span>
+        <span className="text-danger">→</span>
+      </div>
     </div>
+    {showDeleteConfirm && profile?.username && (
+      <div
+        onClick={() => !deleting && setShowDeleteConfirm(false)}
+        className="fixed inset-0 bg-[rgba(0,0,0,0.7)] z-[9999] flex items-center justify-center"
+      >
+        <div
+          onClick={(e) => e.stopPropagation()}
+          className="bg-deep border border-border rounded-2xl max-w-[340px] w-[calc(100%-40px)] py-6 px-5"
+        >
+          <div className="font-serif text-lg text-primary mb-2">
+            Delete your downto account?
+          </div>
+          <div className="font-mono text-tiny text-dim leading-relaxed mb-4">
+            This wipes your profile, friendships, interest checks, responses, comments, squad memberships, and any messages you&apos;ve sent. It cannot be undone.
+          </div>
+          <div className="font-mono text-tiny text-dim mb-1.5">
+            Type <span className="text-primary font-bold">{profile.username}</span> to confirm:
+          </div>
+          <input
+            type="text"
+            value={deleteConfirmText}
+            onChange={(e) => setDeleteConfirmText(e.target.value)}
+            disabled={deleting}
+            autoFocus
+            className="w-full bg-card border border-border-mid rounded-lg py-2 px-3 font-mono text-xs text-primary outline-none mb-4 box-border"
+            placeholder={profile.username}
+          />
+          <div className="flex gap-2.5">
+            <button
+              onClick={() => setShowDeleteConfirm(false)}
+              disabled={deleting}
+              className="flex-1 bg-transparent border border-border-mid rounded-xl py-2.5 font-mono text-xs font-bold uppercase text-primary cursor-pointer disabled:opacity-50"
+              style={{ letterSpacing: "0.08em" }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleDeleteAccount}
+              disabled={deleting || deleteConfirmText.trim() !== profile.username}
+              className={cn(
+                "flex-1 border-none rounded-xl py-2.5 font-mono text-xs font-bold uppercase text-white",
+                deleteConfirmText.trim() === profile.username && !deleting
+                  ? "bg-danger cursor-pointer"
+                  : "bg-border-mid text-dim cursor-not-allowed"
+              )}
+              style={{ letterSpacing: "0.08em" }}
+            >
+              {deleting ? "Deleting..." : "Delete forever"}
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
     {showEditModal && (
       <div
         onClick={() => setShowEditModal(false)}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -825,6 +825,16 @@ export async function deleteInterestCheck(checkId: string): Promise<void> {
   if (error) throw error;
 }
 
+/** Returns true if the check still exists and is not archived. */
+export async function isInterestCheckActive(checkId: string): Promise<boolean> {
+  const { data } = await supabase
+    .from('interest_checks')
+    .select('id, archived_at')
+    .eq('id', checkId)
+    .maybeSingle();
+  return !!data && !data.archived_at;
+}
+
 export async function archiveInterestCheck(checkId: string): Promise<void> {
   const { error } = await supabase
     .from('interest_checks')
@@ -2183,4 +2193,31 @@ export async function reportContent(
       details,
     });
   if (error) throw error;
+}
+
+
+// =============================================================================
+// Account deletion (App Store 5.1.1(v))
+// =============================================================================
+
+/**
+ * Hard-delete the current user's account + all their content.
+ *
+ * Routes through /api/account/delete (service-role) because the auth.users
+ * row can only be removed via the admin API, not from the browser. After
+ * the call resolves, sign the user out — the session token is now stale.
+ */
+export async function deleteMyAccount(): Promise<void> {
+  const token = (await supabase.auth.getSession()).data.session?.access_token;
+  if (!token) throw new Error('Not authenticated');
+
+  const res = await fetch(`${API_BASE}/api/account/delete`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error ?? `Account deletion failed (${res.status})`);
+  }
 }


### PR DESCRIPTION
## Summary
Closes the second App Store 5.1.1 gate after the privacy policy in #421. Apple requires apps that allow account creation to expose an **in-app** delete flow — emailing support isn't sufficient.

## Server: `POST /api/account/delete`
- Authenticates via Authorization Bearer token (same pattern as other API routes via `api-auth.ts`)
- Uses service-role admin client to:
  1. `DELETE FROM profiles WHERE id = userId` — FK CASCADE wipes friendships, interest_checks, check_responses, check_comments, check_co_authors, saved_events, squad_members, messages, blocked_users, reported_content, push tokens, calendar tokens, notifications
  2. `supabase.auth.admin.deleteUser(userId)` — wipes the auth.users row so the email can re-register fresh
- If step 2 fails after step 1 succeeded, returns 500 with a message explaining the half-state (rare; admin API is reliable, but worth flagging for support)

## Client: `db.deleteMyAccount()`
Thin POST wrapper, surfaces a typed Error on failure. Caller signs out after success (the session token is now stale).

## UI: ProfileView "Delete account" row
- Sits below "Log out" in danger styling, separated by a top border so it reads as a deliberate "danger zone" rather than just another setting
- Tap opens a confirmation modal that requires **typing your username** to enable the destructive button — standard friction pattern, prevents fat-finger deletions
- On confirm: spinner → `onLogout` (signOut + clears state) → back to login screen

## v1 trade-off (intentional)
Squad chat history loses the user's messages entirely via CASCADE. Cleanest erasure for the deleting user, but other squad members will see chats with gaps. Anonymizing `sender_id` to a `[deleted]` placeholder is a future iteration if it causes confusion in the wild.

## Test plan
- [ ] Create a throwaway test account on staging, post a check, respond to a friend's check, send a squad message
- [ ] Profile → bottom → "Delete account" — modal appears
- [ ] Type wrong username — "Delete forever" stays disabled
- [ ] Type correct username — button enables
- [ ] Tap "Delete forever" — spinner → redirect to login
- [ ] Re-attempt to log in with the same email — should treat as a brand-new account (no profile, no friends, no checks)
- [ ] Friends should no longer see the deleted user's checks/responses/messages
- [ ] Cancel the modal mid-deletion — confirmation should not fire (deleting flag prevents)

## Remaining App Store 5.1.1 follow-ups
- [ ] Link `/privacy` from the login/onboarding screen (consent signpost)
- [ ] Terms of service at `/terms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)