### PR TITLE
fix: drop redundant interest_checks UPDATE policy that breaks archive

### DIFF
--- a/supabase/migrations/20260425000001_drop_redundant_interest_checks_update_policy.sql
+++ b/supabase/migrations/20260425000001_drop_redundant_interest_checks_update_policy.sql
@@ -1,0 +1,26 @@
+-- Drop the redundant "Authors and co-authors can update interest checks"
+-- (plural) policy. It's superseded by "Author and co-authors can update
+-- interest checks" (singular, added in 20260416000001 and rewritten in
+-- 20260423000003 with the recursion-safe is_check_coauthor helper).
+--
+-- The plural policy is still on prod because 20260416000001 only DROPped
+-- the older "Users can update own interest checks" / "Viewers can update"
+-- names, not "Authors and co-authors..." (note the s on "Authors").
+--
+-- Why this matters: the plural policy uses public.is_check_author_or_coauthor,
+-- which does SELECT FROM interest_checks inside a SECURITY DEFINER body. As
+-- the comment in 20260423000003 spells out, SECURITY DEFINER doesn't reliably
+-- bypass RLS in this deployment, so that inner SELECT goes through the
+-- visibility policy. Visibility now requires check_is_active = true (added in
+-- 20260424000001). On archive, the post-update row has archived_at non-null,
+-- so the visibility predicate fails and the function returns false. With two
+-- permissive policies in play, the new row needs to satisfy at least one
+-- WITH CHECK — and Postgres has been observed rejecting the UPDATE with
+-- "new row violates row-level security policy" (Sentry DOWNTO-A) even though
+-- the newer policy's predicate would pass on its own.
+--
+-- The DELETE counterpart ("Authors and co-authors can delete interest checks")
+-- is left in place: DELETE has no WITH CHECK, only USING, and the row is
+-- still active when USING is evaluated. No need to churn it here.
+
+DROP POLICY IF EXISTS "Authors and co-authors can update interest checks" ON public.interest_checks;


### PR DESCRIPTION
## Summary
Two permissive UPDATE policies are live on `interest_checks`:
- `"Authors and co-authors can update interest checks"` (plural, from `20260305000001`) — uses old `is_check_author_or_coauthor` helper that does `SELECT FROM interest_checks` inside SECURITY DEFINER
- `"Author and co-authors can update interest checks"` (singular, from `20260416000001` → `20260423000003`) — uses the recursion-safe `is_check_coauthor`

The plural was never dropped (`20260416000001` only dropped older names like "Users can update own…" / "Viewers can update…"). `20260423000003`'s comment already documents that SECURITY DEFINER doesn't reliably bypass RLS in this deployment, so the plural policy's inner `SELECT FROM interest_checks` goes through the visibility policy. After archive, `check_is_active` flips false → that SELECT returns no row → the helper returns false → the plural policy's WITH CHECK rejects the new row, and Postgres surfaces "new row violates row-level security policy" (Sentry DOWNTO-A).

Drop the dead plural policy. The singular policy stays and is sufficient. DELETE counterpart left alone — DELETE has no WITH CHECK and the row is still active when USING evaluates.

Resolves: https://downto.sentry.io/issues/7441207276/ (DOWNTO-A)

## Test plan
- [ ] Author can archive their own check
- [ ] Author can unarchive an archived check
- [ ] Accepted co-author can still edit a check
- [ ] Non-author / non-co-author still cannot edit any check (RLS denies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)