### PR TITLE
fix(font): drop synthetic-thin mono — render at native weight 400

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -78,11 +78,13 @@
   }
 }
 
-/* Mono font spacing */
+/* Mono font spacing. Weight 400 is the lightest weight Space Mono ships
+   with (the dragonfruit theme's mono); requesting 300 here forces a
+   synthetic faux-light, which renders as fuzzy / squashed at small sizes.
+   Stay at 400 and let the native glyphs do the work. */
 .font-mono {
   letter-spacing: -0.04em;
-  font-weight: 300;
-  -webkit-text-stroke: 0.15px;
+  font-weight: 400;
 }
 
 .font-serif {


### PR DESCRIPTION
## Summary
The `.font-mono` utility was set to `font-weight: 300` with a `-webkit-text-stroke: 0.15px` band-aid to thicken it back up (`global.css:82-86`). That combo made sense under guava (IBM Plex Mono ships weights 200–700) but breaks under dragonfruit: Space Mono is only loaded at **weights 400 and 700** (`layout.tsx:28`), so the browser synthesizes weight 300 as faux-light. The synthetic glyphs are exactly what's producing the fuzzy/squashed mono labels visible in the squad-poll grid screenshot — every mono label on the dragonfruit theme has been rendering this way.

## Fix
- Bump `.font-mono` weight from `300` → `400` (native in both Space Mono and IBM Plex Mono).
- Drop the `-webkit-text-stroke: 0.15px` workaround — no longer needed once the genuine weight 400 glyphs are in use.
- Keep `letter-spacing: -0.04em` — that's the intended tracking.

## Visual impact
- **Dragonfruit**: noticeably crisper labels at small sizes; grid headers, time labels, timestamps all look like real characters now instead of fuzzy outlines.
- **Guava**: a hair bolder than the previous 300 — IBM Plex Mono Light was on the thin side for 10–11px UI labels anyway, 400 is a more legible default.

## Test plan
- [ ] Open a squad-poll grid (when2meet) on dragonfruit — day/time labels and "tap or drag…" copy render cleanly.
- [ ] Spot-check feed cards, squad chat timestamps, "0 people" / "CLOSE POLL" buttons on both themes — nothing looks broken-bold or off.
- [ ] Pixel-peek tonight badge, expiry labels, and notification timestamps under guava — should still feel light enough.

https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K

---
_Generated by [Claude Code](https://claude.ai/code/session_0157dr6ymaqcmRjRhgvvV28K)_