### PR TITLE
feat: route native push taps into the same nav as the in-app bell

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import * as db from "@/lib/db";
 import { API_BASE } from "@/lib/db";
 import { color } from "@/lib/styles";
 import { sanitize, sanitizeVibes, parseDateToISO, toLocalISODate } from "@/lib/utils";
+import { setPushNavigationHandler, type NavigateAction } from "@/lib/pushNavigation";
 import type { Profile } from "@/lib/types";
 import type { Person, Event, Tab, ScrapedEvent, Squad } from "@/lib/ui-types";
 import { useOnboarding } from "@/features/auth/hooks/useOnboarding";
@@ -432,6 +433,38 @@ export default function Home() {
       setSquadChatOrigin(null);
     }
   }, [squadsHook.squads, selectedSquad]);
+
+  // Single source of truth for "user navigated from a notification" — used by
+  // both the in-app NotificationsPanel onNavigate prop AND the native push
+  // tap handler (see lib/pushNavigation.ts), so an OS push tap and an in-app
+  // bell tap end up at the same surface.
+  const handleNotificationNavigate = useCallback((action: NavigateAction) => {
+    if (action.type === "friends") {
+      friendsHook.setFriendsInitialTab(action.tab);
+      friendsHook.setFriendsOpen(true);
+    } else if (action.type === "groups") {
+      setSquadChatOrigin(tab);
+      // Always switch to squads tab so the user lands somewhere useful even
+      // if the target squad isn't loadable (e.g. membership dropped).
+      setTab("squads");
+      if (action.squadId) {
+        squadsHook.setAutoSelectSquadId(action.squadId);
+      }
+    } else if (action.type === "feed") {
+      setTab("feed");
+      if (action.checkId) {
+        checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: action.checkId });
+        setTimeout(() => checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: null }), 3000);
+      }
+    }
+  }, [tab, friendsHook, squadsHook, checksHook, setTab, setSquadChatOrigin]);
+
+  // Register the same handler for native-push taps. dispatchPushAction in
+  // lib/pushNotifications.ts will call this on `pushNotificationActionPerformed`.
+  useEffect(() => {
+    setPushNavigationHandler(handleNotificationNavigate);
+    return () => setPushNavigationHandler(null);
+  }, [handleNotificationNavigate]);
 
   // ─── Squad API handlers ──────────────────────────────────────────────────
 
@@ -1037,26 +1070,7 @@ export default function Home() {
         userId={userId}
         setUnreadCount={notificationsHook.setUnreadCount}
         friends={friendsHook.friends}
-        onNavigate={(action) => {
-          if (action.type === "friends") {
-            friendsHook.setFriendsInitialTab(action.tab);
-            friendsHook.setFriendsOpen(true);
-          } else if (action.type === "groups") {
-            setSquadChatOrigin(tab);
-            // Always switch to squads tab so the user lands somewhere useful
-            // even if the target squad isn't loadable (e.g. membership dropped).
-            setTab("squads");
-            if (action.squadId) {
-              squadsHook.setAutoSelectSquadId(action.squadId);
-            }
-          } else if (action.type === "feed") {
-            setTab("feed");
-            if (action.checkId) {
-              checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: action.checkId });
-              setTimeout(() => checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: null }), 3000);
-            }
-          }
-        }}
+        onNavigate={handleNotificationNavigate}
       />
 
       <EditEventModal

--- a/src/lib/pushNavigation.ts
+++ b/src/lib/pushNavigation.ts
@@ -1,0 +1,108 @@
+/**
+ * Bridges native push notifications to the in-app navigation logic.
+ *
+ * The push listener (in lib/pushNotifications.ts) lives outside React, so it
+ * can't call hooks or dispatch directly. Instead it calls dispatchPushAction()
+ * here, which delegates to whatever handler page.tsx registered on mount.
+ *
+ * Type mapping deliberately mirrors NotificationsPanel so a tap on the in-app
+ * notification row and a tap on the OS push notification end up at the same
+ * place.
+ */
+
+export type NavigateAction =
+  | { type: "friends"; tab: "friends" | "add" }
+  | { type: "groups"; squadId?: string }
+  | { type: "feed"; checkId?: string };
+
+type PushNavigationHandler = (action: NavigateAction) => void;
+
+let handler: PushNavigationHandler | null = null;
+let pendingAction: NavigateAction | null = null;
+
+/** Register the navigation handler. Call from page.tsx on mount, pass null on unmount. */
+export function setPushNavigationHandler(h: PushNavigationHandler | null): void {
+  handler = h;
+  // If a push fired before page.tsx mounted (cold launch from a notification tap),
+  // replay it now.
+  if (h && pendingAction) {
+    h(pendingAction);
+    pendingAction = null;
+  }
+}
+
+/**
+ * Called from the push listener when the user taps a notification. Reads the
+ * APN/web-push payload, maps to a navigation action, and routes via the
+ * registered handler.
+ */
+export function dispatchPushAction(payload: unknown): void {
+  if (!payload || typeof payload !== "object") return;
+  const data = payload as { type?: unknown; relatedId?: unknown };
+  if (typeof data.type !== "string") return;
+  const relatedId = typeof data.relatedId === "string" ? data.relatedId : undefined;
+
+  const action = mapPushToNavigateAction(data.type, relatedId);
+  if (!action) return;
+
+  if (handler) {
+    handler(action);
+  } else {
+    // Cold-launch race: push fires before page.tsx registers. Stash the most
+    // recent action and replay when the handler arrives.
+    pendingAction = action;
+  }
+}
+
+/**
+ * Map a notification `type` (from the notifications.type CHECK constraint)
+ * + optional related id to a navigation action.
+ *
+ * Mirrors the routing in NotificationsPanel.tsx click handlers.
+ */
+export function mapPushToNavigateAction(
+  notifType: string,
+  relatedId?: string,
+): NavigateAction | null {
+  if (notifType === "friend_request") return { type: "friends", tab: "add" };
+  if (notifType === "friend_accepted") return { type: "friends", tab: "friends" };
+
+  // Squad-related → squads tab + auto-select the squad.
+  if (
+    notifType === "squad_message" ||
+    notifType === "squad_invite" ||
+    notifType === "squad_mention" ||
+    notifType === "squad_join_request" ||
+    notifType === "poll_created" ||
+    notifType === "date_confirm"
+  ) {
+    return { type: "groups", squadId: relatedId };
+  }
+
+  // Check-related → feed + highlight the check card.
+  if (
+    notifType === "friend_check" ||
+    notifType === "check_response" ||
+    notifType === "check_tag" ||
+    notifType === "check_date_updated" ||
+    notifType === "check_text_updated" ||
+    notifType === "check_comment" ||
+    notifType === "comment_mention"
+  ) {
+    return { type: "feed", checkId: relatedId };
+  }
+
+  // Event-related → feed (no specific card highlight; events scroll into view
+  // via the feed's own logic).
+  if (
+    notifType === "event_down" ||
+    notifType === "friend_event" ||
+    notifType === "event_date_updated" ||
+    notifType === "event_comment" ||
+    notifType === "event_reminder"
+  ) {
+    return { type: "feed" };
+  }
+
+  return null;
+}

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/lib/supabase';
 import { API_BASE } from '@/lib/db';
 import { Capacitor } from '@capacitor/core';
 import { PushNotifications } from '@capacitor/push-notifications';
+import { dispatchPushAction } from '@/lib/pushNavigation';
 
 const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!;
 
@@ -157,9 +158,11 @@ export async function registerNativePush(): Promise<void> {
       console.log('Push received in foreground:', notification);
     });
 
-    // User tapped on a notification
+    // User tapped on a notification — route to the right surface.
     PushNotifications.addListener('pushNotificationActionPerformed', (action) => {
-      console.log('Push action performed:', action);
+      // payload comes in via .notification.data ({ type, relatedId, ... } —
+      // shape matches what lib/push.ts sends as note.payload).
+      dispatchPushAction(action.notification.data);
     });
   } catch (err) {
     console.warn('Native push registration failed:', err);


### PR DESCRIPTION
## Summary
Until now, tapping an iOS push notification just opened the app on whatever screen it was last on. The notification's data payload (`type` + `relatedId`, sent from `lib/push.ts`) was discarded by the `pushNotificationActionPerformed` listener.

This PR routes those taps to the same surface `NotificationsPanel` opens for the equivalent in-app bell row — feed + checkId for `check_response` / `friend_check` / etc., squads + squadId for `squad_message`, friends tab for `friend_request` / `friend_accepted`, etc.

## Implementation

### `src/lib/pushNavigation.ts` (new)
Small registry bridging the React-less push listener to `page.tsx`'s navigation:
- `setPushNavigationHandler(fn | null)` — page.tsx registers a callback on mount, nulls on unmount
- `dispatchPushAction(payload)` — push listener calls this; reads `{type, relatedId}` from the payload, maps to a navigation action, invokes the registered handler
- `mapPushToNavigateAction(type, relatedId)` — pure function with the type-to-route mapping. Mirrors `NotificationsPanel.tsx` exactly so OS-tap and in-app-tap can never drift.

**Cold-launch race**: if a push fires before `page.tsx` mounts (cold launch from a notification tap), the action is stashed in `pendingAction` and replayed when the handler registers.

### `src/lib/pushNotifications.ts`
`pushNotificationActionPerformed` listener now calls `dispatchPushAction(action.notification.data)` instead of just logging.

### `src/app/page.tsx`
Extracted the existing inline `onNavigate` prop body into a `useCallback` (`handleNotificationNavigate`) so it can be reused. Passed to `NotificationsPanel` as before AND registered via `setPushNavigationHandler` in a `useEffect`.

## Note
Same routing logic powers both surfaces. Adding a new notification type now means updating the mapping in `pushNavigation.ts` AND the click handler in `NotificationsPanel.tsx` (one of which we should extract next — both currently maintain duplicate type→route logic).

## Test plan
Requires PR #433 (push entitlements) merged + Apple-portal setup completed first.

- [ ] Build to a real iOS device, sign in, accept push permission
- [ ] On a different account, send a friend request to the test user → push arrives → tap → app opens to friends tab on "Add" sub-tab
- [ ] Have a friend post a check → push arrives → tap → app opens to feed with that check highlighted
- [ ] Send a squad message → push arrives → tap → app opens to squads tab + auto-selects the squad
- [ ] Cold-launch test: kill the app, send a notification, tap it → app launches → routes correctly (pendingAction replay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)