### PR TITLE
fix: drop XML comment from App.entitlements (Xcode build error)

### DIFF
--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -2,16 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTD/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!--
-	  aps-environment is required for the Push Notifications capability.
-	  Value notes:
-	    "development" — works for Xcode debug builds + TestFlight via dev profile.
-	    "production"  — required only for App Store distribution. Xcode swaps
-	                    this automatically when archiving with a distribution
-	                    provisioning profile (default behavior with automatic
-	                    code signing), so leaving "development" here is fine
-	                    for both local builds and App Store releases.
-	-->
 	<key>aps-environment</key>
 	<string>development</string>
 </dict>


### PR DESCRIPTION
## Summary
Xcode rewrites entitlements plists to canonical form during the build (strips comments, normalizes whitespace). The explanatory comment added in #433 tripped Xcode's "entitlements file modified during the build" guard, killing the build with:

> Entitlements file "App.entitlements" was modified during the build, which is not supported.

`ios/PUSH_SETUP.md` already covers the development-vs-production distinction; the inline comment was redundant and now actively breaking local builds. Drop it.

## Test plan
- [ ] Run from Xcode → build succeeds, no "entitlements file modified" error
- [ ] On a real device, the Push Notifications capability still resolves correctly (smoke test from PUSH_SETUP.md still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)