### PR TITLE
feat: dev-only user switcher for two-user manual testing

### DIFF
--- a/src/app/api/dev/switch-user/route.ts
+++ b/src/app/api/dev/switch-user/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { getServiceClient } from '@/lib/supabase-admin';
+
+/**
+ * Dev-only instant sign-in for two-user manual testing.
+ *
+ * Mints a one-time OTP via the service-role admin API for an *@test.com email
+ * and returns it to the caller, who signs in with verifyOtp(). No real email
+ * is sent. Lets you flip between test accounts in two browser windows without
+ * OTP friction.
+ *
+ * Defense in depth — this route MUST never be reachable in prod:
+ *   1. NODE_ENV gate: returns 404 in any non-development build (Vercel
+ *      preview/prod set NODE_ENV=production).
+ *   2. Allowlist gate: only @test.com addresses are honored. Even if (1) ever
+ *      regressed, real user accounts still couldn't be hijacked.
+ */
+export async function POST(request: Request) {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  let body: { email?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const email = body.email?.trim().toLowerCase();
+  if (!email || !/^[^\s@]+@test\.com$/.test(email)) {
+    return NextResponse.json(
+      { error: 'Email must match *@test.com' },
+      { status: 403 },
+    );
+  }
+
+  const admin = getServiceClient();
+  const { data, error } = await admin.auth.admin.generateLink({
+    type: 'magiclink',
+    email,
+  });
+
+  if (error || !data?.properties?.email_otp) {
+    return NextResponse.json(
+      { error: error?.message ?? 'Failed to generate link' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ email, otp: data.properties.email_otp });
+}

--- a/src/app/components/DevUserSwitcher.tsx
+++ b/src/app/components/DevUserSwitcher.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { supabase } from "@/lib/supabase";
+
+/** Hand-picked roster — covers the "you + a friend" case for most flows.
+ *  Expand as new test fixtures land. The server route also checks @test.com,
+ *  so additions here must match that pattern. */
+const TEST_USERS = [
+  "kat@test.com",
+  "testuser2@test.com",
+  "sara@test.com",
+  "leo@test.com",
+  "river@test.com",
+  "devon@test.com",
+];
+
+const DevUserSwitcher = () => {
+  const [currentEmail, setCurrentEmail] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (alive) setCurrentEmail(data.user?.email ?? null);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (alive) setCurrentEmail(session?.user?.email ?? null);
+    });
+    return () => { alive = false; sub.subscription.unsubscribe(); };
+  }, []);
+
+  const switchTo = async (email: string) => {
+    setBusy(email);
+    setError(null);
+    try {
+      const res = await fetch("/api/dev/switch-user", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+
+      await supabase.auth.signOut();
+      const { error: verifyErr } = await supabase.auth.verifyOtp({
+        email: body.email,
+        token: body.otp,
+        type: "email",
+      });
+      if (verifyErr) throw verifyErr;
+
+      // Full reload so every hook re-fetches under the new session, including
+      // server components and useAuth's initial bootstrap path.
+      window.location.reload();
+    } catch (err) {
+      setBusy(null);
+      setError(err instanceof Error ? err.message : "Switch failed");
+    }
+  };
+
+  return (
+    <div
+      className="fixed bottom-4 right-4 z-[300] font-mono text-xs select-none"
+      style={{ pointerEvents: "auto" }}
+    >
+      {open && (
+        <div
+          className="mb-2 rounded-xl border border-border bg-surface p-2 shadow-2xl"
+          style={{ minWidth: 200 }}
+        >
+          <div className="px-2 pb-2 text-[10px] uppercase tracking-widest text-dim">
+            Switch to
+          </div>
+          {TEST_USERS.filter((e) => e !== currentEmail).map((email) => (
+            <button
+              key={email}
+              disabled={!!busy}
+              onClick={() => switchTo(email)}
+              className="block w-full text-left px-2 py-1.5 rounded-lg hover:bg-deep disabled:opacity-50 cursor-pointer text-primary"
+            >
+              {busy === email ? `signing in as ${email}…` : email}
+            </button>
+          ))}
+          {error && (
+            <div className="px-2 pt-2 text-[10px] text-red-500 break-words">
+              {error}
+            </div>
+          )}
+        </div>
+      )}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="rounded-full border border-border bg-surface px-3 py-2 shadow-2xl flex items-center gap-2 cursor-pointer text-primary"
+      >
+        <span className="text-[10px] uppercase tracking-widest text-dim">dev</span>
+        <span className="truncate max-w-[160px]">{currentEmail ?? "(signed out)"}</span>
+        <span className="text-dim">{open ? "▾" : "▸"}</span>
+      </button>
+    </div>
+  );
+};
+
+export default DevUserSwitcher;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Inter } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
+import DevUserSwitcher from '@/app/components/DevUserSwitcher';
 import UpdateBanner from '@/app/components/UpdateBanner';
 import Grain from '@/app/components/Grain';
 import ThemeHydrator from '@/app/components/ThemeHydrator';
@@ -100,6 +101,7 @@ export default function RootLayout({
         <div className="mx-auto flex w-full max-w-105 flex-col">
           {children}
         </div>
+        {process.env.NODE_ENV === 'development' && <DevUserSwitcher />}
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Floating bottom-right pill in dev that swaps the auth session to any `*@test.com` user in one click — no OTP, no email.
- Server route `POST /api/dev/switch-user` mints a one-time code via `auth.admin.generateLink` (service role) and returns it; client calls `verifyOtp` and hard-reloads.
- Mounted in `layout.tsx` behind `NODE_ENV === 'development'` so the import tree-shakes out of prod.

## Why
Manually testing two-user flows (notifications, friend visibility, FoF, squad chat) meant signing out, fetching a code from Mailpit/email, signing back in — for both accounts, repeatedly. This collapses each switch to a single click. Pair it with two browser windows (regular + incognito, or two Chrome profiles) and you've got two sessions side-by-side.

## Defense in depth
1. **NODE_ENV gate** — handler returns 404 in any build where `NODE_ENV !== 'development'` (Vercel preview/prod ship with `NODE_ENV=production`).
2. **Allowlist gate** — only emails matching `^[^\s@]+@test\.com$` are honored. Even if (1) ever regressed, real accounts still couldn't be hijacked.
3. **No client-side service-role exposure** — the service role key never leaves the server.

## Test plan
- [ ] In dev, the floating pill appears bottom-right showing the current user's email
- [ ] Click pill → dropdown of test users (excluding current)
- [ ] Click a user → hard reload, app re-renders signed in as that user
- [ ] Hit `/api/dev/switch-user` with a non-`@test.com` email → 403
- [ ] Build with `NODE_ENV=production` (or check Vercel preview): pill is absent and `/api/dev/switch-user` returns 404
- [ ] Two browser windows (regular + incognito) can each hold an independent session and switch independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)