### PR TITLE
feat: funny screen when tapping a notification for a deleted check

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ import BottomNav from "@/app/components/BottomNav";
 import FriendRequestBanner, { FRIEND_REQUEST_BANNER_HEIGHT_PX } from "@/app/components/FriendRequestBanner";
 import Toast from "@/app/components/Toast";
 import NotificationsPanel from "@/features/notifications/components/NotificationsPanel";
+import DeletedCheckScreen from "@/features/checks/components/DeletedCheckScreen";
 import { useAuth } from "@/features/auth/hooks/useAuth";
 import { useToast } from "@/app/hooks/useToast";
 import { usePushNotifications } from "@/features/auth/hooks/usePushNotifications";
@@ -74,6 +75,7 @@ export default function Home() {
 
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [addModalDefaultMode, setAddModalDefaultMode] = useState<"paste" | "idea" | "manual" | null>(null);
+  const [deletedCheckScreenOpen, setDeletedCheckScreenOpen] = useState(false);
 
   // ─── Misc page-level state ──────────────────────────────────────────────
   const [selectedSquad, setSelectedSquad] = useState<Squad | null>(null);
@@ -1070,7 +1072,13 @@ export default function Home() {
         userId={userId}
         setUnreadCount={notificationsHook.setUnreadCount}
         friends={friendsHook.friends}
+        onDeletedCheck={() => setDeletedCheckScreenOpen(true)}
         onNavigate={handleNotificationNavigate}
+      />
+
+      <DeletedCheckScreen
+        open={deletedCheckScreenOpen}
+        onClose={() => setDeletedCheckScreenOpen(false)}
       />
 
       <EditEventModal

--- a/src/features/checks/components/DeletedCheckScreen.tsx
+++ b/src/features/checks/components/DeletedCheckScreen.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+import { useModalTransition } from "@/shared/hooks/useModalTransition";
+
+const EULOGIES = [
+  "they got cold feet. it happens.",
+  "this check has left the chat.",
+  "the check went out for milk and never came back.",
+  "rip. archived. ghosted. yeeted.",
+  "the check has crossed the rainbow bridge.",
+  "404 — vibes not found.",
+  "this check has been moved to a farm upstate.",
+  "the check has gone where all checks go. nowhere.",
+  "abandoned, like new year's resolutions.",
+  "they unchecked. the universe checked back.",
+  "this check is sleeping with the fishes.",
+  "the check ascended to a higher plane (the trash).",
+  "rsvp'd to nothing forever.",
+  "the check unsubscribed from being a check.",
+];
+
+const DISMISSALS = [
+  "oh well",
+  "whatever",
+  "press f",
+  "rip",
+  "such is life",
+  "bummer",
+  "noted",
+  "fair",
+  "moving on",
+  "carry on",
+  "godspeed",
+  "pour one out",
+  "tragic",
+  "respect",
+  "no thoughts",
+  "cool cool",
+  "next",
+];
+
+const DeletedCheckScreen = ({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) => {
+  const { visible, entering, closing, close } = useModalTransition(open, onClose);
+
+  const eulogy = useMemo(
+    () => EULOGIES[Math.floor(Math.random() * EULOGIES.length)],
+    // re-roll each time the screen is opened
+    [open], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+  const dismissal = useMemo(
+    () => DISMISSALS[Math.floor(Math.random() * DISMISSALS.length)],
+    [open], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  useEffect(() => {
+    if (!visible) return;
+    document.body.style.overflow = "hidden";
+    return () => { document.body.style.overflow = ""; };
+  }, [visible]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center px-6">
+      <div
+        onClick={close}
+        className="absolute inset-0 bg-black/70"
+        style={{
+          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          opacity: (entering || closing) ? 0 : 1,
+          transition: "opacity 0.25s ease, backdrop-filter 0.25s ease, -webkit-backdrop-filter 0.25s ease",
+        }}
+      />
+      <div
+        className="relative bg-surface w-full max-w-[360px] rounded-3xl border border-border px-6 py-10 flex flex-col items-center text-center"
+        style={{
+          opacity: (entering || closing) ? 0 : 1,
+          transform: (entering || closing) ? "scale(0.96) translateY(8px)" : "scale(1) translateY(0)",
+          transition: "opacity 0.25s ease-out, transform 0.25s ease-out",
+        }}
+      >
+        <div
+          aria-hidden
+          className="font-serif text-primary mb-4 select-none"
+          style={{ fontSize: 56, lineHeight: 1 }}
+        >
+          ⌑
+        </div>
+        <h2 className="font-serif text-primary font-normal mb-3" style={{ fontSize: 24, lineHeight: 1.15 }}>
+          this check is gone.
+        </h2>
+        <p className="font-mono text-sm text-dim mb-8" style={{ lineHeight: 1.5 }}>
+          {eulogy}
+        </p>
+        <button
+          onClick={close}
+          className="font-mono text-xs uppercase bg-dt text-on-accent border-none rounded-xl cursor-pointer w-full"
+          style={{
+            padding: "12px 16px",
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+          }}
+        >
+          {dismissal}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DeletedCheckScreen;

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -20,6 +20,26 @@ interface Notification {
   created_at: string;
 }
 
+/** Probe the check; if it's archived/deleted, surface the "gone" screen
+ *  instead of dumping the user into a feed where the check no longer appears. */
+function navigateToCheckIfActive(
+  checkId: string | null,
+  onNavigate: (action: { type: "feed"; checkId?: string }) => void,
+  onDeletedCheck: () => void,
+) {
+  if (!checkId) {
+    onNavigate({ type: "feed" });
+    return;
+  }
+  db.isInterestCheckActive(checkId).then((active) => {
+    if (active) onNavigate({ type: "feed", checkId });
+    else onDeletedCheck();
+  }).catch(() => {
+    // Network/DB hiccup — fall back to existing behavior so the user isn't stranded
+    onNavigate({ type: "feed", checkId });
+  });
+}
+
 const NotificationsPanel = ({
   open,
   onClose,
@@ -29,6 +49,7 @@ const NotificationsPanel = ({
   setUnreadCount,
   friends,
   onNavigate,
+  onDeletedCheck,
 }: {
   open: boolean;
   onClose: () => void;
@@ -38,6 +59,7 @@ const NotificationsPanel = ({
   setUnreadCount: React.Dispatch<React.SetStateAction<number>>;
   friends: { id: string }[];
   onNavigate: (action: { type: "friends"; tab: "friends" | "add" } | { type: "groups"; squadId?: string } | { type: "feed"; checkId?: string }) => void;
+  onDeletedCheck: () => void;
 }) => {
   const { visible, entering, closing, close } = useModalTransition(open, onClose);
   const touchStartY = useRef(0);
@@ -245,7 +267,7 @@ const NotificationsPanel = ({
                       setUnreadCount((prev) => Math.max(0, prev - 1));
                     }
                     onClose();
-                    onNavigate({ type: "feed", checkId: n.related_check_id ?? undefined });
+                    navigateToCheckIfActive(n.related_check_id, onNavigate, onDeletedCheck);
                   } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated" || n.type === "check_text_updated") {
                     // Mark single notification as read (except check_tag — cleared on accept/decline)
                     if (!n.is_read && n.type !== "check_tag") {
@@ -256,7 +278,7 @@ const NotificationsPanel = ({
                       setUnreadCount((prev) => Math.max(0, prev - 1));
                     }
                     onClose();
-                    onNavigate({ type: "feed", checkId: n.related_check_id ?? undefined });
+                    navigateToCheckIfActive(n.related_check_id, onNavigate, onDeletedCheck);
                   }
                 }}
                 className={cn(


### PR DESCRIPTION
## Summary
- Tapping a notification for an archived/deleted check now opens a small overlay with a random eulogy + random dismiss button, instead of silently dumping the user into a feed where the check no longer appears.
- 14 eulogies, 17 dismiss buttons, both re-roll on every open.
- Drops back to the existing feed-highlight flow on a network/DB hiccup so nobody gets stranded.

## What's new
- `src/features/checks/components/DeletedCheckScreen.tsx` — full-screen overlay, dim/blur backdrop, centered card. Fades via `useModalTransition`.
- `src/features/notifications/components/NotificationsPanel.tsx` — for the six check-related notification types (`check_response`, `friend_check`, `check_tag`, `check_comment`, `comment_mention`, `check_date_updated`, `check_text_updated`), the click handler now probes the check via `db.isInterestCheckActive` before routing. Gone → `onDeletedCheck()`. Active → existing feed nav.
- `src/app/page.tsx` — mounts the screen and wires `onDeletedCheck`.

## Test plan
- [ ] Tap a check-type notification whose check is archived → DeletedCheckScreen opens with random copy
- [ ] Tap a check-type notification whose check is still active → feed opens, check is highlighted (existing behavior)
- [ ] Open and dismiss the screen multiple times → eulogy and button copy both change
- [ ] Probe failure (kill network mid-tap) → feed nav happens anyway, user isn't stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)