### PR TITLE
fix: profile push toggle is a no-op on Capacitor iOS

### DIFF
--- a/src/features/auth/hooks/usePushNotifications.ts
+++ b/src/features/auth/hooks/usePushNotifications.ts
@@ -1,11 +1,14 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
+import { PushNotifications } from "@capacitor/push-notifications";
 import {
   isPushSupported,
+  isNativePlatform,
   registerServiceWorker,
   subscribeToPush,
   unsubscribeFromPush,
+  registerNativePush,
 } from "@/lib/pushNotifications";
 
 export function usePushNotifications(
@@ -22,16 +25,30 @@ export function usePushNotifications(
     setPushSupported(true);
 
     (async () => {
+      if (isNativePlatform()) {
+        // On native, the OS owns permission state. Mirror it into the toggle.
+        const perm = await PushNotifications.checkPermissions();
+        if (perm.receive === "granted") {
+          setPushEnabled(true);
+        } else if (
+          perm.receive === "prompt" &&
+          !localStorage.getItem("pushAutoPrompted")
+        ) {
+          localStorage.setItem("pushAutoPrompted", "1");
+          const ok = await registerNativePush();
+          if (ok) setPushEnabled(true);
+        }
+        return;
+      }
+
       const reg = await registerServiceWorker();
       if (!reg) return;
       swRegistrationRef.current = reg;
 
-      // Check if already subscribed
       const existing = await reg.pushManager.getSubscription();
       if (existing) {
         setPushEnabled(true);
       } else if (!localStorage.getItem("pushAutoPrompted") && process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY) {
-        // Auto-prompt once after first login
         localStorage.setItem("pushAutoPrompted", "1");
         const sub = await subscribeToPush(reg);
         if (sub) {
@@ -42,6 +59,23 @@ export function usePushNotifications(
   }, [isLoggedIn]);
 
   const handleTogglePush = async () => {
+    if (isNativePlatform()) {
+      if (pushEnabled) {
+        // iOS doesn't let an app revoke its own push permission. Tell the user
+        // where to flip it, since the toggle in our UI can't do it directly.
+        showToast("Disable in iOS Settings → downto → Notifications");
+        return;
+      }
+      const ok = await registerNativePush();
+      if (ok) {
+        setPushEnabled(true);
+        showToast("Push notifications enabled!");
+      } else {
+        showToast("Push permission denied — enable in iOS Settings → downto");
+      }
+      return;
+    }
+
     const reg = swRegistrationRef.current;
     if (!reg) return;
 


### PR DESCRIPTION
## Summary
The "Push Notifications" row on the profile screen did nothing when tapped on the native iOS app. `usePushNotifications` was 100% web-push: it called `registerServiceWorker()` in `useEffect` (returns null on Capacitor — WKWebView has no service workers), so `swRegistrationRef` stayed null and `handleTogglePush` early-returned with no UX feedback.

Same bug shape as the onboarding screen we just fixed in #433 — different surface.

Branch on `isNativePlatform()`:
- Initial state mirrors `PushNotifications.checkPermissions()` so the toggle reflects OS truth on mount.
- Auto-prompt-once path calls `registerNativePush()` (matches the onboarding screen).
- Toggle-on calls `registerNativePush()`; toggle-off explains where to flip the permission since iOS doesn't let an app programmatically revoke its own push permission.

## Test plan
- [ ] Native iOS, fresh install, never granted: open Profile → tap Push Notifications → permission prompt appears → Allow → toggle shows ✓ Enabled
- [ ] Native iOS, permission already granted: open Profile → toggle shows ✓ Enabled on mount
- [ ] Native iOS, permission denied: tap Push Notifications → toast points user to iOS Settings
- [ ] Web (PWA / browser): existing behavior unchanged — service worker subscribe/unsubscribe

🤖 Generated with [Claude Code](https://claude.com/claude-code)