### PR TITLE
chore: add npm run ios:fresh — clean-slate iOS install loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build:capacitor": "bash scripts/build-capacitor.sh",
     "cap:sync": "npx cap sync ios",
     "start": "next start",
-    "test": "echo 'Unit tests disabled'"
+    "test": "echo 'Unit tests disabled'",
+    "ios:fresh": "bash scripts/ios-fresh.sh"
   },
   "keywords": [],
   "author": "",

--- a/scripts/ios-fresh.sh
+++ b/scripts/ios-fresh.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Clean-slate iOS build + install on a connected iPhone.
+#
+# Useful when iterating on permission/registration flows where iOS caches the
+# previous answer (push notifications, tracking, location, etc.). This script
+# uninstalls the app first so the next launch behaves like a fresh install.
+#
+# Steps:
+#   1. Find the first connected iPhone via `xcrun devicectl`.
+#   2. Uninstall xyz.downto.app from that device.
+#   3. Run npm run build:capacitor (next build → static export → cap sync).
+#   4. xcodebuild → produce a Debug .app for arm64-apple-ios.
+#   5. Install + launch the .app on the device.
+#
+# Requirements: Xcode 15+ (for devicectl), jq, automatic code signing
+# already configured in Xcode at least once.
+
+set -euo pipefail
+
+BUNDLE_ID="xyz.downto.app"
+SCHEME="App"
+PROJECT="ios/App/App.xcodeproj"
+DERIVED_DATA="/tmp/downto-ios-fresh"
+
+step() { printf "\n\033[1;36m▸ %s\033[0m\n" "$1"; }
+fail() { printf "\033[1;31m✖ %s\033[0m\n" "$1" >&2; exit 1; }
+
+command -v jq >/dev/null || fail "jq not installed (brew install jq)"
+command -v xcodebuild >/dev/null || fail "xcodebuild not on PATH"
+
+step "Finding connected iOS device"
+DEVICES_JSON=$(mktemp)
+trap 'rm -f "$DEVICES_JSON"' EXIT
+xcrun devicectl list devices --json-output "$DEVICES_JSON" >/dev/null
+
+DEVICE_ID=$(jq -r '
+  .result.devices[]
+  | select(.connectionProperties.tunnelState == "connected")
+  | select(.hardwareProperties.platform == "iOS")
+  | .identifier
+' "$DEVICES_JSON" | head -1)
+
+[ -n "$DEVICE_ID" ] || fail "No connected iOS device. Plug in an iPhone, unlock it, trust the Mac."
+
+DEVICE_NAME=$(jq -r --arg id "$DEVICE_ID" '
+  .result.devices[] | select(.identifier == $id) | .deviceProperties.name
+' "$DEVICES_JSON")
+echo "  $DEVICE_NAME ($DEVICE_ID)"
+
+step "Uninstalling $BUNDLE_ID"
+xcrun devicectl device uninstall app --device "$DEVICE_ID" "$BUNDLE_ID" 2>/dev/null \
+  || echo "  (not installed; skipping)"
+
+step "Building Capacitor web bundle"
+npm run build:capacitor
+
+step "Building iOS app (Debug, device arm64)"
+xcodebuild \
+  -project "$PROJECT" \
+  -scheme "$SCHEME" \
+  -configuration Debug \
+  -destination "id=$DEVICE_ID" \
+  -derivedDataPath "$DERIVED_DATA" \
+  -allowProvisioningUpdates \
+  build \
+  | xcbeautify 2>/dev/null || xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration Debug \
+    -destination "id=$DEVICE_ID" \
+    -derivedDataPath "$DERIVED_DATA" \
+    -allowProvisioningUpdates \
+    build
+
+APP_PATH="$DERIVED_DATA/Build/Products/Debug-iphoneos/App.app"
+[ -d "$APP_PATH" ] || fail "Build did not produce $APP_PATH"
+
+step "Installing on $DEVICE_NAME"
+xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH"
+
+step "Launching $BUNDLE_ID"
+xcrun devicectl device process launch --device "$DEVICE_ID" "$BUNDLE_ID"
+
+printf "\n\033[1;32m✔ Fresh install running on %s\033[0m\n" "$DEVICE_NAME"
+echo "Open Web Inspector (Safari → Develop → $DEVICE_NAME → App) to debug."


### PR DESCRIPTION
## Summary
Iterating on permission/registration flows (push, tracking, location) needs the app to forget the previous "Don't Allow" answer between runs. The current loop is: long-press app on home screen → Delete → \`npm run build:capacitor\` → click Run in Xcode → wait for install. Tedious.

\`scripts/ios-fresh.sh\` automates it with the modern Xcode 15+ tooling:
- \`xcrun devicectl\` finds the first connected iPhone
- uninstalls \`xyz.downto.app\` (ignored if not installed)
- \`npm run build:capacitor\` (next build + cap sync)
- \`xcodebuild\` produces a Debug \`.app\`
- \`devicectl\` installs + launches it

Wired up as \`npm run ios:fresh\` so the daily flow is a single command followed by opening Web Inspector for the new WebView.

## Test plan
- [ ] iPhone plugged in + trusted: \`npm run ios:fresh\` uninstalls, rebuilds, installs, launches with no manual Xcode click
- [ ] Permission state is fresh — system push prompt fires at the expected point
- [ ] Helpful error if no device connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)