### PR TITLE
feat: unify check delete + notify down responders on archive

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -386,34 +386,16 @@ export default function CheckCard({
         friends={friendsList}
         hasSquad={!!check.squadId}
         onShare={(check.isYours || check.isCoAuthor) ? () => { setEditModalOpen(false); shareCheck(); } : undefined}
-        onArchive={(check.isYours || check.isCoAuthor) ? async () => {
-          setEditModalOpen(false);
-          try { await db.archiveInterestCheck(check.id); } catch (err) { logError("archiveCheck", err, { checkId: check.id }); }
-          await loadRealData();
-          if (showToastWithAction) {
-            showToastWithAction("Check archived — undo?", async () => {
-              try { await db.unarchiveInterestCheck(check.id); } catch (err) { logError("unarchiveCheck", err, { checkId: check.id }); }
-              await loadRealData();
-            });
-          } else {
-            showToast("Check archived");
-          }
-        } : undefined}
         onDelete={(check.isYours || check.isCoAuthor) ? async () => {
           setEditModalOpen(false);
           try { await db.archiveInterestCheck(check.id); } catch (err) { logError("archiveCheck", err, { checkId: check.id }); }
           await loadRealData();
           if (showToastWithAction) {
-            const timer = setTimeout(async () => {
-              try { await db.deleteInterestCheck(check.id); } catch (err) { logError("deleteCheck", err, { checkId: check.id }); }
-            }, 4500);
             showToastWithAction("Check removed — undo?", async () => {
-              clearTimeout(timer);
               try { await db.unarchiveInterestCheck(check.id); } catch (err) { logError("unarchiveCheck", err, { checkId: check.id }); }
               await loadRealData();
             });
           } else {
-            try { await db.deleteInterestCheck(check.id); } catch (err) { logError("deleteCheck", err, { checkId: check.id }); }
             showToast("Check removed");
           }
         } : undefined}

--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -16,7 +16,6 @@ const EditCheckModal = ({
   onTagFriend,
   onRemoveTag,
   onShare,
-  onArchive,
   onDelete,
   hasSquad,
 }: {
@@ -37,7 +36,6 @@ const EditCheckModal = ({
   onTagFriend?: (checkId: string, friendId: string) => Promise<void>;
   onRemoveTag?: (checkId: string, userId: string) => Promise<void>;
   onShare?: () => void;
-  onArchive?: () => void;
   onDelete?: () => void;
   hasSquad?: boolean;
 }) => {
@@ -281,8 +279,8 @@ const EditCheckModal = ({
           )}
           {!whenPreview && <div className="mb-2" />}
 
-          {/* Action row: Share / Archive / Delete */}
-          {(onShare || onArchive || onDelete) && (
+          {/* Action row: Share / Delete */}
+          {(onShare || onDelete) && (
             <div className="flex flex-col gap-0 border-t border-border mt-3">
               {onShare && (
                 <button
@@ -294,18 +292,6 @@ const EditCheckModal = ({
                     <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor"><path d="M137.54,186.36a8,8,0,0,1,0,11.31l-9.94,10A56,56,0,0,1,48.38,128.4L72.5,104.28A56,56,0,0,1,149.31,102a8,8,0,1,1-10.64,12,40,40,0,0,0-54.85,1.63L59.7,139.72a40,40,0,0,0,56.58,56.58l9.94-9.94A8,8,0,0,1,137.54,186.36Zm70.08-138a56.08,56.08,0,0,0-79.22,0l-9.94,9.95a8,8,0,0,0,11.32,11.31l9.94-9.94a40,40,0,0,1,56.58,56.58L172.18,140.4A40,40,0,0,1,117.33,142,8,8,0,1,0,106.69,154a56,56,0,0,0,76.81-2.26l24.12-24.12A56.08,56.08,0,0,0,207.62,48.38Z"/></svg>
                   </span>
                   Share link
-                </button>
-              )}
-              {onArchive && (
-                <button
-                  onClick={onArchive}
-                  className="flex items-center gap-3 w-full bg-transparent border-none border-b border-border py-3.5 font-mono text-sm cursor-pointer text-left text-primary"
-                  style={{ borderBottom: `1px solid ${color.border}` }}
-                >
-                  <span className="w-6 flex items-center justify-center shrink-0">
-                    <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor"><path d="M216,40H40A16,16,0,0,0,24,56V88a16,16,0,0,0,16,16v88a16,16,0,0,0,16,16H200a16,16,0,0,0,16-16V104a16,16,0,0,0,16-16V56A16,16,0,0,0,216,40ZM200,192H56V104H200v88Zm16-104H40V56H216v32ZM104,136a8,8,0,0,1,8-8h32a8,8,0,0,1,0,16H112A8,8,0,0,1,104,136Z"/></svg>
-                  </span>
-                  Archive
                 </button>
               )}
               {onDelete && !hasSquad && (

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -268,7 +268,7 @@ const NotificationsPanel = ({
                     }
                     onClose();
                     navigateToCheckIfActive(n.related_check_id, onNavigate, onDeletedCheck);
-                  } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated" || n.type === "check_text_updated") {
+                  } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated" || n.type === "check_text_updated" || n.type === "check_archived") {
                     // Mark single notification as read (except check_tag — cleared on accept/decline)
                     if (!n.is_read && n.type !== "check_tag") {
                       if (userId) db.markNotificationRead(n.id);
@@ -303,6 +303,7 @@ const NotificationsPanel = ({
                       : n.type === "check_text_updated" ? "#E8FF5A22"
                       : n.type === "event_date_updated" ? "#E8FF5A22"
                       : n.type === "event_comment" ? "#5AC8FA22"
+                      : n.type === "check_archived" ? "#FF444422"
                       : "#5856D622",
                   }}
                 >
@@ -343,6 +344,9 @@ const NotificationsPanel = ({
                       case "check_text_updated":
                         // Pencil
                         return <svg {...iconProps}><path d="M227.31,73.37,182.63,28.68a16,16,0,0,0-22.63,0L36.69,152A15.86,15.86,0,0,0,32,163.31V208a16,16,0,0,0,16,16H92.69A15.86,15.86,0,0,0,104,219.31L227.31,96a16,16,0,0,0,0-22.63ZM92.69,208H48V163.31l88-88L180.69,120ZM192,108.68,147.31,64l24-24L216,84.68Z"/></svg>;
+                      case "check_archived":
+                        // Trash
+                        return <svg {...iconProps}><path d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"/></svg>;
                       default:
                         // ChatTeardrop
                         return <svg {...iconProps}><path d="M132,24A100.11,100.11,0,0,0,32,124v84a16,16,0,0,0,16,16h84a100,100,0,0,0,0-200Zm0,184H48V124a84,84,0,1,1,84,84Z"/></svg>;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -815,16 +815,6 @@ export async function createInterestCheck(
   return data;
 }
 
-export async function deleteInterestCheck(checkId: string): Promise<void> {
-  const { error } = await supabase
-    .from('interest_checks')
-    .delete()
-    .eq('id', checkId);
-  // RLS policy allows author and accepted co-authors
-
-  if (error) throw error;
-}
-
 /** Returns true if the check still exists and is not archived. */
 export async function isInterestCheckActive(checkId: string): Promise<boolean> {
   const { data } = await supabase
@@ -835,12 +825,13 @@ export async function isInterestCheckActive(checkId: string): Promise<boolean> {
   return !!data && !data.archived_at;
 }
 
+/** Archive a check via SECURITY DEFINER RPC. The RPC also fires
+ *  `check_archived` notifications to "down" responders in the same tx.
+ *  Re-archiving an already-archived row is a silent no-op server-side. */
 export async function archiveInterestCheck(checkId: string): Promise<void> {
-  const { error } = await supabase
-    .from('interest_checks')
-    .update({ archived_at: new Date().toISOString() })
-    .eq('id', checkId);
-
+  const { error } = await supabase.rpc('archive_interest_check', {
+    p_check_id: checkId,
+  });
   if (error) throw error;
 }
 

--- a/supabase/migrations/20260425000002_archive_check_rpc_and_notify.sql
+++ b/supabase/migrations/20260425000002_archive_check_rpc_and_notify.sql
@@ -1,0 +1,113 @@
+-- Unify the check delete/archive flow on a SECURITY DEFINER RPC and notify
+-- the people who actually committed (responded "down") that the plan is off.
+--
+-- Why an RPC instead of the existing client-side UPDATE:
+--   1. The current archive UPDATE 42501s on staging — the consolidated SELECT
+--      policy from 20260424000001 requires check_is_active (archived_at IS
+--      NULL), which Postgres enforces as additional WITH CHECK on UPDATE, so
+--      flipping archived_at non-null trips it. PR #430 was an incomplete fix
+--      (Sentry DOWNTO-A is still open). SECURITY DEFINER sidesteps the
+--      visibility policy entirely while we keep the auth check explicit.
+--   2. We want archive + notification insert in a single transaction, so the
+--      recipient never sees the notification for a not-yet-archived row.
+--
+-- Recipients are scoped to "down" responders only. friend_check already went
+-- out at create time to all friends; firing another check_archived to that
+-- broader set on every cancel would be noisy. Down responders are the people
+-- who said they were coming — they're the ones who care that the plan is off.
+
+
+-- 1. Extend the notifications.type CHECK constraint.
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN (
+    'friend_request', 'friend_accepted', 'check_response',
+    'squad_message', 'squad_invite', 'friend_check', 'date_confirm',
+    'check_tag', 'check_comment', 'poll_created', 'squad_join_request',
+    'squad_mention', 'comment_mention', 'friend_event', 'event_reminder',
+    'event_down', 'check_date_updated', 'event_date_updated',
+    'check_text_updated',
+    'check_archived'
+  ));
+
+
+-- 2. archive_interest_check(p_check_id) — SECURITY DEFINER.
+--    Auth: caller must be the author or an accepted co-author.
+--    Effect: sets archived_at = now() if not already, then inserts a
+--    check_archived notification per "down" responder (excluding the author)
+--    with a randomly chosen phrase. Idempotent — re-archiving an already
+--    archived row is a no-op.
+CREATE OR REPLACE FUNCTION public.archive_interest_check(p_check_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller UUID := (SELECT auth.uid());
+  v_author_id UUID;
+  v_text TEXT;
+  v_phrase TEXT;
+  v_recipient UUID;
+  v_phrases TEXT[] := ARRAY[
+    'the check got deleted',
+    'rip — they bailed',
+    'this one is off the table',
+    'cancelled. it happens.',
+    'the check disintegrated',
+    'plan dissolved',
+    'they pulled the plug',
+    'check went poof',
+    'the check has left the building',
+    'scratch that one'
+  ];
+BEGIN
+  IF v_caller IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT author_id, text INTO v_author_id, v_text
+  FROM public.interest_checks
+  WHERE id = p_check_id;
+
+  IF v_author_id IS NULL THEN
+    RAISE EXCEPTION 'Check not found';
+  END IF;
+
+  IF v_author_id <> v_caller AND NOT public.is_check_coauthor(p_check_id, v_caller) THEN
+    RAISE EXCEPTION 'Not authorized to archive this check';
+  END IF;
+
+  -- Only proceed if currently active. Re-archiving is a silent no-op so
+  -- duplicate clicks don't fan out duplicate notifications.
+  UPDATE public.interest_checks
+    SET archived_at = now()
+    WHERE id = p_check_id AND archived_at IS NULL;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  FOR v_recipient IN
+    SELECT user_id FROM public.check_responses
+    WHERE check_id = p_check_id
+      AND response = 'down'
+      AND user_id <> v_author_id
+  LOOP
+    v_phrase := v_phrases[1 + floor(random() * array_length(v_phrases, 1))::int];
+    INSERT INTO public.notifications (
+      user_id, type, title, body, related_user_id, related_check_id
+    )
+    VALUES (
+      v_recipient,
+      'check_archived',
+      v_phrase,
+      LEFT(COALESCE(v_text, 'a check'), 120),
+      v_author_id,
+      p_check_id
+    );
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.archive_interest_check(UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- Single **Delete** button on the edit sheet — soft archive only, no more hidden 4.5s hard-delete timer. Toast undo still works.
- Archive now goes through a SECURITY DEFINER RPC (`archive_interest_check`) that fans out **`check_archived`** notifications to "down" responders in the same transaction.
- Trash icon for the new notification type; tap routes through the existing probe → DeletedCheckScreen (#437).

## Why this shape

**One button.** Two near-identical buttons (Archive vs Delete) confused the data model. Soft-delete only is the simpler thing for the user *and* sets up the revive flow that's next.

**RPC instead of direct UPDATE.** The client-side archive 42501s on staging (Sentry DOWNTO-A still open after #430). The consolidated SELECT policy from `20260424000001` requires `check_is_active`, and Postgres enforces SELECT USING as additional WITH CHECK on UPDATE — so flipping `archived_at` non-null trips the check. SECURITY DEFINER sidesteps the visibility policy without weakening it. The RPC also does an explicit author/co-author auth check, then runs both the update and the notification fan-out in one transaction, so a recipient can't see the notification before the row is actually archived.

**Recipients = "down" responders.** Not all friends — they already got `friend_check` at create time, and another notification on every cancel would be noisy. Down responders are the ones who said they were coming.

**Random phrases server-side.** Picked from a SQL array on each notification insert ("the check got deleted", "rip — they bailed", "scratch that one", etc.) so the notification feed doesn't read like a stack of identical bullets.

**Idempotent server-side.** Re-calling `archive_interest_check` on an already-archived row is a no-op, so duplicate clicks can't fan out duplicate notifications.

## Files
- `supabase/migrations/20260425000002_archive_check_rpc_and_notify.sql` — the RPC + the new `check_archived` value on `notifications.type`
- `src/lib/db.ts` — `archiveInterestCheck` calls the RPC; removed the dead `deleteInterestCheck` wrapper
- `src/features/checks/components/EditCheckModal.tsx` — drop the Archive button + `onArchive` prop
- `src/features/checks/components/CheckCard.tsx` — collapse the two handlers into one Delete handler (no hard-delete timer)
- `src/features/notifications/components/NotificationsPanel.tsx` — route `check_archived` through the active probe (→ DeletedCheckScreen on archived); trash icon, red-tinted bg

## Test plan
- [ ] Edit modal shows only Share + Delete (no Archive)
- [ ] Tap Delete on your own check → toast appears; check is archived; "down" responders get a `check_archived` notification with a random phrase
- [ ] Tap Undo → check is back; notifications stay (out of scope to clean up here — next PR with the revive flow handles undo de-dup)
- [ ] Tap a `check_archived` notification → DeletedCheckScreen opens
- [ ] Same check archived twice in quick succession → only one `check_archived` notification per recipient (idempotency)
- [ ] Non-author calling the RPC directly → 4xx with "Not authorized"

## Follow-up
Revive flow PR is next: tap-on-own `check_archived` opens DeletedCheckScreen with a "revive it" button that re-activates the check and sends `check_revived` notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)