### PR TITLE
fix: ios:fresh now resolves the right device ID for xcodebuild

### DIFF
--- a/scripts/ios-fresh.sh
+++ b/scripts/ios-fresh.sh
@@ -29,26 +29,43 @@ command -v jq >/dev/null || fail "jq not installed (brew install jq)"
 command -v xcodebuild >/dev/null || fail "xcodebuild not on PATH"
 
 step "Finding connected iOS device"
+# Apple ships two ID systems for iPhones and they don't agree:
+#   • xcodebuild speaks the hardware UDID (ECID-style, e.g. 00008150-001A11E41A20401C)
+#   • devicectl speaks a CoreDevice tunnel UUID (e.g. 0A27B33C-A981-...)
+# We need both: UDID for xcodebuild, CoreDevice UUID for install/launch.
+
+# Hardware UDID — parse from xctrace's "Name (OS) (UDID)" lines, skipping
+# simulators which xctrace lists in a separate "== Simulators ==" section.
+# Hardware UDIDs are 8-hex / 16-hex (e.g. 00008150-001A11E41A20401C); sim UUIDs
+# are standard 8-4-4-4-12 and don't match this pattern.
+BUILD_UDID=$(xcrun xctrace list devices 2>&1 \
+  | sed '/^== Simulators ==/,$d' \
+  | grep -oE '[0-9A-F]{8}-[0-9A-F]{16}' \
+  | head -1)
+[ -n "$BUILD_UDID" ] || fail "No physical iOS device. Plug in an iPhone, unlock it, trust the Mac."
+
+# CoreDevice UUID for install/launch
 DEVICES_JSON=$(mktemp)
 trap 'rm -f "$DEVICES_JSON"' EXIT
 xcrun devicectl list devices --json-output "$DEVICES_JSON" >/dev/null
 
-DEVICE_ID=$(jq -r '
+CORE_ID=$(jq -r '
   .result.devices[]
   | select(.connectionProperties.tunnelState == "connected")
   | select(.hardwareProperties.platform == "iOS")
   | .identifier
 ' "$DEVICES_JSON" | head -1)
+[ -n "$CORE_ID" ] || fail "Device visible to xctrace but not devicectl. Try \`xcrun devicectl list devices\` and check the cable/trust prompt."
 
-[ -n "$DEVICE_ID" ] || fail "No connected iOS device. Plug in an iPhone, unlock it, trust the Mac."
-
-DEVICE_NAME=$(jq -r --arg id "$DEVICE_ID" '
+DEVICE_NAME=$(jq -r --arg id "$CORE_ID" '
   .result.devices[] | select(.identifier == $id) | .deviceProperties.name
 ' "$DEVICES_JSON")
-echo "  $DEVICE_NAME ($DEVICE_ID)"
+echo "  $DEVICE_NAME"
+echo "  build UDID: $BUILD_UDID"
+echo "  core UUID:  $CORE_ID"
 
 step "Uninstalling $BUNDLE_ID"
-xcrun devicectl device uninstall app --device "$DEVICE_ID" "$BUNDLE_ID" 2>/dev/null \
+xcrun devicectl device uninstall app --device "$CORE_ID" "$BUNDLE_ID" 2>/dev/null \
   || echo "  (not installed; skipping)"
 
 step "Building Capacitor web bundle"
@@ -59,7 +76,7 @@ xcodebuild \
   -project "$PROJECT" \
   -scheme "$SCHEME" \
   -configuration Debug \
-  -destination "id=$DEVICE_ID" \
+  -destination "id=$BUILD_UDID" \
   -derivedDataPath "$DERIVED_DATA" \
   -allowProvisioningUpdates \
   build \
@@ -67,7 +84,7 @@ xcodebuild \
     -project "$PROJECT" \
     -scheme "$SCHEME" \
     -configuration Debug \
-    -destination "id=$DEVICE_ID" \
+    -destination "id=$BUILD_UDID" \
     -derivedDataPath "$DERIVED_DATA" \
     -allowProvisioningUpdates \
     build
@@ -76,10 +93,10 @@ APP_PATH="$DERIVED_DATA/Build/Products/Debug-iphoneos/App.app"
 [ -d "$APP_PATH" ] || fail "Build did not produce $APP_PATH"
 
 step "Installing on $DEVICE_NAME"
-xcrun devicectl device install app --device "$DEVICE_ID" "$APP_PATH"
+xcrun devicectl device install app --device "$CORE_ID" "$APP_PATH"
 
 step "Launching $BUNDLE_ID"
-xcrun devicectl device process launch --device "$DEVICE_ID" "$BUNDLE_ID"
+xcrun devicectl device process launch --device "$CORE_ID" "$BUNDLE_ID"
 
 printf "\n\033[1;32m✔ Fresh install running on %s\033[0m\n" "$DEVICE_NAME"
 echo "Open Web Inspector (Safari → Develop → $DEVICE_NAME → App) to debug."


### PR DESCRIPTION
## Summary
The first cut of \`scripts/ios-fresh.sh\` (#439) fed \`devicectl\`'s CoreDevice tunnel UUID (e.g. \`0A27B33C-...\`) into \`xcodebuild\`, which doesn't recognize that ID system. \`xcodebuild\` speaks the hardware UDID (\`00008150-001A11E41A20401C\`, ECID format), so it failed with "Unable to find a device matching the provided destination specifier" and dumped the full simulator list.

Apple ships two ID systems for connected iPhones and they don't agree:
- \`xcodebuild\` → hardware UDID (8-hex / 16-hex)
- \`devicectl\` → CoreDevice tunnel UUID (standard 8-4-4-4-12)

Now the script resolves both:
- \`BUILD_UDID\` via \`xcrun xctrace list devices\` for the xcodebuild destination
- \`CORE_ID\` via \`xcrun devicectl list devices --json-output\` for install / launch

The xctrace parser uses \`sed\` to lop off the simulator section (BSD awk on macOS doesn't support \`match()\` with capture groups, so awk-based extraction wasn't portable). Hardware UDIDs are easy to disambiguate from sim UUIDs by regex shape.

Confirmed end-to-end on a real device: build → install → launch all succeed in one \`npm run ios:fresh\`.

## Test plan
- [x] \`npm run ios:fresh\` with a connected iPhone → uninstalls, builds, installs, launches
- [x] Friendly error if no physical iOS device is connected
- [ ] Behaves sensibly with multiple connected iPhones (picks the first; explicit device override could come later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)