### PR TITLE
fix: don't show 'install the app' screen inside the native iOS app

### DIFF
--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -22,6 +22,11 @@ export function isIOS(): boolean {
 
 export function isIOSNotStandalone(): boolean {
   if (!isIOS()) return false;
+  // Capacitor's WKWebView reports an iOS UA but neither navigator.standalone
+  // nor display-mode:standalone — without this guard we'd flag the native
+  // app as "iOS Safari, not yet installed" and shove the user at the
+  // "Add to Home Screen" screen.
+  if (isNativePlatform()) return false;
   const isStandalone =
     (window.navigator as unknown as { standalone?: boolean }).standalone === true ||
     window.matchMedia('(display-mode: standalone)').matches;


### PR DESCRIPTION
## Summary
\`isIOSNotStandalone()\` returned true on Capacitor's WKWebView because:
- the UA still says iPhone (so \`isIOS()\` returns true)
- \`navigator.standalone\` is undefined (that's a Safari-only thing)
- \`display-mode: standalone\` doesn't match in a WKWebView either

Onboarding then routed the user to the "Add to Home Screen" install screen — nonsensical inside an already-installed native app, and ironically also blocks them from reaching the actual notifications screen we just wired up for native.

Short-circuit on \`isNativePlatform()\`: anything running under Capacitor is by definition already installed, so it's "standalone" for the purposes of this check.

## Test plan
- [ ] Native iOS app: onboarding goes straight to the "stay in the loop" notifications screen, not the IOSInstallScreen
- [ ] Mobile Safari (not standalone): still shows the "Add to Home Screen" prompt
- [ ] iOS Safari PWA after install (standalone): skips the install screen as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)