### PR TITLE
feat: revive deleted checks + notify down responders on revive

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -75,7 +75,7 @@ export default function Home() {
 
   const [addModalOpen, setAddModalOpen] = useState(false);
   const [addModalDefaultMode, setAddModalDefaultMode] = useState<"paste" | "idea" | "manual" | null>(null);
-  const [deletedCheckScreenOpen, setDeletedCheckScreenOpen] = useState(false);
+  const [deletedCheckInfo, setDeletedCheckInfo] = useState<{ checkId: string; isMine: boolean } | null>(null);
 
   // ─── Misc page-level state ──────────────────────────────────────────────
   const [selectedSquad, setSelectedSquad] = useState<Squad | null>(null);
@@ -939,10 +939,10 @@ export default function Home() {
             onRestoreCheck={async (checkId) => {
               setArchivedChecks((prev) => prev.filter((c) => c.id !== checkId));
               try {
-                await db.unarchiveInterestCheck(checkId);
+                await db.reviveInterestCheck(checkId);
                 loadRealDataRef.current();
               } catch (err) {
-                logError("unarchiveCheck", err, { checkId });
+                logError("reviveCheck", err, { checkId });
               }
               showToast("Check restored");
             }}
@@ -1072,13 +1072,28 @@ export default function Home() {
         userId={userId}
         setUnreadCount={notificationsHook.setUnreadCount}
         friends={friendsHook.friends}
-        onDeletedCheck={() => setDeletedCheckScreenOpen(true)}
+        onDeletedCheck={(info) => setDeletedCheckInfo(info)}
         onNavigate={handleNotificationNavigate}
       />
 
       <DeletedCheckScreen
-        open={deletedCheckScreenOpen}
-        onClose={() => setDeletedCheckScreenOpen(false)}
+        open={!!deletedCheckInfo}
+        onClose={() => setDeletedCheckInfo(null)}
+        isMine={deletedCheckInfo?.isMine ?? false}
+        onRevive={async () => {
+          const checkId = deletedCheckInfo?.checkId;
+          if (!checkId) return;
+          try {
+            await db.reviveInterestCheck(checkId);
+            await loadRealDataRef.current();
+            setTab("feed");
+            checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId });
+            setTimeout(() => checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: null }), 3000);
+          } catch (err) {
+            logError("reviveCheck", err, { checkId });
+            showToast("Couldn't revive — try again");
+          }
+        }}
       />
 
       <EditEventModal

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -392,7 +392,7 @@ export default function CheckCard({
           await loadRealData();
           if (showToastWithAction) {
             showToastWithAction("Check removed — undo?", async () => {
-              try { await db.unarchiveInterestCheck(check.id); } catch (err) { logError("unarchiveCheck", err, { checkId: check.id }); }
+              try { await db.reviveInterestCheck(check.id); } catch (err) { logError("reviveCheck", err, { checkId: check.id }); }
               await loadRealData();
             });
           } else {

--- a/src/features/checks/components/DeletedCheckScreen.tsx
+++ b/src/features/checks/components/DeletedCheckScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useModalTransition } from "@/shared/hooks/useModalTransition";
 
 const EULOGIES = [
@@ -43,11 +43,19 @@ const DISMISSALS = [
 const DeletedCheckScreen = ({
   open,
   onClose,
+  isMine,
+  onRevive,
 }: {
   open: boolean;
   onClose: () => void;
+  /** Author/co-author of the deleted check — when true, shows a "revive" CTA. */
+  isMine: boolean;
+  /** Called when the author taps "revive it". Should re-activate the check
+   *  via the SECURITY DEFINER RPC and refresh data. The screen closes after. */
+  onRevive: () => Promise<void>;
 }) => {
   const { visible, entering, closing, close } = useModalTransition(open, onClose);
+  const [reviving, setReviving] = useState(false);
 
   const eulogy = useMemo(
     () => EULOGIES[Math.floor(Math.random() * EULOGIES.length)],
@@ -100,17 +108,53 @@ const DeletedCheckScreen = ({
         <p className="font-mono text-sm text-dim mb-8" style={{ lineHeight: 1.5 }}>
           {eulogy}
         </p>
-        <button
-          onClick={close}
-          className="font-mono text-xs uppercase bg-dt text-on-accent border-none rounded-xl cursor-pointer w-full"
-          style={{
-            padding: "12px 16px",
-            fontWeight: 700,
-            letterSpacing: "0.08em",
-          }}
-        >
-          {dismissal}
-        </button>
+        {isMine ? (
+          <>
+            <button
+              disabled={reviving}
+              onClick={async () => {
+                setReviving(true);
+                try {
+                  await onRevive();
+                  close();
+                } finally {
+                  setReviving(false);
+                }
+              }}
+              className="font-mono text-xs uppercase bg-dt text-on-accent border-none rounded-xl cursor-pointer w-full disabled:opacity-60"
+              style={{
+                padding: "12px 16px",
+                fontWeight: 700,
+                letterSpacing: "0.08em",
+              }}
+            >
+              {reviving ? "reviving…" : "revive it"}
+            </button>
+            <button
+              onClick={close}
+              disabled={reviving}
+              className="font-mono text-xs uppercase bg-transparent border-none cursor-pointer text-dim mt-3 disabled:opacity-60"
+              style={{
+                padding: "8px 16px",
+                letterSpacing: "0.08em",
+              }}
+            >
+              {dismissal}
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={close}
+            className="font-mono text-xs uppercase bg-dt text-on-accent border-none rounded-xl cursor-pointer w-full"
+            style={{
+              padding: "12px 16px",
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+            }}
+          >
+            {dismissal}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -21,19 +21,20 @@ interface Notification {
 }
 
 /** Probe the check; if it's archived/deleted, surface the "gone" screen
- *  instead of dumping the user into a feed where the check no longer appears. */
+ *  with isMine so we know whether to show the revive CTA. Active checks
+ *  fall through to the existing feed nav. */
 function navigateToCheckIfActive(
   checkId: string | null,
   onNavigate: (action: { type: "feed"; checkId?: string }) => void,
-  onDeletedCheck: () => void,
+  onDeletedCheck: (info: { checkId: string; isMine: boolean }) => void,
 ) {
   if (!checkId) {
     onNavigate({ type: "feed" });
     return;
   }
-  db.isInterestCheckActive(checkId).then((active) => {
+  db.getCheckState(checkId).then(({ active, isMine }) => {
     if (active) onNavigate({ type: "feed", checkId });
-    else onDeletedCheck();
+    else onDeletedCheck({ checkId, isMine });
   }).catch(() => {
     // Network/DB hiccup — fall back to existing behavior so the user isn't stranded
     onNavigate({ type: "feed", checkId });
@@ -59,7 +60,7 @@ const NotificationsPanel = ({
   setUnreadCount: React.Dispatch<React.SetStateAction<number>>;
   friends: { id: string }[];
   onNavigate: (action: { type: "friends"; tab: "friends" | "add" } | { type: "groups"; squadId?: string } | { type: "feed"; checkId?: string }) => void;
-  onDeletedCheck: () => void;
+  onDeletedCheck: (info: { checkId: string; isMine: boolean }) => void;
 }) => {
   const { visible, entering, closing, close } = useModalTransition(open, onClose);
   const touchStartY = useRef(0);
@@ -268,7 +269,7 @@ const NotificationsPanel = ({
                     }
                     onClose();
                     navigateToCheckIfActive(n.related_check_id, onNavigate, onDeletedCheck);
-                  } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated" || n.type === "check_text_updated" || n.type === "check_archived") {
+                  } else if (n.type === "check_response" || n.type === "friend_check" || n.type === "check_tag" || n.type === "check_date_updated" || n.type === "check_text_updated" || n.type === "check_archived" || n.type === "check_revived") {
                     // Mark single notification as read (except check_tag — cleared on accept/decline)
                     if (!n.is_read && n.type !== "check_tag") {
                       if (userId) db.markNotificationRead(n.id);
@@ -304,6 +305,7 @@ const NotificationsPanel = ({
                       : n.type === "event_date_updated" ? "#E8FF5A22"
                       : n.type === "event_comment" ? "#5AC8FA22"
                       : n.type === "check_archived" ? "#FF444422"
+                      : n.type === "check_revived" ? "#34C75922"
                       : "#5856D622",
                   }}
                 >
@@ -347,6 +349,9 @@ const NotificationsPanel = ({
                       case "check_archived":
                         // Trash
                         return <svg {...iconProps}><path d="M216,48H176V40a24,24,0,0,0-24-24H104A24,24,0,0,0,80,40v8H40a8,8,0,0,0,0,16h8V208a16,16,0,0,0,16,16H192a16,16,0,0,0,16-16V64h8a8,8,0,0,0,0-16ZM96,40a8,8,0,0,1,8-8h48a8,8,0,0,1,8,8v8H96Zm96,168H64V64H192ZM112,104v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Zm48,0v64a8,8,0,0,1-16,0V104a8,8,0,0,1,16,0Z"/></svg>;
+                      case "check_revived":
+                        // Sparkle
+                        return <svg {...iconProps}><path d="M208,144a15.78,15.78,0,0,1-10.42,14.94L146,178l-19,51.62a15.92,15.92,0,0,1-29.88,0L78,178l-51.62-19a15.92,15.92,0,0,1,0-29.88L78,110l19-51.62a15.92,15.92,0,0,1,29.88,0L146,110l51.62,19A15.78,15.78,0,0,1,208,144ZM152,48h16V64a8,8,0,0,0,16,0V48h16a8,8,0,0,0,0-16H184V16a8,8,0,0,0-16,0V32H152a8,8,0,0,0,0,16Zm88,32h-8V72a8,8,0,0,0-16,0v8h-8a8,8,0,0,0,0,16h8v8a8,8,0,0,0,16,0V96h8a8,8,0,0,0,0-16Z"/></svg>;
                       default:
                         // ChatTeardrop
                         return <svg {...iconProps}><path d="M132,24A100.11,100.11,0,0,0,32,124v84a16,16,0,0,0,16,16h84a100,100,0,0,0,0-200Zm0,184H48V124a84,84,0,1,1,84,84Z"/></svg>;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -815,14 +815,16 @@ export async function createInterestCheck(
   return data;
 }
 
-/** Returns true if the check still exists and is not archived. */
-export async function isInterestCheckActive(checkId: string): Promise<boolean> {
-  const { data } = await supabase
-    .from('interest_checks')
-    .select('id, archived_at')
-    .eq('id', checkId)
-    .maybeSingle();
-  return !!data && !data.archived_at;
+/** Returns whether a check is currently active and whether the caller owns it
+ *  (author or accepted co-author). Goes through a SECURITY DEFINER RPC so the
+ *  caller can discover ownership of their own archived rows — the SELECT
+ *  policy hides those even from their author. */
+export async function getCheckState(checkId: string): Promise<{ active: boolean; isMine: boolean }> {
+  const { data, error } = await supabase
+    .rpc('get_check_state', { p_check_id: checkId })
+    .single<{ active: boolean; is_mine: boolean }>();
+  if (error) throw error;
+  return { active: !!data?.active, isMine: !!data?.is_mine };
 }
 
 /** Archive a check via SECURITY DEFINER RPC. The RPC also fires
@@ -835,12 +837,15 @@ export async function archiveInterestCheck(checkId: string): Promise<void> {
   if (error) throw error;
 }
 
-export async function unarchiveInterestCheck(checkId: string): Promise<void> {
-  const { error } = await supabase
-    .from('interest_checks')
-    .update({ archived_at: null })
-    .eq('id', checkId);
-
+/** Revive an archived check via SECURITY DEFINER RPC. If the archive happened
+ *  within the last ~5 min (toast-undo window), the RPC silently deletes the
+ *  prior `check_archived` notifications instead of fanning out new ones —
+ *  recipients see no notification at all for a quick undo. Older revives
+ *  send `check_revived` notifications to "down" responders. */
+export async function reviveInterestCheck(checkId: string): Promise<void> {
+  const { error } = await supabase.rpc('revive_interest_check', {
+    p_check_id: checkId,
+  });
   if (error) throw error;
 }
 

--- a/supabase/migrations/20260425000003_revive_check_rpc_and_state.sql
+++ b/supabase/migrations/20260425000003_revive_check_rpc_and_state.sql
@@ -1,0 +1,143 @@
+-- Companion to 20260425000002 (archive RPC). Adds:
+--   1. check_revived as a notifications.type value.
+--   2. revive_interest_check(p_check_id) — SECURITY DEFINER mirror of the
+--      archive RPC, with an undo-aware notification path.
+--   3. get_check_state(p_check_id) — a probe the client uses on a
+--      notification tap. Returns {active, is_mine} so the panel can decide
+--      between feed-nav, no-revive screen, or revive-screen.
+--
+-- Why SECURITY DEFINER on get_check_state too: archived rows are hidden by
+-- the SELECT policy from 20260424000001 (check_is_active), even from their
+-- author. The author needs to be able to discover that a tapped notification
+-- still maps to one of *their* checks so we can offer the revive UI. The
+-- function only returns two booleans — no sensitive payload.
+--
+-- Undo de-dup logic in revive_interest_check:
+--   The Delete button shows a 4.5s "undo?" toast. If the user undoes inside
+--   that window (or shortly after), we want recipients to see *no*
+--   notification — the cancel never really happened from their POV. So we
+--   gate on archived_at: if it's < 5 minutes old, treat the revive as undo
+--   and DELETE the prior check_archived notifications instead of inserting
+--   check_revived. 5 min is generous safety margin past the 4.5s toast.
+
+
+-- 1. Extend notifications.type
+ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
+ALTER TABLE public.notifications ADD CONSTRAINT notifications_type_check
+  CHECK (type IN (
+    'friend_request', 'friend_accepted', 'check_response',
+    'squad_message', 'squad_invite', 'friend_check', 'date_confirm',
+    'check_tag', 'check_comment', 'poll_created', 'squad_join_request',
+    'squad_mention', 'comment_mention', 'friend_event', 'event_reminder',
+    'event_down', 'check_date_updated', 'event_date_updated',
+    'check_text_updated',
+    'check_archived', 'check_revived'
+  ));
+
+
+-- 2. revive_interest_check(p_check_id)
+CREATE OR REPLACE FUNCTION public.revive_interest_check(p_check_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller UUID := (SELECT auth.uid());
+  v_author_id UUID;
+  v_text TEXT;
+  v_old_archived_at TIMESTAMPTZ;
+  v_phrase TEXT;
+  v_recipient UUID;
+  v_phrases TEXT[] := ARRAY[
+    'the check got undeleted',
+    'back from the dead',
+    'false alarm — the check is alive',
+    'the check came back',
+    'plan revived',
+    'the check pulled a lazarus',
+    'scratch that — its back on',
+    'the check rose from the grave',
+    'never mind — the check is back',
+    'resurrection arc'
+  ];
+BEGIN
+  IF v_caller IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT author_id, text, archived_at
+    INTO v_author_id, v_text, v_old_archived_at
+  FROM public.interest_checks
+  WHERE id = p_check_id;
+
+  IF v_author_id IS NULL THEN
+    RAISE EXCEPTION 'Check not found';
+  END IF;
+
+  IF v_author_id <> v_caller AND NOT public.is_check_coauthor(p_check_id, v_caller) THEN
+    RAISE EXCEPTION 'Not authorized to revive this check';
+  END IF;
+
+  -- Idempotent: re-reviving an already-active row is a silent no-op.
+  UPDATE public.interest_checks
+    SET archived_at = NULL
+    WHERE id = p_check_id AND archived_at IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Undo (recently archived) → erase the archive notifications, send nothing.
+  -- Real revive (older archive) → notify down responders the plan is back on.
+  IF v_old_archived_at > now() - interval '5 minutes' THEN
+    DELETE FROM public.notifications
+      WHERE related_check_id = p_check_id
+        AND type = 'check_archived';
+  ELSE
+    FOR v_recipient IN
+      SELECT user_id FROM public.check_responses
+      WHERE check_id = p_check_id
+        AND response = 'down'
+        AND user_id <> v_author_id
+    LOOP
+      v_phrase := v_phrases[1 + floor(random() * array_length(v_phrases, 1))::int];
+      INSERT INTO public.notifications (
+        user_id, type, title, body, related_user_id, related_check_id
+      )
+      VALUES (
+        v_recipient,
+        'check_revived',
+        v_phrase,
+        LEFT(COALESCE(v_text, 'a check'), 120),
+        v_author_id,
+        p_check_id
+      );
+    END LOOP;
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.revive_interest_check(UUID) TO authenticated;
+
+
+-- 3. get_check_state(p_check_id) — probe used by NotificationsPanel.
+CREATE OR REPLACE FUNCTION public.get_check_state(p_check_id UUID)
+RETURNS TABLE(active BOOLEAN, is_mine BOOLEAN)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    COALESCE(ic.archived_at IS NULL, false) AS active,
+    COALESCE(
+      ic.author_id = (SELECT auth.uid())
+      OR public.is_check_coauthor(ic.id, (SELECT auth.uid())),
+      false
+    ) AS is_mine
+  FROM (SELECT 1) AS dummy
+  LEFT JOIN public.interest_checks ic ON ic.id = p_check_id
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_check_state(UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- Authors can bring a deleted check back to life by tapping their own stale notification — the "this check is gone" overlay grows a **revive it** CTA when `isMine`.
- New `check_revived` notification fires to "down" responders with a random phrase ("back from the dead", "plan revived", "resurrection arc", …). Sparkle icon, green-tinted background.
- **Undo de-dup baked in:** if the revive happens within 5 min of the archive (i.e. it was a toast undo), the RPC silently deletes the prior `check_archived` notifications instead of sending revive ones — recipients see zero notification for a quick cancel-then-undo.

## Why this shape

**Two RPCs, no client UPDATE.** Mirror of `archive_interest_check` from #440. Same SECURITY DEFINER pattern, same auth check, same idempotency, same single-tx fan-out. Bypasses the same staging RLS bug (Sentry DOWNTO-A) that motivated the archive RPC.

**`get_check_state` for the probe.** Old `isInterestCheckActive` returned only a boolean, which couldn't tell the panel whether to offer revive. The new RPC returns `{active, is_mine}`. SECURITY DEFINER because the SELECT policy hides archived rows from their author — without this, an author tapping their own `check_archived` notification couldn't even discover that the check is theirs.

**5-min undo window.** Toast lives 4.5s; 5 min is generous safety margin. Anyone reviving past that has clearly chosen to bring the check back, so notifications fire.

**`unarchiveInterestCheck` removed.** Both call sites (toast undo + restore-from-archived-list) now go through `reviveInterestCheck` and benefit from the de-dup logic.

## Files
- `supabase/migrations/20260425000003_revive_check_rpc_and_state.sql` — `revive_interest_check`, `get_check_state`, `check_revived` value
- `src/lib/db.ts` — add `reviveInterestCheck` + `getCheckState`; drop `isInterestCheckActive` + `unarchiveInterestCheck`
- `src/features/checks/components/DeletedCheckScreen.tsx` — `isMine` + `onRevive` props; "revive it" primary CTA when owner, dismissal becomes secondary
- `src/features/notifications/components/NotificationsPanel.tsx` — probe via `getCheckState`; surface `{checkId, isMine}` to `onDeletedCheck`; `check_revived` icon + bg + routing
- `src/app/page.tsx` — track screen target as `{checkId, isMine} | null`; revive callback runs RPC, reloads, jumps to feed, highlights the resurrected check
- `src/features/checks/components/CheckCard.tsx` — toast undo path uses `reviveInterestCheck`

## Test plan
- [ ] Delete your own check; immediately tap Undo → check is back; **down responders see no notification at all** (de-dup window)
- [ ] Delete your own check; let toast expire; some time later tap the `check_archived` notification → DeletedCheckScreen with "revive it" button → tap → check is back, feed highlights it, **down responders get a `check_revived` notification with a random phrase**
- [ ] Tap a `check_archived` notification on someone else's archived check → screen shows random dismissal only (no revive button)
- [ ] Tap a `check_revived` notification → routes to feed, highlights the check (sparkle icon)
- [ ] Restore a check from the "archived checks" list in profile → revive notifications fire (this is a "real" revive, not within 5 min)
- [ ] Re-revive an already-active check directly via RPC → silent no-op
- [ ] Non-author calling RPC → "Not authorized"

🤖 Generated with [Claude Code](https://claude.com/claude-code)