### PR TITLE
fix: AppDelegate posts the NotificationCenter events Capacitor push needs

### DIFF
--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -23,4 +23,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         return ApplicationDelegateProxy.shared.application(application, continue: userActivity, restorationHandler: restorationHandler)
     }
+
+    // @capacitor/push-notifications listens on NotificationCenter for these
+    // names; without these hooks the iOS APNs callback is a no-op and the
+    // plugin never fires `registration` / `registrationError`.
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    }
 }

--- a/scripts/build-capacitor.sh
+++ b/scripts/build-capacitor.sh
@@ -31,8 +31,13 @@ restore() {
 }
 trap restore EXIT
 
-# Run static export build
-CAPACITOR_BUILD=true npx next build
+# Run static export build.
+# NEXT_PUBLIC_API_BASE points fetch('/api/...') calls at the Vercel deploy —
+# the WebView serves only the static bundle, there's no localhost API server.
+# Override at call time if you want to test against staging/preview.
+CAPACITOR_BUILD=true \
+NEXT_PUBLIC_API_BASE="${NEXT_PUBLIC_API_BASE:-https://downto.xyz}" \
+npx next build
 
 echo ""
 echo "Static export ready in ./out"


### PR DESCRIPTION
## Summary
#433 claimed Capacitor's PushNotifications plugin handles iOS remote-notification registration callbacks via method swizzling, so the AppDelegate didn't need changes. That's not true for the current plugin version — it listens on \`NotificationCenter\` for \`.capacitorDidRegisterForRemoteNotifications\` / \`.capacitorDidFailToRegisterForRemoteNotifications\`, and the AppDelegate has to post them explicitly.

Without the hooks the chain silently breaks:
1. \`PushNotifications.register()\` bridges to native ✓
2. native calls \`UIApplication.registerForRemoteNotifications()\` ✓
3. iOS asks APNs and gets a token ✓
4. iOS calls \`didRegisterForRemoteNotificationsWithDeviceToken\` on AppDelegate
5. **AppDelegate has no handler** → token disappears
6. plugin never fires \`registration\` → no DB write
7. apsd device log shows no per-app token request for \`xyz.downto.app\`

Add the two handlers; let the plugin actually receive the OS callbacks.

## Test plan
- [ ] \`npm run ios:fresh\` → sign in → toggle Push Notifications → Allow → Web Inspector Console shows \`Native push token: <hex>\`
- [ ] \`select * from push_subscriptions where platform='ios'\` returns the row within seconds
- [ ] Have a friend respond \`down\` to a check → push lands on the device

🤖 Generated with [Claude Code](https://claude.com/claude-code)