### PR TITLE
feat: readable closed-poll results + propose/reopen from summary

### DIFF
--- a/src/app/api/squads/close-poll/route.ts
+++ b/src/app/api/squads/close-poll/route.ts
@@ -67,11 +67,14 @@ export async function POST(req: NextRequest) {
   if (poll.poll_type === 'dates') {
     const { data: votes } = await adminClient
       .from('squad_poll_votes')
-      .select('option_index')
+      .select('option_index, user_id')
       .eq('poll_id', pollId);
 
     const counts = new Map<number, number>();
     for (const v of votes ?? []) counts.set(v.option_index, (counts.get(v.option_index) ?? 0) + 1);
+    // Anyone who voted at least once is treated as already-confirmed for the
+    // proposed date — they implicitly weighed in by voting in the poll.
+    const responderIds = Array.from(new Set((votes ?? []).map((v) => v.user_id))) as string[];
 
     let topIdx: number | null = null;
     let topCount = 0;
@@ -102,6 +105,7 @@ export async function POST(req: NextRequest) {
             time: winner.time,
             proposerUserId: null,
             proposerDisplayName: 'The poll',
+            preConfirmedUserIds: responderIds,
           });
         } catch (err) {
           // Non-fatal: poll is already closed and the winner message is in
@@ -119,6 +123,8 @@ export async function POST(req: NextRequest) {
       .from('squad_poll_availability')
       .select('user_id, day_offset, slot_index')
       .eq('poll_id', pollId);
+
+    const responderIds = Array.from(new Set((cells ?? []).map((c) => c.user_id))) as string[];
 
     const counts = new Map<string, { count: number; dayOffset: number; slotIndex: number }>();
     for (const c of cells ?? []) {
@@ -161,6 +167,7 @@ export async function POST(req: NextRequest) {
           time: timeStr,
           proposerUserId: null,
           proposerDisplayName: 'The poll',
+          preConfirmedUserIds: responderIds,
         });
       } catch (err) {
         console.error('proposeSquadDate from availability winner failed', err);
@@ -174,11 +181,12 @@ export async function POST(req: NextRequest) {
   if (poll.poll_type === 'when') {
     const { data: votes } = await adminClient
       .from('squad_poll_votes')
-      .select('option_index')
+      .select('option_index, user_id')
       .eq('poll_id', pollId);
 
     const counts = new Map<number, number>();
     for (const v of votes ?? []) counts.set(v.option_index, (counts.get(v.option_index) ?? 0) + 1);
+    const responderIds = Array.from(new Set((votes ?? []).map((v) => v.user_id))) as string[];
 
     let topIdx: number | null = null;
     let topCount = 0;
@@ -218,6 +226,7 @@ export async function POST(req: NextRequest) {
             time: timeStr,
             proposerUserId: null,
             proposerDisplayName: 'The poll',
+            preConfirmedUserIds: responderIds,
           });
         } catch (err) {
           console.error('proposeSquadDate from when winner failed', err);

--- a/src/app/api/squads/propose-from-poll/route.ts
+++ b/src/app/api/squads/propose-from-poll/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateRequest, isAuthError } from '@/lib/api-auth';
+import { proposeSquadDate } from '@/lib/server/squadDate';
+
+// Propose a date that came out of a closed availability poll. Members who
+// already voted in the poll get their date_confirm row pre-marked 'yes' (and
+// no notification) — they implicitly confirmed by voting. Only members who
+// didn't respond to the poll see "are you still down?".
+export async function POST(req: NextRequest) {
+  const auth = await authenticateRequest(req);
+  if (isAuthError(auth)) return auth.error;
+  const { user, supabase } = auth;
+
+  const { pollId, date, time } = await req.json();
+  if (!pollId || !date) {
+    return NextResponse.json({ error: 'pollId and date required' }, { status: 400 });
+  }
+
+  const { data: poll, error: pollError } = await supabase
+    .from('squad_polls')
+    .select('id, squad_id, poll_type, status')
+    .eq('id', pollId)
+    .single();
+  if (pollError || !poll) {
+    return NextResponse.json({ error: 'Poll not found' }, { status: 404 });
+  }
+
+  // Caller must be a non-waitlisted member of the squad
+  const { data: membership } = await supabase
+    .from('squad_members')
+    .select('id, role')
+    .eq('squad_id', poll.squad_id)
+    .eq('user_id', user.id)
+    .maybeSingle();
+  if (!membership || membership.role === 'waitlist') {
+    return NextResponse.json({ error: 'Not a squad member' }, { status: 403 });
+  }
+
+  const { getServiceClient } = await import('@/lib/supabase-admin');
+  const adminClient = getServiceClient();
+
+  // Responders depend on poll type:
+  //   - 'availability' polls store cells in squad_poll_availability
+  //   - 'when' polls (any collection style) store votes in squad_poll_votes
+  let responderIds: string[] = [];
+  if (poll.poll_type === 'availability') {
+    const { data: cells } = await adminClient
+      .from('squad_poll_availability')
+      .select('user_id')
+      .eq('poll_id', pollId);
+    responderIds = Array.from(new Set((cells ?? []).map((c) => c.user_id))) as string[];
+  } else {
+    const { data: votes } = await adminClient
+      .from('squad_poll_votes')
+      .select('user_id')
+      .eq('poll_id', pollId);
+    responderIds = Array.from(new Set((votes ?? []).map((v) => v.user_id))) as string[];
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('display_name')
+    .eq('id', user.id)
+    .single();
+  const displayName = profile?.display_name ?? 'Someone';
+
+  try {
+    const { expiresAt } = await proposeSquadDate({
+      adminClient,
+      squadId: poll.squad_id,
+      date,
+      time: typeof time === 'string' && time.length > 0 ? time : null,
+      proposerUserId: user.id,
+      proposerDisplayName: displayName,
+      preConfirmedUserIds: responderIds,
+    });
+    return NextResponse.json({ ok: true, expires_at: expiresAt, date_status: 'proposed' });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to propose date';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/squads/reopen-poll/route.ts
+++ b/src/app/api/squads/reopen-poll/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateRequest, isAuthError } from '@/lib/api-auth';
+
+// Flip a closed poll back to active so members can keep voting. Only the
+// poll creator can re-open, mirroring close-poll's authz. Doesn't touch any
+// date that may have been auto-proposed when the poll closed — the squad
+// can clear/repropose manually if they want a clean slate.
+export async function POST(req: NextRequest) {
+  const auth = await authenticateRequest(req);
+  if (isAuthError(auth)) return auth.error;
+  const { user, supabase } = auth;
+
+  const { pollId } = await req.json();
+  if (!pollId) {
+    return NextResponse.json({ error: 'pollId required' }, { status: 400 });
+  }
+
+  const { getServiceClient } = await import('@/lib/supabase-admin');
+  const adminClient = getServiceClient();
+
+  const { data: poll, error: pollError } = await adminClient
+    .from('squad_polls')
+    .select('id, squad_id, status, created_by')
+    .eq('id', pollId)
+    .single();
+  if (pollError || !poll) {
+    return NextResponse.json({ error: 'Poll not found' }, { status: 404 });
+  }
+  if (poll.status !== 'closed') {
+    return NextResponse.json({ error: 'Poll is not closed' }, { status: 400 });
+  }
+  if (poll.created_by !== user.id) {
+    return NextResponse.json({ error: 'Only the poll creator can reopen it' }, { status: 403 });
+  }
+
+  const { error: updateError } = await adminClient
+    .from('squad_polls')
+    .update({ status: 'active' })
+    .eq('id', pollId);
+  if (updateError) {
+    return NextResponse.json({ error: updateError.message }, { status: 500 });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('display_name')
+    .eq('id', user.id)
+    .single();
+  const displayName = profile?.display_name ?? 'Someone';
+
+  await adminClient
+    .from('messages')
+    .insert({
+      squad_id: poll.squad_id,
+      sender_id: null,
+      text: `${displayName} reopened the poll`,
+      is_system: true,
+    });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/features/squads/components/ChatMessage.tsx
+++ b/src/features/squads/components/ChatMessage.tsx
@@ -115,6 +115,8 @@ interface ChatMessageProps {
   isWaitlisted: boolean;
   pollMessageRef: React.RefObject<HTMLDivElement | null>;
   onPollClosed?: (pollId: string) => void;
+  squadMembers?: { userId: string; displayName: string }[];
+  onProposeDateFromPoll?: (pollId: string, date: string, time: string) => Promise<void>;
 }
 
 export default function ChatMessage({
@@ -133,6 +135,8 @@ export default function ChatMessage({
   isWaitlisted,
   pollMessageRef,
   onPollClosed,
+  squadMembers,
+  onProposeDateFromPoll,
 }: ChatMessageProps) {
   if (msg.sender === "system") {
     if (msg.messageType === 'date_confirm' && isLastConfirm) {
@@ -184,8 +188,12 @@ export default function ChatMessage({
               isWaitlisted={isWaitlisted}
               pollMessageRef={pollMessageRef}
               onPollClosed={onPollClosed}
+              squadMembers={squadMembers}
               onToggleCell={async (d, s) => { await db.toggleAvailabilityCell(poll.id, d, s); }}
               onClearMine={async () => { await db.clearMyAvailability(poll.id); }}
+              onProposeDate={onProposeDateFromPoll
+                ? async (date, time) => { await onProposeDateFromPoll(poll.id, date, time); }
+                : undefined}
             />
           </div>
         );
@@ -219,12 +227,16 @@ export default function ChatMessage({
                 isWaitlisted={isWaitlisted}
                 pollMessageRef={pollMessageRef}
                 onPollClosed={onPollClosed}
+                squadMembers={squadMembers}
                 onToggleCell={async (d, s) => {
                   const idx = grid.cellToSlotIndex.get(`${d}|${s}`);
                   if (idx === undefined) return;
                   await db.votePoll(poll.id, idx);
                 }}
                 onClearMine={async () => { await db.clearMyWhenVotes(poll.id); }}
+                onProposeDate={onProposeDateFromPoll
+                  ? async (date, time) => { await onProposeDateFromPoll(poll.id, date, time); }
+                  : undefined}
               />
             </div>
           );

--- a/src/features/squads/components/GridPollMessage.tsx
+++ b/src/features/squads/components/GridPollMessage.tsx
@@ -30,11 +30,20 @@ interface GridPollMessageProps {
   isWaitlisted: boolean;
   pollMessageRef: React.RefObject<HTMLDivElement | null>;
   onPollClosed?: (pollId: string) => void;
+  // Squad members (excluding waitlist). Used by the closed-results view to
+  // compute who responded vs who hasn't. Optional so legacy callers don't
+  // break — without it, we just show responder count without the "didn't
+  // respond" annotation.
+  squadMembers?: { userId: string; displayName: string }[];
   // Caller decides how a cell toggle / clear-mine is persisted. For legacy
   // 'availability' polls this hits squad_poll_availability; for 'when' polls
   // with availability style it maps the cell to a slot's option index and votes.
   onToggleCell: (dayOffset: number, slotIndex: number) => Promise<void>;
   onClearMine: () => Promise<void>;
+  // Optional: when present, the closed-results view shows a "propose this"
+  // button on each best-time row that hands the date+start-time to the
+  // existing squad date proposal flow. Caller wires up the actual API call.
+  onProposeDate?: (date: string, time: string) => Promise<void>;
 }
 
 function formatSlotLabel(hourStart: number, slotIndex: number, slotMinutes: number): string {
@@ -63,6 +72,47 @@ function formatDayHeader(dateIso: string, compact: boolean): { top: string; bott
   };
 }
 
+function formatFullDayLabel(dateIso: string): string {
+  const d = new Date(dateIso + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+}
+
+interface SlotGroup {
+  dayOffset: number;
+  startSlot: number;
+  endSlot: number; // inclusive
+  userIds: string[]; // sorted
+}
+
+// Group runs of consecutive slots within the same day where the available user
+// set is identical. Turns a 12-tile "5pm-10:30pm 2/2" stripe into one row.
+function groupConsecutiveSlots(
+  cellUsers: Map<string, Set<string>>,
+  days: number,
+  slotsPerDay: number,
+): SlotGroup[] {
+  const out: SlotGroup[] = [];
+  for (let d = 0; d < days; d++) {
+    let i = 0;
+    while (i < slotsPerDay) {
+      const users = cellUsers.get(`${d}|${i}`);
+      if (!users || users.size === 0) { i++; continue; }
+      const sorted = [...users].sort();
+      const sig = sorted.join(',');
+      let j = i;
+      while (j + 1 < slotsPerDay) {
+        const next = cellUsers.get(`${d}|${j + 1}`);
+        if (!next || next.size === 0) break;
+        if ([...next].sort().join(',') !== sig) break;
+        j++;
+      }
+      out.push({ dayOffset: d, startSlot: i, endSlot: j, userIds: sorted });
+      i = j + 1;
+    }
+  }
+  return out;
+}
+
 export default function GridPollMessage({
   poll,
   availability,
@@ -70,8 +120,10 @@ export default function GridPollMessage({
   isWaitlisted,
   pollMessageRef,
   onPollClosed,
+  squadMembers,
   onToggleCell,
   onClearMine,
+  onProposeDate,
 }: GridPollMessageProps) {
   const [local, setLocal] = useState<AvailabilityCell[]>(availability);
   const [isClosed, setIsClosed] = useState(poll.status === 'closed');
@@ -196,6 +248,12 @@ export default function GridPollMessage({
     }).catch(() => {});
   };
 
+  const handleReopen = () => {
+    db.reopenPoll(poll.id).then(() => {
+      setIsClosed(false);
+    }).catch(() => {});
+  };
+
   const densityBg = (count: number, yours: boolean): string => {
     if (yours) return 'bg-dt';
     if (count === 0 || totalUsers === 0) return 'bg-deep';
@@ -206,6 +264,82 @@ export default function GridPollMessage({
     if (frac >= 0.2) return 'bg-[rgba(232,255,90,0.18)]';
     return 'bg-[rgba(232,255,90,0.08)]';
   };
+
+  const grid = (
+    <div
+      ref={gridBodyRef}
+      onPointerMove={handlePointerMove}
+      className="select-none"
+    >
+      {/* Header row: day labels. Past 7 days the columns get too narrow
+          for "Sat 4/25" — collapse to single-letter weekday + day number
+          and stash the full date in title= so hover recovers it. */}
+      <div className="flex">
+        <div className="shrink-0 w-10" />
+        {Array.from({ length: days }, (_, d) => {
+          const h = formatDayHeader(poll.gridDates[d], days > 7);
+          return (
+            <div key={d} title={h.title} className="flex-1 min-w-0 text-center px-0.5 overflow-hidden">
+              <div className="font-mono text-tiny text-dim leading-none truncate">{h.top}</div>
+              <div className="font-mono text-tiny text-faint leading-tight truncate">{h.bottom}</div>
+            </div>
+          );
+        })}
+      </div>
+      {/* Slot rows */}
+      {Array.from({ length: slotsPerDay }, (_, s) => (
+        <div key={s} className="flex items-stretch">
+          <div className="shrink-0 w-10 flex items-center justify-end pr-1">
+            <span className="font-mono text-tiny text-faint">
+              {formatSlotLabel(poll.gridHourStart, s, poll.gridSlotMinutes)}
+            </span>
+          </div>
+          {Array.from({ length: days }, (_, d) => {
+            const k = `${d}|${s}`;
+            const users = cellUsers.get(k);
+            const count = users?.size ?? 0;
+            const yours = !!userId && !!users?.has(userId);
+            const title = users && users.size > 0
+              ? Array.from(users).map((uid) => uid === userId ? 'You' : userLabels.get(uid) ?? 'Unknown').join(', ')
+              : '';
+            return (
+              <div
+                key={d}
+                data-day={d}
+                data-slot={s}
+                onPointerDown={(e) => handlePointerDown(e, d, s)}
+                title={title}
+                style={{ touchAction: 'none' }}
+                className={cn(
+                  "flex-1 min-w-0 h-7 border border-border",
+                  densityBg(count, yours),
+                  canTap ? "cursor-pointer" : "cursor-default",
+                )}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+
+  // Closed state: pivot from cramped heat-map grid to a ranked list of time
+  // blocks. Consecutive slots with the same available user set collapse into a
+  // single "5pm–10:30pm" row, so the eye can land on the answer without
+  // counting tiles. Original grid is still available in a collapsed details.
+  const closedSummary = isClosed ? (
+    <ClosedResultsSummary
+      poll={poll}
+      cellUsers={cellUsers}
+      userLabels={userLabels}
+      totalUsers={totalUsers}
+      days={days}
+      slotsPerDay={slotsPerDay}
+      userId={userId}
+      squadMembers={squadMembers}
+      onProposeDate={onProposeDate}
+    />
+  ) : null;
 
   return (
     <div ref={pollMessageRef} className="flex justify-center py-2">
@@ -218,63 +352,24 @@ export default function GridPollMessage({
           {canTap ? "tap or drag to paint the times you're free" : isClosed ? "poll closed" : "read only"}
         </div>
 
-        {/* Grid fits without horizontal scroll — cells flex to share width.
-            touch-action: none on cells prevents iOS from scrolling/zooming mid-drag. */}
-        <div
-          ref={gridBodyRef}
-          onPointerMove={handlePointerMove}
-          className="select-none"
-        >
-          {/* Header row: day labels. Past 7 days the columns get too narrow
-              for "Sat 4/25" — collapse to single-letter weekday + day number
-              and stash the full date in title= so hover recovers it. */}
-          <div className="flex">
-            <div className="shrink-0 w-10" />
-            {Array.from({ length: days }, (_, d) => {
-              const h = formatDayHeader(poll.gridDates[d], days > 7);
-              return (
-                <div key={d} title={h.title} className="flex-1 min-w-0 text-center px-0.5 overflow-hidden">
-                  <div className="font-mono text-tiny text-dim leading-none truncate">{h.top}</div>
-                  <div className="font-mono text-tiny text-faint leading-tight truncate">{h.bottom}</div>
-                </div>
-              );
-            })}
-          </div>
-          {/* Slot rows */}
-          {Array.from({ length: slotsPerDay }, (_, s) => (
-            <div key={s} className="flex items-stretch">
-              <div className="shrink-0 w-10 flex items-center justify-end pr-1">
-                <span className="font-mono text-tiny text-faint">
-                  {formatSlotLabel(poll.gridHourStart, s, poll.gridSlotMinutes)}
-                </span>
-              </div>
-              {Array.from({ length: days }, (_, d) => {
-                const k = `${d}|${s}`;
-                const users = cellUsers.get(k);
-                const count = users?.size ?? 0;
-                const yours = !!userId && !!users?.has(userId);
-                const title = users && users.size > 0
-                  ? Array.from(users).map((uid) => uid === userId ? 'You' : userLabels.get(uid) ?? 'Unknown').join(', ')
-                  : '';
-                return (
-                  <div
-                    key={d}
-                    data-day={d}
-                    data-slot={s}
-                    onPointerDown={(e) => handlePointerDown(e, d, s)}
-                    title={title}
-                    style={{ touchAction: 'none' }}
-                    className={cn(
-                      "flex-1 min-w-0 h-7 border border-border",
-                      densityBg(count, yours),
-                      canTap ? "cursor-pointer" : "cursor-default",
-                    )}
-                  />
-                );
-              })}
-            </div>
-          ))}
-        </div>
+        {isClosed ? (
+          <>
+            {closedSummary}
+            {totalUsers > 0 && (
+              <details className="mt-3 group">
+                <summary className="font-mono text-tiny uppercase tracking-wider text-dim cursor-pointer select-none px-1 list-none flex items-center gap-1">
+                  <span className="group-open:rotate-90 transition-transform inline-block">▸</span>
+                  full grid
+                </summary>
+                <div className="mt-2">{grid}</div>
+              </details>
+            )}
+          </>
+        ) : (
+          /* Grid fits without horizontal scroll — cells flex to share width.
+             touch-action: none on cells prevents iOS from scrolling/zooming mid-drag. */
+          grid
+        )}
 
         <div className="flex justify-between items-center mt-2.5 px-1 gap-2">
           <span className="font-mono text-tiny text-faint">
@@ -303,9 +398,182 @@ export default function GridPollMessage({
                 CLOSE POLL
               </button>
             )}
+            {isCreator && isClosed && (
+              <button
+                onClick={handleReopen}
+                className="bg-transparent border border-border-mid rounded-lg font-mono text-tiny font-bold text-dim cursor-pointer"
+                style={{ padding: '4px 10px' }}
+              >
+                REOPEN POLL
+              </button>
+            )}
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+interface ClosedResultsSummaryProps {
+  poll: GridPoll;
+  cellUsers: Map<string, Set<string>>;
+  userLabels: Map<string, string>;
+  totalUsers: number;
+  days: number;
+  slotsPerDay: number;
+  userId: string | null;
+  squadMembers?: { userId: string; displayName: string }[];
+  onProposeDate?: (date: string, time: string) => Promise<void>;
+}
+
+// Format a list of names as "A", "A and B", "A, B and C", "A, B, C and D".
+function joinNames(names: string[]): string {
+  if (names.length === 0) return '';
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+}
+
+function ProposeButton({ onClick }: { onClick: () => Promise<void> }) {
+  const [state, setState] = useState<'idle' | 'busy' | 'done'>('idle');
+  const handle = async () => {
+    if (state !== 'idle') return;
+    setState('busy');
+    try {
+      await onClick();
+      setState('done');
+    } catch {
+      setState('idle');
+    }
+  };
+  const label = state === 'idle' ? 'PROPOSE' : state === 'busy' ? '…' : 'PROPOSED';
+  return (
+    <button
+      onClick={handle}
+      disabled={state !== 'idle'}
+      className={cn(
+        "shrink-0 rounded-lg font-mono text-tiny font-bold tracking-wider px-3 py-1.5 cursor-pointer disabled:cursor-default",
+        state === 'done'
+          ? "bg-transparent border border-border-mid text-dim"
+          : "bg-dt text-black border border-dt",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function ClosedResultsSummary({
+  poll,
+  cellUsers,
+  userLabels,
+  totalUsers,
+  days,
+  slotsPerDay,
+  userId,
+  squadMembers,
+  onProposeDate,
+}: ClosedResultsSummaryProps) {
+  const groups = useMemo(
+    () => groupConsecutiveSlots(cellUsers, days, slotsPerDay),
+    [cellUsers, days, slotsPerDay],
+  );
+
+  // Responders: anyone who voted at least one cell. Non-responders: squad
+  // members minus responders. We omit the current user from name lists when
+  // they're the viewer ("you" reads weird in third-person summaries here).
+  const responderIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const set of cellUsers.values()) for (const id of set) ids.add(id);
+    return ids;
+  }, [cellUsers]);
+
+  const nameOf = (id: string): string => (id === userId ? 'you' : userLabels.get(id) ?? '?');
+
+  const responderNames = [...responderIds].map(nameOf);
+  const nonResponderNames =
+    squadMembers
+      ?.filter((m) => !responderIds.has(m.userId))
+      .map((m) => (m.userId === userId ? 'you' : m.displayName)) ?? [];
+
+  if (totalUsers === 0 || groups.length === 0) {
+    return (
+      <div className="font-mono text-xs text-dim text-center py-6 bg-deep border border-border rounded-lg">
+        no responses
+        {nonResponderNames.length > 0 && (
+          <div className="mt-1 font-mono text-tiny text-faint">
+            {joinNames(nonResponderNames)} {nonResponderNames.length === 1 ? "didn't respond" : "didn't respond"}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Best slots = max-overlap groups. We deliberately drop partial-overlap
+  // groups from this summary — they're noise for "when can we meet". Anyone
+  // who wants the full picture can expand "full grid" below.
+  const maxCount = groups.reduce((m, g) => Math.max(m, g.userIds.length), 0);
+  const best = groups
+    .filter((g) => g.userIds.length === maxCount)
+    .sort((a, b) => {
+      if (a.dayOffset !== b.dayOffset) return a.dayOffset - b.dayOffset;
+      return a.startSlot - b.startSlot;
+    });
+
+  const allRespondersOverlap = maxCount === responderIds.size;
+
+  const headerLine: string = allRespondersOverlap
+    ? `${joinNames(responderNames)} ${responderNames.length === 1 ? 'is' : 'are all'} free at:`
+    : `most overlap — ${maxCount} of ${responderIds.size} responders:`;
+
+  // When everyone-who-responded overlaps, the per-row name pill is redundant
+  // (it's the same set every row). When it's a partial overlap, name pill
+  // tells the user *which* subset is in for that block.
+  const renderRow = (g: SlotGroup) => {
+    const isoDate = poll.gridDates[g.dayOffset];
+    const date = formatFullDayLabel(isoDate);
+    const startTime = formatSlotLabel(poll.gridHourStart, g.startSlot, poll.gridSlotMinutes);
+    const end = formatSlotLabel(poll.gridHourStart, g.endSlot + 1, poll.gridSlotMinutes);
+    const range = g.startSlot === g.endSlot ? startTime : `${startTime}–${end}`;
+    const showNames = !allRespondersOverlap;
+    const names = g.userIds.map(nameOf);
+    return (
+      <div
+        key={`${g.dayOffset}-${g.startSlot}`}
+        className="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border bg-[rgba(232,255,90,0.08)] border-[rgba(232,255,90,0.35)]"
+      >
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <div className="font-serif text-sm text-primary truncate">{date}</div>
+          <div className="font-mono text-tiny text-dim">{range}</div>
+          {showNames && (
+            <span
+              className="font-mono text-tiny text-primary truncate"
+              title={names.join(', ')}
+            >
+              {joinNames(names)}
+            </span>
+          )}
+        </div>
+        {onProposeDate && (
+          <ProposeButton
+            onClick={() => onProposeDate(isoDate, startTime)}
+          />
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="space-y-2.5">
+      <div className="font-mono text-xs text-primary px-1 leading-snug">
+        {headerLine}
+      </div>
+      <div className="space-y-1.5">{best.map(renderRow)}</div>
+      {nonResponderNames.length > 0 && (
+        <div className="font-mono text-tiny text-faint px-1">
+          {joinNames(nonResponderNames)} didn&apos;t respond
+        </div>
+      )}
     </div>
   );
 }

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -943,6 +943,11 @@ const SquadChat = ({
       >
         {(() => {
           const lastConfirmIdx = messages.reduce((acc, m, idx) => m.messageType === 'date_confirm' ? idx : acc, -1);
+          // Active members (excludes waitlist) — used by closed-poll results
+          // to compute "didn't respond" relative to who could have voted.
+          const activeMembers = (localSquad.members ?? [])
+            .filter((m) => !!m.userId)
+            .map((m) => ({ userId: m.userId as string, displayName: m.name }));
           return messages.map((msg, i) => {
             const prev = i > 0 ? messages[i - 1] : null;
             const next = i < messages.length - 1 ? messages[i + 1] : null;
@@ -975,6 +980,13 @@ const SquadChat = ({
                   }
                   return next;
                 })}
+                squadMembers={activeMembers}
+                onProposeDateFromPoll={async (pollId, date, time) => {
+                  // Realtime subscription on `messages` will pick up the new
+                  // date_confirm row inserted server-side, so no manual
+                  // refresh needed here.
+                  await db.proposeDateFromPoll(pollId, date, time);
+                }}
               />
             );
           });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1783,6 +1783,36 @@ export async function closePoll(pollId: string) {
   return res.json();
 }
 
+export async function reopenPoll(pollId: string) {
+  const token = (await supabase.auth.getSession()).data.session?.access_token;
+  if (!token) throw new Error('Not authenticated');
+  const res = await fetch(`${API_BASE}/api/squads/reopen-poll`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ pollId }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || 'Failed to reopen poll');
+  }
+  return res.json();
+}
+
+export async function proposeDateFromPoll(pollId: string, date: string, time: string | null) {
+  const token = (await supabase.auth.getSession()).data.session?.access_token;
+  if (!token) throw new Error('Not authenticated');
+  const res = await fetch(`${API_BASE}/api/squads/propose-from-poll`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ pollId, date, time }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || 'Failed to propose date');
+  }
+  return res.json();
+}
+
 export function subscribeToPollVotes(
   pollId: string,
   callback: (payload: { user_id: string; option_index: number; poll_id: string }) => void

--- a/src/lib/server/squadDate.ts
+++ b/src/lib/server/squadDate.ts
@@ -17,6 +17,12 @@ export function formatDateLabel(date: string): string {
  * Pass `proposerUserId: null` when the proposal is system-initiated (e.g. a
  * dates-poll winner). In that case no auto-yes is recorded and confirm rows
  * are created for every member.
+ *
+ * Pass `preConfirmedUserIds` to skip the "are you still down?" prompt for
+ * members who already implicitly confirmed (e.g. they voted in the poll
+ * whose winning slot is now being proposed). Those members get
+ * `response: 'yes'` confirm rows and no notification — the only people
+ * pinged are squad members who didn't weigh in.
  */
 export async function proposeSquadDate(params: {
   adminClient: SupabaseClient;
@@ -25,8 +31,9 @@ export async function proposeSquadDate(params: {
   time: string | null;
   proposerUserId: string | null;
   proposerDisplayName: string;
+  preConfirmedUserIds?: string[];
 }): Promise<{ expiresAt: string; messageId: string }> {
-  const { adminClient, squadId, date, time, proposerUserId, proposerDisplayName } = params;
+  const { adminClient, squadId, date, time, proposerUserId, proposerDisplayName, preConfirmedUserIds } = params;
 
   const { data: squad } = await adminClient
     .from('squads')
@@ -92,16 +99,35 @@ export async function proposeSquadDate(params: {
     : await memberFilter;
   const otherMembers = allMembers ?? [];
 
+  // Split "other members" into two buckets:
+  //   - pre-confirmed (auto-yes, no notification) — they already weighed in
+  //     via the source-of-truth signal (poll vote, etc.)
+  //   - needs-prompt (response=null + notification) — the standard flow
+  const preConfirmedSet = new Set(preConfirmedUserIds ?? []);
+  const needsPrompt = otherMembers.filter((m) => !preConfirmedSet.has(m.user_id));
+  const autoYesOthers = otherMembers.filter((m) => preConfirmedSet.has(m.user_id));
+
   if (proposerUserId) {
     await adminClient
       .from('squad_date_confirms')
       .insert({ squad_id: squadId, message_id: messageId, user_id: proposerUserId, response: 'yes' });
   }
 
-  if (otherMembers.length > 0) {
+  if (autoYesOthers.length > 0) {
     await adminClient
       .from('squad_date_confirms')
-      .insert(otherMembers.map((m) => ({
+      .insert(autoYesOthers.map((m) => ({
+        squad_id: squadId,
+        message_id: messageId,
+        user_id: m.user_id,
+        response: 'yes',
+      })));
+  }
+
+  if (needsPrompt.length > 0) {
+    await adminClient
+      .from('squad_date_confirms')
+      .insert(needsPrompt.map((m) => ({
         squad_id: squadId,
         message_id: messageId,
         user_id: m.user_id,
@@ -109,7 +135,7 @@ export async function proposeSquadDate(params: {
 
     await adminClient
       .from('notifications')
-      .insert(otherMembers.map((m) => ({
+      .insert(needsPrompt.map((m) => ({
         user_id: m.user_id,
         type: 'date_confirm',
         title: squad?.name ?? 'Squad',


### PR DESCRIPTION
## Summary
- **Readable closed-poll view**: replaces the cramped heat-map grid (truncated "S 2..." headers, indistinguishable yellow tiles) with a ranked summary that groups consecutive same-set slots into "Sun, Apr 27 · 6pm–11pm" rows. Names who responded vs who didn't. Original heat map preserved as a collapsed details element.
- **PROPOSE button on each best-time row** — fires `/api/squads/propose-from-poll`. Crucially, anyone who voted in the poll is treated as already-confirmed (auto-yes confirm row, no notification), so the "are you still down?" prompt only pings squad members who never weighed in. The auto-propose path inside `close-poll` uses the same `preConfirmedUserIds` plumbing.
- **REOPEN POLL button** for poll creators — `/api/squads/reopen-poll`, mirrors close-poll's authz. Doesn't unwind any auto-proposed date.

No schema changes; works with existing closed polls in the DB (legacy `availability` and new `when:availability`).

## Test plan
- [ ] Close an availability poll with multiple voters — confirm summary lists max-overlap day/time blocks grouped into ranges, names responders, lists non-responders.
- [ ] Click PROPOSE on a best-time row — confirm a date_confirm message appears, voters in poll have pre-confirmed status (no prompt), only non-responders see "are you still down?".
- [ ] Reopen a closed poll as the creator — confirm status flips back to active, system message posts, voting becomes possible again.
- [ ] Close a poll with full vote (everyone responded) — confirm auto-propose locks without prompting anyone.
- [ ] Verify legacy closed polls in production render the new summary without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)