### PR TITLE
fix: real unique constraint on push_subscriptions(user_id, device_token)

### DIFF
--- a/supabase/migrations/20260426000001_push_subscriptions_real_unique_constraint.sql
+++ b/supabase/migrations/20260426000001_push_subscriptions_real_unique_constraint.sql
@@ -1,0 +1,25 @@
+-- Replace the partial unique index on (user_id, device_token) with a real
+-- unique constraint so PostgREST's `onConflict: user_id,device_token` upsert
+-- can find a matching constraint.
+--
+-- Background: 20260403000001 added
+--   CREATE UNIQUE INDEX push_subscriptions_user_device_token_key
+--     ON push_subscriptions (user_id, device_token)
+--     WHERE device_token IS NOT NULL;
+--
+-- Postgres can use partial indexes for ON CONFLICT only if the INSERT also
+-- specifies the same WHERE predicate, and PostgREST's `onConflict` query
+-- parameter doesn't emit one. Result: every native-push subscribe upsert
+-- fails with "there is no unique or exclusion constraint matching the
+-- ON CONFLICT specification" → API route returns 500 → push token never
+-- saved.
+--
+-- A non-partial UNIQUE constraint is functionally equivalent here: web push
+-- rows have device_token = NULL, and standard SQL treats NULL ≠ NULL for
+-- uniqueness, so multiple web-push rows per user are still allowed.
+
+DROP INDEX IF EXISTS public.push_subscriptions_user_device_token_key;
+
+ALTER TABLE public.push_subscriptions
+  ADD CONSTRAINT push_subscriptions_user_device_token_key
+  UNIQUE (user_id, device_token);


### PR DESCRIPTION
## Summary
Native iOS push registration round-trip now reaches the API but fails with 500. Root cause:

\`20260403000001\` added a **partial** unique index on \`(user_id, device_token) WHERE device_token IS NOT NULL\`. Postgres only uses partial indexes for ON CONFLICT if the INSERT carries the same WHERE predicate, and PostgREST's \`onConflict=user_id,device_token\` query parameter doesn't emit one. Every native-push upsert from \`/api/push/subscribe\` errors with:

> there is no unique or exclusion constraint matching the ON CONFLICT specification

so the API returns 500 and the device token never lands in the table.

Replace the partial index with a real UNIQUE constraint. Functionally equivalent here — web-push rows have \`device_token = NULL\` and standard SQL treats NULL ≠ NULL for uniqueness, so multiple web rows per user are still permitted (one per browser endpoint, which is what we want).

## Test plan
- [ ] After merge + Supabase migration apply: native iOS push toggle → row appears in \`push_subscriptions\` with \`platform='ios'\`, \`device_token\` populated
- [ ] Web push still works (existing rows untouched, new web rows still allowed per endpoint)
- [ ] Re-registering the same device on the same user upserts (no duplicate row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)