### PR TITLE
fix: show Delete button on checks that have a squad

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -384,7 +384,6 @@ export default function CheckCard({
         open={editModalOpen}
         onClose={() => setEditModalOpen(false)}
         friends={friendsList}
-        hasSquad={!!check.squadId}
         onShare={(check.isYours || check.isCoAuthor) ? () => { setEditModalOpen(false); shareCheck(); } : undefined}
         onDelete={(check.isYours || check.isCoAuthor) ? async () => {
           setEditModalOpen(false);

--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -17,7 +17,6 @@ const EditCheckModal = ({
   onRemoveTag,
   onShare,
   onDelete,
-  hasSquad,
 }: {
   check: InterestCheck | null;
   open: boolean;
@@ -37,7 +36,6 @@ const EditCheckModal = ({
   onRemoveTag?: (checkId: string, userId: string) => Promise<void>;
   onShare?: () => void;
   onDelete?: () => void;
-  hasSquad?: boolean;
 }) => {
   const [text, setText] = useState("");
   const [whenInput, setWhenInput] = useState("");
@@ -294,7 +292,7 @@ const EditCheckModal = ({
                   Share link
                 </button>
               )}
-              {onDelete && !hasSquad && (
+              {onDelete && (
                 <button
                   onClick={onDelete}
                   className="flex items-center gap-3 w-full bg-transparent border-none py-3.5 font-mono text-sm cursor-pointer text-left"


### PR DESCRIPTION
## Summary
Delete used to be hidden from the edit modal when a check had an associated squad. That guard was a holdover from when the action issued a hard delete (which would have orphaned the squad's \`check_id\` via \`ON DELETE SET NULL\`). PR #440 swapped the action to a soft archive only, so the original concern no longer applies — but the conditional came along, and there's been no way to retract a plan once a squad formed.

## Fix
Drop the \`!hasSquad\` guard in EditCheckModal. Remove the now-unused \`hasSquad\` prop + its CheckCard pass-through.

Soft-archive leaves \`squads.check_id\` intact (the FK didn't change), so the squad still resolves its parent check after Delete; revive un-hides the check again. If the delete was a real cancellation, the squad's lifecycle is handled separately by the existing expiry cron.

## Test plan
- [ ] Edit a check that *has* a formed squad → Delete button now visible
- [ ] Tap Delete → archive happens; toast undo restores; revive notification fires for down responders past the 5-min undo window (existing behavior)
- [ ] Edit a check with *no* squad → Delete still works (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)