### PR TITLE
fix: realtime sync rebuilds myCheckResponses for archived→revived checks

### DIFF
--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -127,11 +127,32 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
           if (via) c.viaFriendName = via;
         }
       }
-      dispatch({ type: CheckActionType.SYNC_CHECKS, checks: transformedChecks, userId });
+
+      // Rebuild myCheckResponses from server data — same shape as
+      // hydrateChecks. Without this, a check that re-appears via the
+      // realtime sub (e.g. after a revive) leaves the local responses
+      // map stale, so the "DOWN" button indicator doesn't switch back to
+      // "✓ DOWN" until the next full hydrate. patchYouResponses inside
+      // SYNC_CHECKS still re-applies any optimistic in-flight responses.
+      const restoredResponses: Record<string, "down" | "waitlist"> = {};
+      for (const c of transformedChecks) {
+        const myResponse = c.responses.find((r) => r.odbc === userId);
+        if (myResponse && (myResponse.status === "down" || myResponse.status === "waitlist")) {
+          restoredResponses[c.id] = myResponse.status;
+        }
+      }
+
+      dispatch({
+        type: CheckActionType.SYNC_CHECKS,
+        checks: transformedChecks,
+        responses: restoredResponses,
+        avatarLetter: profile?.avatar_letter,
+        userId,
+      });
     } catch (err) {
       logWarn("loadChecks", "Failed to load checks", { error: err });
     }
-  }, [userId]);
+  }, [userId, profile?.display_name, profile?.avatar_letter]);
 
   const hydrateChecks = useCallback((
     activeChecks: Awaited<ReturnType<typeof db.getActiveChecks>>,


### PR DESCRIPTION
## Symptom
On the recipient's window after the author revives a check: the check shows up in the feed, the "Kat + 2 others down" line correctly counts the recipient as one of the others, but the recipient's own button reads **DOWN ?** instead of **✓ DOWN**. A manual refresh fixes it.

## Why
Two paths sync checks into local state:

| | Source | \`responses\` param? |
|---|---|---|
| \`hydrateChecks\` | \`page.tsx\` \`loadRealData\` | ✅ rebuilt from server |
| \`loadChecks\` | realtime sub on \`interest_checks\` / \`check_responses\` | ❌ omitted |

The reducer's \`SYNC_CHECKS\` REPLACES \`myCheckResponses\` when \`responses\` is provided and PRESERVES the existing map when it isn't. Symmetry breaks when a check disappears and reappears in the same session:

1. Sara responds **down** on c4444444 → \`myCheckResponses[c4444444] = "down"\`.
2. Some hydrate runs while c4444444 is archived (or wasn't in feed at first load) → its entry never makes it into \`restoredResponses\` → REPLACE wipes it.
3. Kat revives → sara's realtime sub fires \`loadChecks\` → SYNC_CHECKS without \`responses\` → fallback preserves the now-empty map.
4. \`c.responses\` has sara's down (server data is fine). \`myCheckResponses[c4444444]\` doesn't. The button keys off the latter → "DOWN ?".

## Fix
\`loadChecks\` now derives \`restoredResponses\` from \`c.responses\` the same way \`hydrateChecks\` does and passes it to SYNC_CHECKS. \`patchYouResponses\` inside the reducer still re-injects optimistic in-flight responses, so the "I just tapped DOWN, server hasn't confirmed yet" race doesn't regress.

## Test plan
- [ ] As Sara: respond **down** on a check; check the button reads "✓ DOWN" (regression check)
- [ ] Kat archives the check; on Sara's side the check disappears
- [ ] Kat revives; on Sara's side without refreshing — check reappears AND button reads "✓ DOWN"
- [ ] Optimistic flow: Sara taps DOWN; before server confirms, a realtime sync fires (e.g. someone else responds) → button stays "✓ DOWN" (patchYouResponses safety net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)