### PR TITLE
fix: refresh feed when check_archived / check_revived realtime arrives

### DIFF
--- a/src/app/hooks/useRealtimeNotifications.ts
+++ b/src/app/hooks/useRealtimeNotifications.ts
@@ -117,6 +117,14 @@ export function useRealtimeNotifications({
       } else if (newNotif.type === "check_tag") {
         if (newNotif.body) showToastRef.current(newNotif.title + ": " + newNotif.body);
         loadRealDataRef.current();
+      } else if (newNotif.type === "check_archived" || newNotif.type === "check_revived") {
+        // Realtime on `interest_checks` is RLS-gated: once a check is
+        // archived, the recipient loses SELECT visibility and so the
+        // UPDATE event never reaches them — their cached checks list
+        // would otherwise still show the row. Same in reverse on revive
+        // when the row was previously hidden. Fall through to a full
+        // refresh so the feed converges to the new state.
+        loadRealDataRef.current();
       } else if (newNotif.type === "friend_accepted" && newNotif.related_user_id) {
         if (newNotif.body) showToastRef.current(newNotif.body);
         loadRealDataRef.current();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -199,7 +199,7 @@ export interface SquadJoinRequest {
 export interface Notification {
   id: string;
   user_id: string;
-  type: 'friend_request' | 'friend_accepted' | 'check_response' | 'squad_message' | 'squad_invite' | 'friend_check' | 'date_confirm' | 'check_tag' | 'check_comment' | 'poll_created' | 'squad_join_request' | 'squad_mention' | 'comment_mention' | 'friend_event' | 'event_reminder' | 'event_down' | 'check_date_updated' | 'event_date_updated' | 'event_comment';
+  type: 'friend_request' | 'friend_accepted' | 'check_response' | 'squad_message' | 'squad_invite' | 'friend_check' | 'date_confirm' | 'check_tag' | 'check_comment' | 'poll_created' | 'squad_join_request' | 'squad_mention' | 'comment_mention' | 'friend_event' | 'event_reminder' | 'event_down' | 'check_date_updated' | 'check_text_updated' | 'event_date_updated' | 'event_comment' | 'check_archived' | 'check_revived';
   title: string;
   body: string | null;
   related_user_id: string | null;


### PR DESCRIPTION
## Symptom
After Kat archives a check, Sara's feed keeps showing the row even though her notification panel correctly receives \`check_archived\`. A manual refresh removes it. Same shape on revive — local feed state stays stale until the next full hydrate.

## Root cause
Two realtime channels are involved and they have different RLS reach:

- \`interest_checks\` channel (subscribed via \`db.subscribeToChecks\`) → RLS-gated. Once \`archived_at\` is set, the recipient loses SELECT visibility on the row, so Supabase realtime filters out the UPDATE event before delivering it. Their \`loadChecks\` never fires.
- \`notifications\` channel (subscribed via \`useRealtimeNotifications\`) → does deliver the \`check_archived\` / \`check_revived\` row, because the recipient *can* see notifications addressed to them. But the type-specific handler had no branch for these two types.

So the bell got the message and the feed didn't.

## Fix
Add a \`check_archived\` / \`check_revived\` branch in \`useRealtimeNotifications\` that calls \`loadRealDataRef.current()\` — same pattern \`friend_check\`, \`check_tag\`, \`squad_invite\` already use. The full hydrate re-fetches \`getActiveChecks\` (with its \`.is('archived_at', null)\` filter), so the archived row drops off the recipient's feed and the revived row reappears, all without a manual refresh.

Also patches the \`notification.type\` union in \`types.ts\` — it had drifted from the SQL constraint (missing \`check_archived\`, \`check_revived\`, \`check_text_updated\`).

## Test plan
- [ ] Window A archives a check → Window B's feed drops the row within ~1s, no manual refresh
- [ ] Window A revives the same check → Window B's feed re-shows it immediately
- [ ] Other notification types (\`friend_check\`, \`check_tag\`, etc.) still trigger their existing handlers (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)