### PR TITLE
fix: evict iOS-Safari PWA subs when user installs native iOS app

### DIFF
--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -7,7 +7,7 @@ export async function POST(request: NextRequest) {
   const { user, supabase } = auth;
 
   const body = await request.json();
-  const { platform, deviceToken, endpoint, p256dh, auth: authKey } = body;
+  const { platform, deviceToken, endpoint, p256dh, auth: authKey, userAgent } = body;
 
   // Native push (iOS / Android)
   if (platform === 'ios' || platform === 'android') {
@@ -33,6 +33,20 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
+    // If this user has a Safari-on-iOS PWA web push row, the iPhone they just
+    // registered the native app on is the same physical device that registered
+    // that row. Without this, every push fans out to both the PWA and the
+    // native app — duplicate banners on one phone. Mac Safari PWA + Android
+    // PWA stay untouched (different UAs).
+    if (platform === 'ios') {
+      await supabase
+        .from('push_subscriptions')
+        .delete()
+        .eq('user_id', user.id)
+        .eq('platform', 'web')
+        .or('user_agent.ilike.*iPhone*,user_agent.ilike.*iPad*,user_agent.ilike.*iPod*');
+    }
+
     return NextResponse.json({ ok: true });
   }
 
@@ -44,7 +58,14 @@ export async function POST(request: NextRequest) {
   const { error } = await supabase
     .from('push_subscriptions')
     .upsert(
-      { user_id: user.id, endpoint, p256dh, auth: authKey, platform: 'web' },
+      {
+        user_id: user.id,
+        endpoint,
+        p256dh,
+        auth: authKey,
+        platform: 'web',
+        user_agent: typeof userAgent === 'string' ? userAgent : null,
+      },
       { onConflict: 'user_id,endpoint' }
     );
 

--- a/src/lib/pushNotifications.ts
+++ b/src/lib/pushNotifications.ts
@@ -105,6 +105,9 @@ async function saveSubscriptionToServer(subscription: PushSubscription): Promise
       endpoint: subscription.endpoint,
       p256dh: subJson.keys?.p256dh,
       auth: subJson.keys?.auth,
+      // UA so the server can later identify iOS-Safari rows to evict
+      // when the same user installs the native app.
+      userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : undefined,
     }),
   });
 }

--- a/supabase/migrations/20260426000002_push_subscriptions_user_agent.sql
+++ b/supabase/migrations/20260426000002_push_subscriptions_user_agent.sql
@@ -1,0 +1,15 @@
+-- Track which UA registered each web push subscription so we can clean up
+-- iOS-Safari PWA subs when the same user installs the native iOS app.
+--
+-- Without this, a user who saved the PWA to their home screen and then
+-- downloads the App Store app gets every notification twice on the same
+-- iPhone: once via Apple Web Push to the PWA, once via APNs to the native
+-- app. The endpoints both live under web.push.apple.com / Apple Push
+-- Service so we can't tell them apart by URL alone — but we *can* tell
+-- iOS Safari from Mac Safari from the user agent.
+--
+-- Existing rows stay NULL; the cleanup logic falls back to "leave alone"
+-- for rows it can't classify.
+
+ALTER TABLE public.push_subscriptions
+  ADD COLUMN IF NOT EXISTS user_agent TEXT;


### PR DESCRIPTION
## Summary
Once the App Store app is live, a user who has the PWA saved to their iPhone home screen *and* installs the native app gets every notification twice on the same device — once via Apple Web Push to the PWA, once via APNs to the native app. Both endpoints live under \`web.push.apple.com\` / Apple Push Service, so we can't disambiguate by URL alone.

Use the user agent instead. iOS Safari's UA includes \`iPhone\` / \`iPad\` / \`iPod\`; macOS Safari's doesn't. When the user registers a native iOS device, that's the same physical iPhone whose Safari subscribed. Delete just those iOS-Safari rows; leave Mac/Android web rows intact so those devices keep receiving pushes.

### Changes
- **Migration** \`20260426000002\`: add \`push_subscriptions.user_agent TEXT\` (nullable, no backfill)
- **Client** \`pushNotifications.ts\`: send \`navigator.userAgent\` with the web subscribe payload
- **API** \`/api/push/subscribe\`:
  - On web subscribe: persist \`user_agent\`
  - On iOS native subscribe: also delete that user's iOS-Safari web rows

### Notes on legacy data
Existing rows stay NULL on \`user_agent\` and are left alone by the cleanup. They'll naturally clean up via the existing \`lib/push.ts\` 404/410 / Unregistered / BadDeviceToken handling on the next fan-out attempt, OR the next time the user re-subscribes via the PWA (which will overwrite with a UA-tagged row).

## Test plan
- [ ] After migration: existing rows have \`user_agent IS NULL\`; new web subscribes write the UA
- [ ] PWA subscribe on iPhone Safari + native app install on same user → web row deleted, only iOS row remains
- [ ] PWA subscribe on Mac Safari + native iOS install → Mac web row preserved
- [ ] Android Chrome PWA subscribe + native iOS install → Android web row preserved
- [ ] Web push to a Mac/Android user still works (no schema regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)