### PR TITLE
docs: rewrite CLAUDE.md design rules to match cream/magenta system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,64 +9,94 @@ Product behavior specs live in `specs/`. Read the relevant spec before implement
 - Next.js (App Router)
 - TypeScript
 - Supabase (auth, Postgres, RLS, Realtime, DB triggers)
-- Migrating to Tailwind CSS — inline styles are fine during this transition. Space Mono + Instrument Serif fonts, dark theme with #E8FF5A accent
+- Tailwind CSS (primary). The theme lives in `src/app/global.css` (`@theme` block). `src/lib/styles.ts` exports a parallel `color` map that mirrors the Tailwind palette — fine to use for inline styles when reaching for one-off values
+- Light cream theme (#FCFFE2 bg) with #FE44FF magenta accent. Inter for serif/headings, IBM Plex Mono for body/labels
 
 ## Design Rules
 
-Migrating from inline styles to Tailwind CSS. Inline styles with tokens from `src/lib/styles.ts` are acceptable during the transition.
+Prefer Tailwind classes over inline styles. The `color` object in `src/lib/styles.ts` is kept in sync with the Tailwind palette and is acceptable for inline-style use; the `font` object there (`Sora`/`Exo`) is **out of sync** with the actual rendered fonts (Inter / IBM Plex Mono) — don't rely on it, use the `font-serif` / `font-mono` classes.
+
+### Surfaces
+- `bg-bg` (#FCFFE2 cream) — page background
+- `bg-card` (#FCFFE2) — card background, same as page; cards rely on borders for separation
+- `bg-surface` (#E0DCC8) — bottom sheets, panels
+- `bg-deep` (#D8D4C0) — modal panels, confirm dialogs
+- `bg-dt` / `text-dt` (#FE44FF magenta) — brand accent, your content, active states. Pair with `text-on-accent` (#fff) on `bg-dt` backgrounds
+- `bg-pool` / `text-pool` (#00D4FF) — squad pool / "looking for crew" affordances
+- `bg-danger` / `text-danger` (#ff6b6b) — destructive / urgent
+
+### Text hierarchy
+- `text-primary` (#2A2A1A) — main content
+- `text-muted` (#6B6B5A) — secondary (other people's names, last-message previews)
+- `text-dim` (#8A8A70) — tertiary (venue, timestamps, "via" annotations)
+- `text-faint` (#B0B098) — quaternary (placeholder, expired/disabled state, separators)
+- `text-dt` — your content, active states, links, primary actions
+
+### Borders
+- `border-border` (#D8D4C0) — default card/panel borders
+- `border-border-light` (#C8C4B0) — subtle separators, used as the bg for non-highlight avatars and pill chips
+- `border-border-mid` (#B8B4A0) — emphasized borders
 
 ### Typography
-- **Headings**: `font.serif`, weight 400 — 22px for sheet/panel titles, 24px for event card titles, 18px for check body text and modal titles, 17px for squad card names
-- **Body/labels**: `font.mono` — 12–13px for body text and buttons, 11px for secondary labels (author names, notification titles), 10px for metadata (timestamps, section labels, expiry)
-- **Section labels**: `font.mono`, 10px, `textTransform: "uppercase"`, `letterSpacing: "0.15em"`, `color.dim`
-- **Action button text**: `font.mono`, 12px, weight 700, uppercase, `letterSpacing: "0.08em"`
-
-### Color hierarchy (text)
-- `color.text` (#fff) — primary content
-- `color.muted` (#888) — secondary (other people's names, last messages)
-- `color.dim` (#666) — tertiary (venue, timestamps, "via" annotations, inactive buttons)
-- `color.faint` (#444) — quaternary (message timestamps, expiry labels, disabled state)
-- `color.accent` (#E8FF5A) — your content, active states, primary actions
+- `font-serif` → Inter. Use for headings. The `.font-serif` class applies `letter-spacing: -0.04em`. Standard heading sizes: `text-lg` (18px) for card titles, `text-xl`/`text-2xl` for sheet/modal titles.
+- `font-mono` → IBM Plex Mono. Use for body, labels, buttons. The `.font-mono` class applies `letter-spacing: -0.04em` and weight 400. Standard sizes: `text-xs` (12px) body, `text-tiny` (10px) metadata/labels.
+- Section labels: `font-mono text-tiny uppercase tracking-widest text-dim`
+- Action button text: `font-mono text-xs font-bold uppercase tracking-wider`
 
 ### Cards
-- Event cards: `borderRadius: 20`, `marginBottom: 16`, bg `color.card`, border `color.border`
-- Check cards: `borderRadius: 14`, `marginBottom: 8`, bg `color.card`, border `color.border`
-- Squad cards: `borderRadius: 16`, `marginBottom: 8`, `padding: 16`, bg `color.card`, border `color.border`
+- Default: `rounded-2xl mb-2 bg-card border border-border` (16px radius)
+- Newly-added emphasis: `rounded-sm bg-(--color-check-new-bg) border-(--color-check-new-border)` — sharper corners + warm tint draw the eye
+- Down state on check cards: apply the `check-down` class (defined in `global.css`) — sets `bg-(--color-check-down-bg)` and clears the border
+- Author/created-by check cards: apply the `check-mine` class — same pattern with `bg-(--color-check-mine-bg)`
+- Author row (cards in feed): `w-5 h-5 rounded-full bg-border-light text-dt` letter circle, then `font-mono text-tiny text-muted` line with the author name in `text-dt font-semibold`. "via {friendName}" uses `text-dim` for the FoF annotation.
+
+### Bottom sheets (DetailSheet, ReportSheet, CheckActionsSheet, NotificationsPanel, EventLobby, …)
+- Mount under `fixed inset-0 z-[100] flex items-end justify-center`
+- Backdrop: transparent → `backdropFilter: blur(8px)`, transitioned over 300ms (entering and closing both go to `blur(0px)`)
+- Panel: `bg-surface rounded-t-3xl pt-3`, max width 420px, max height 70–80vh
+- Drag handle: `w-10 h-1 bg-faint rounded-sm` centered at top (inside a `touch-none` wrapper)
+- Animation: `animate-slide-up` on open; `translateY(100%)` over 250ms on close
+- Swipe-to-dismiss: 60px downward threshold
+- The shared shell is `src/shared/components/DetailSheet.tsx` — prefer extending it over reimplementing the gesture/animation logic
 
 ### Avatars
-- Letter circles, `borderRadius: "50%"`. Sizes: 36px (lobby/notifications), 28px (check authors), 24px (responses, chat members)
-- Your avatar: bg `color.accent`, color `#000`
-- Others: bg `color.borderLight`, color `color.dim`
-- Stacked avatars overlap with `marginLeft: -6` (responses) or `-8` (event social preview), `border: 2px solid color.card`
-- Overflow: "+N" counter at 8px mono 700
+Use `<AvatarLetter avatarLetter={...} size="..." highlight={isYou} />`.
+- Sizes: `inline` (24px), `small` (28px), `medium` (40px), `display` (72px)
+- `highlight={true}` → your avatar, magenta fill
+- Stacked avatars overlap with `marginLeft: -6` to `-8`, `border: 2px solid` matching the surface they sit on
+- "+N" overflow counter: `font-mono text-[8px] font-bold`
+- The component's non-highlight default still references dark-theme tokens (`bg-neutral-800 text-neutral-500`) — call sites that want the cream-theme look pass `className="bg-border-light text-dim"`. When touching avatar-using components, prefer fixing them (or the component) to the new tokens.
 
-### Bottom sheets (EventLobby, NotificationsPanel)
-- Backdrop: `rgba(0,0,0,0.7)` + `backdropFilter: blur(8px)`, zIndex 100
-- Panel: bg `color.surface`, `borderRadius: "24px 24px 0 0"`, maxWidth 420, maxHeight 70–80vh
-- Drag handle: 40x4px, bg `color.faint`, borderRadius 2, centered
-- Open animation: `slideUp 0.3s ease-out`. Close: `translateY(100%)` over 0.25s
-- Swipe-to-dismiss threshold: 60px downward
-
-### Compound metadata
-Join related info with `" · "` separator (space-dot-space) in a single line:
-- `2h · expires 3d` (squad list)
-- `Feb 15 · 8pm` (event card)
-Use `color.faint` for the whole line, or per-segment coloring (e.g. red for urgent expiry under 24h)
-
-### Status indicators
-- Notification unread dot: 8px circle, `color.accent` (yellow)
-- Squad unread dot: 8px circle, `#ff3b30` (red) — used in both squad cards and bottom nav
-- Expiry bar on checks: 3px tall, green→orange→red as time elapses
+### Pills, badges, dots
+- "New" badge: `bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full`
+- Vibe pill: `bg-border-light text-dt py-0.5 px-1.5 rounded-xl font-mono text-tiny uppercase tracking-widest`
+- Notification unread dot: `w-2 h-2 rounded-full bg-dt`
+- Squad unread dot: `w-2 h-2 rounded-full bg-red-500` (squad cards + bottom nav)
+- Expiry bar on checks: 3px tall, green → orange → red gradient as time elapses
 
 ### Buttons
-- Primary: bg `color.accent`, color `#000`, borderRadius 12, padding 12–14px
-- Secondary: bg transparent, color `color.text`/`color.dim`, border `1px solid color.borderMid`, borderRadius 12
-- Destructive: bg `#ff4444`, color `#fff`, borderRadius 10
+Use `<Button variant="..." size="..." />` from `src/shared/components/Button.tsx` for the standard set:
+- `primary` — `bg-dt` filled, dark text
+- `outline` — transparent with a neutral border (this variant still uses dark-theme tokens, hasn't been reskinned yet)
+- `highlight` — transparent with `text-dt` and `border-dt`
+- Sizes: `small` (`rounded-lg text-tiny`), `medium` (`rounded-lg text-xs`), `large` (`rounded-xl text-sm uppercase tracking-widest`)
 
-### Confirm dialogs
-- Overlay: fixed inset, `rgba(0,0,0,0.7)`, zIndex 9999
-- Panel: bg `color.deep`, border `color.border`, borderRadius 16, maxWidth 300, padding `24px 20px`
-- Title serif 18px, body mono 11px `color.dim`, button row flex gap 10
+Card-internal toggles ("DOWN ?" on event cards):
+- Idle: `bg-(--color-down-idle-bg) text-dt border border-(--color-down-idle-border) rounded-full`
+- Active: `bg-dt text-bg rounded-full`
+
+### Compound metadata
+Join related info with `" · "` separator (space-dot-space):
+- `Feb 15 · 8pm` (event/check date/time line)
+- `2h · expires 3d` (squad list)
+Use `text-faint` for the whole line, or per-segment coloring (e.g. `text-danger` for urgent expiry under 24h).
+
+### Global behaviors (in `global.css` `@layer base`)
+- All buttons: `transition: all 0.15s ease`, `:active` scales to 0.97
+- Inputs: `:focus { border-color: #FE44FF }` and `::placeholder { color: #B0B098 }`
+- `html, body` are `overflow: hidden` with `overscroll-behavior: none` (mobile-first, no rubber-banding)
+- `* { user-select: none }` by default; inputs/textareas/contenteditable opt back into text selection
+- Animations available as Tailwind classes: `animate-fade-in`, `animate-slide-up`. `expiryShimmer` keyframe is defined for the check expiry bar.
 
 ## Development
 - `npm run dev` — local Supabase (`127.0.0.1:54321` via `.env.development.local`)


### PR DESCRIPTION
## Summary
- The previous Design Rules section in `CLAUDE.md` described the pre-reskin dark theme (`#E8FF5A` yellow, Space Mono / Instrument Serif). The codebase has migrated to the cream/magenta system in `src/app/global.css` with Inter + IBM Plex Mono.
- Rewrites the section using the current Tailwind class tokens (`bg-bg`, `bg-surface`, `bg-deep`, `text-dt`, `text-primary`, `border-border-mid`, …) and real component patterns from `EventCard`, `CheckCard`, `DetailSheet`, and `Button`.
- Flags three known reskin gaps so future-me doesn't drift back into the old patterns: stale `font` tokens in `src/lib/styles.ts` (Sora/Exo), the un-reskinned `Button` `outline` variant, and the `AvatarLetter` non-highlight default.

## Test plan
- [ ] Skim diff to confirm tokens match `src/app/global.css` `@theme` block
- [ ] Spot-check a few referenced patterns (`check-down` / `check-mine` classes, `DetailSheet` shell) still match the components

🤖 Generated with [Claude Code](https://claude.com/claude-code)