### PR TITLE
chore: drop unused font families and redundant Google Fonts link

### DIFF
--- a/src/app/components/Toast.tsx
+++ b/src/app/components/Toast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { font, color } from "@/lib/styles";
+import { color } from "@/lib/styles";
 
 const Toast = ({
   message,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next';
-import { Sora, Exo, Instrument_Serif, Space_Mono, IBM_Plex_Mono, Inter } from 'next/font/google';
+import { Instrument_Serif, Space_Mono, IBM_Plex_Mono, Inter } from 'next/font/google';
 import DevProdBanner from '@/app/components/DevProdBanner';
 import DevUserSwitcher from '@/app/components/DevUserSwitcher';
 import UpdateBanner from '@/app/components/UpdateBanner';
@@ -10,16 +10,10 @@ import NativeStatusBar from '@/app/components/NativeStatusBar';
 import './global.css';
 import './animations.css';
 
-const sora = Sora({
-  weight: ['400', '500', '600', '700'],
-  variable: '--font-sora',
-  subsets: ['latin'],
-});
-const exo = Exo({
-  weight: ['400', '500', '600', '700'],
-  variable: '--font-exo',
-  subsets: ['latin'],
-});
+// Fonts loaded here are referenced by the theme system in src/lib/themes/.
+// Inter + IBM Plex Mono → guava (default). Instrument Serif + Space Mono →
+// dragonfruit. next/font/google self-hosts at build time, so no Google Fonts
+// <link> is needed at runtime.
 const instrumentSerif = Instrument_Serif({
   weight: '400',
   variable: '--font-instrument-serif',
@@ -73,19 +67,9 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${sora.variable} ${exo.variable} ${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${inter.variable}`}
+      className={`${instrumentSerif.variable} ${spaceMono.variable} ${ibmPlexMono.variable} ${inter.variable}`}
     >
       <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Exo:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=Space+Mono:ital,wght@0,400;0,700;1,400&display=swap"
-          rel="stylesheet"
-        />
         <meta name="theme-color" content="#FCFFE2" />
         <link rel="apple-touch-icon" href="/icons/icon-192.png" />
         <style>{`

--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -1,8 +1,11 @@
-export const font = {
-  mono: "'Exo', sans-serif",
-  serif: "'Sora', sans-serif",
-};
-
+// Color palette mirror of the @theme block in src/app/global.css. Use these
+// for inline-style values when reaching for one-offs; for everything else
+// prefer the Tailwind classes (bg-bg, text-primary, …). The active theme
+// (guava | dragonfruit) overrides these via CSS vars at runtime, so values
+// here are guava defaults.
+//
+// Fonts: use the `font-serif` / `font-mono` Tailwind classes (which resolve
+// to per-theme CSS vars). There is no font map exported here.
 export const color = {
   accent: "#FE44FF",
   bg: "#FCFFE2",


### PR DESCRIPTION
## Summary
- The runtime theme system (`src/lib/themes/`) has two themes: **guava** (default) → IBM Plex Mono + Inter, and **dragonfruit** → Space Mono + Instrument Serif. Sora and Exo are referenced by neither — dropped.
- `src/app/layout.tsx` was loading Sora/Exo via `next/font/google` *and* re-loading Sora, Exo, Instrument Serif, and Space Mono via a `<link>` to fonts.googleapis.com. Since `next/font/google` self-hosts at build time, the `<link>` was duplicate-loading 4 faces on every page. Removed the link and the matching preconnects.
- `src/lib/styles.ts` exported a `font` map (`'Sora'`/`'Exo'`) that was out of sync with both themes and only imported by `Toast.tsx`, which already uses `var(--font-mono)` directly. Removed the export and the dead import.

Net effect: 4 font faces dropped from the network on first paint (Sora + Exo via next/font, plus the redundant `<link>` for those + Instrument Serif + Space Mono), no visual change.

## Test plan
- [ ] Build the app and confirm no Sora/Exo references remain (`grep -rn "Sora\|Exo\|font-sora\|font-exo" src/`)
- [ ] Switch between guava and dragonfruit at runtime and verify fonts still render
- [ ] DevTools Network: confirm only IBM Plex Mono + Inter (+ Instrument Serif + Space Mono if dragonfruit) are loaded — no googleapis.com requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)