### PR TITLE
feat: auto-form squad on first non-author down via SQL trigger

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -100,13 +100,6 @@ export default function Home() {
     showToast,
     onCheckCreated: () => { setTab("feed"); clearAddGlowRef.current(); },
     onDownResponse: () => { loadRealDataRef.current(); },
-    onAutoSquad: (checkId: string) => {
-      // Use latest checks state via ref to avoid stale closure
-      const check = checksHook.checks.find((c) => c.id === checkId);
-      if (check && !check.squadId) {
-        squadsHook.startSquadFromCheck(check);
-      }
-    },
     onCoAuthorRespond: (checkId: string) => {
       // Mark check_tag notification as read when user accepts/declines
       const tagNotif = notificationsHook.notifications.find(
@@ -853,7 +846,6 @@ export default function Home() {
             friends={friendsHook.friends}
             userId={userId}
             profile={profile}
-            startSquadFromCheck={squadsHook.startSquadFromCheck}
             loadRealData={loadRealData}
             showToast={showToast}
             showToastWithAction={showToastWithAction}

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -66,7 +66,6 @@ export interface CheckCardProps {
   friends: Friend[];
   sharedCheckId?: string | null;
   initialCommentCount: number;
-  startSquadFromCheck: (check: InterestCheck) => Promise<void>;
   onNavigateToGroups: (squadId?: string) => void;
   onViewProfile?: (userId: string) => void;
   showToast: (msg: string) => void;
@@ -82,7 +81,6 @@ export default function CheckCard({
   friends,
   sharedCheckId,
   initialCommentCount,
-  startSquadFromCheck,
   onNavigateToGroups,
   onViewProfile,
   showToast,
@@ -285,12 +283,6 @@ export default function CheckCard({
                 </div>
               );
             })()}
-            {(check.isYours || check.isCoAuthor) && !check.squadId && myCheckResponses[check.id] !== "down" && check.responses.some(r => r.status === "down") && (
-              <button
-                onClick={(e) => { e.stopPropagation(); startSquadFromCheck(check); }}
-                className="bg-transparent text-dt border border-dt rounded-md py-1 px-2 font-mono text-tiny font-bold cursor-pointer mt-1.5"
-              >Squad →</button>
-            )}
           </div>
 
           {/* Responses + comment toggle + down button */}

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -102,11 +102,10 @@ interface UseChecksParams {
   showToast: (msg: string) => void;
   onCheckCreated?: () => void;
   onDownResponse?: () => Promise<void> | void;
-  onAutoSquad?: (checkId: string) => void;
   onCoAuthorRespond?: (checkId: string) => void;
 }
 
-export function useChecks({ userId, profile, friendCount, showToast, onCheckCreated, onDownResponse, onAutoSquad, onCoAuthorRespond }: UseChecksParams) {
+export function useChecks({ userId, profile, friendCount, showToast, onCheckCreated, onDownResponse, onCoAuthorRespond }: UseChecksParams) {
   // Single reducer replaces 6x useState
   const [state, dispatch] = useReducer(checksReducer, initialChecksState);
   const { checks, myCheckResponses, hiddenCheckIds, pendingDownCheckIds, newlyAddedCheckId, leftChecks } = state;
@@ -204,16 +203,6 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
           if (onDownResponse) await onDownResponse();
           else await loadChecks();
           dispatch({ type: CheckActionType.SET_PENDING, checkId, pending: false });
-          if (result.response === 'down' && onAutoSquad) {
-            // Read latest checks after reload to check squad/down count
-            const updated = checks.find((c) => c.id === checkId);
-            if (updated && !updated.squadId) {
-              const downCount = updated.responses.filter((r) => r.status === "down").length;
-              if (downCount >= 2) {
-                setTimeout(() => onAutoSquad(checkId), 300);
-              }
-            }
-          }
         })
         .catch((err) => {
           dispatch({ type: CheckActionType.SET_PENDING, checkId, pending: false });

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -92,7 +92,6 @@ export interface FeedViewProps {
   friends: Friend[];
   userId: string | null;
   profile: Profile | null;
-  startSquadFromCheck: (check: InterestCheck) => Promise<void>;
   loadRealData: () => Promise<void>;
   showToast: (msg: string) => void;
   showToastWithAction?: (msg: string, action: () => void) => void;
@@ -115,7 +114,6 @@ export default function FeedView({
   friends,
   userId,
   profile,
-  startSquadFromCheck,
   loadRealData,
   showToast,
   showToastWithAction,
@@ -248,7 +246,6 @@ export default function FeedView({
                 friends={friends}
                 sharedCheckId={sharedCheckId}
                 initialCommentCount={commentCounts[check.id] ?? 0}
-                startSquadFromCheck={startSquadFromCheck}
                 onNavigateToGroups={onNavigateToGroups}
                 onViewProfile={onViewProfile}
                 showToast={showToast}
@@ -269,7 +266,6 @@ export default function FeedView({
                   friends={friends}
                   sharedCheckId={sharedCheckId}
                   initialCommentCount={commentCounts[item.data.id] ?? 0}
-                  startSquadFromCheck={startSquadFromCheck}
                   onNavigateToGroups={onNavigateToGroups}
                   onViewProfile={onViewProfile}
                   showToast={showToast}

--- a/supabase/migrations/20260426000002_auto_create_squad_on_first_other_down.sql
+++ b/supabase/migrations/20260426000002_auto_create_squad_on_first_other_down.sql
@@ -1,0 +1,124 @@
+-- Auto-form the squad as soon as the first non-author down response lands.
+--
+-- Squad creation used to have two paths and neither covered the obvious case
+-- "author makes a check, friend taps Down, plan happens":
+--   1. Author taps a "Squad →" button on the check card (manual).
+--   2. Client-side onAutoSquad in useChecks fires when the local user taps
+--      "down" and the threshold of >=2 explicit responders is met.
+--
+-- Both ignore that the author is *implicitly* down — we shouldn't need them
+-- to tap anything for the squad to form. And both depend on a specific
+-- client being online at the right moment.
+--
+-- This trigger does the work in SQL so it's deterministic regardless of who
+-- tapped what or who's online. The companion auto_join_squad_on_down_response
+-- trigger from 20260217000008 keeps adding subsequent responders to the
+-- existing squad — this only handles the *creation* moment.
+
+CREATE OR REPLACE FUNCTION public.auto_create_squad_on_first_other_down()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_check_id UUID := NEW.check_id;
+  v_author_id UUID;
+  v_check_text TEXT;
+  v_squad_name TEXT;
+  v_existing_squad_id UUID;
+  v_existing_archived_squad_id UUID;
+  v_squad_id UUID;
+  v_opener TEXT;
+BEGIN
+  -- Only act on "down" responses.
+  IF NEW.response != 'down' THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT author_id, text INTO v_author_id, v_check_text
+  FROM public.interest_checks
+  WHERE id = v_check_id;
+
+  -- Author tapping down on their own check doesn't form a squad — author is
+  -- implicit, we need at least one OTHER person down.
+  IF NEW.user_id = v_author_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- Skip if a non-archived squad already exists for this check. The
+  -- companion auto-join trigger will fold this responder in.
+  SELECT id INTO v_existing_squad_id
+  FROM public.squads
+  WHERE check_id = v_check_id
+    AND archived_at IS NULL
+  LIMIT 1;
+  IF v_existing_squad_id IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- If an archived squad exists for this check, reactivate it instead of
+  -- spinning up a duplicate. Mirrors the client's "rebuild the same squad"
+  -- semantics.
+  SELECT id INTO v_existing_archived_squad_id
+  FROM public.squads
+  WHERE check_id = v_check_id
+    AND archived_at IS NOT NULL
+  ORDER BY created_at DESC
+  LIMIT 1;
+  IF v_existing_archived_squad_id IS NOT NULL THEN
+    UPDATE public.squads
+      SET archived_at = NULL
+      WHERE id = v_existing_archived_squad_id;
+    INSERT INTO public.squad_members (squad_id, user_id)
+    VALUES (v_existing_archived_squad_id, NEW.user_id)
+    ON CONFLICT (squad_id, user_id) DO NOTHING;
+    RETURN NEW;
+  END IF;
+
+  -- Squad name is the check text trimmed to 30 chars.
+  v_squad_name := SUBSTRING(COALESCE(v_check_text, 'squad') FROM 1 FOR 30);
+  IF char_length(COALESCE(v_check_text, '')) > 30 THEN
+    v_squad_name := v_squad_name || '...';
+  END IF;
+
+  INSERT INTO public.squads (name, check_id, created_by)
+  VALUES (v_squad_name, v_check_id, NEW.user_id)
+  RETURNING id INTO v_squad_id;
+
+  INSERT INTO public.squad_members (squad_id, user_id, role)
+  VALUES
+    (v_squad_id, v_author_id, 'member'),
+    (v_squad_id, NEW.user_id, 'member')
+  ON CONFLICT (squad_id, user_id) DO NOTHING;
+
+  -- Random opener so the squad chat doesn't open empty. Curated subset of the
+  -- client's SQUAD_OPENERS list (skip the title-interpolated ones — pure SQL
+  -- random pick is enough flavor).
+  v_opener := (ARRAY[
+    'i cleared my schedule. i didn''t have anything but still',
+    'already mentally there tbh',
+    'just cancelled plans i didn''t have for this',
+    'mentally i''m already there waiting for you guys',
+    'if anyone flakes i''m airing it out',
+    'screenshot taken. evidence logged.',
+    'flaking is a federal offense btw',
+    'historians will write about this squad',
+    'main character energy activated',
+    'cool. no turning back now',
+    'well that happened fast',
+    'anyway i''m already dressed',
+    'ok bet',
+    'LETS GOOOOO',
+    'oh this is gonna be unhinged',
+    'everybody act normal',
+    'this energy is immaculate'
+  ])[1 + floor(random() * 17)::int];
+
+  INSERT INTO public.messages (squad_id, sender_id, text)
+  VALUES (v_squad_id, NEW.user_id, v_opener);
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_check_response_auto_create_squad ON public.check_responses;
+CREATE TRIGGER on_check_response_auto_create_squad
+  AFTER INSERT OR UPDATE ON public.check_responses
+  FOR EACH ROW EXECUTE FUNCTION public.auto_create_squad_on_first_other_down();


### PR DESCRIPTION
## Summary
Drops the "Squad →" button on CheckCard and the client-side \`onAutoSquad\` plumbing it backed. Squad now forms server-side the moment the first non-author "down" response lands on a check.

## Why
Squad creation used to depend on:
- A specific user's client being online at the right moment
- An \`onAutoSquad\` threshold of \`>=2\` explicit responders

Both ignored that the author is implicitly down, so the most natural flow — *author posts a check, friend taps Down, plan happens* — fell through. Two things had to happen: someone had to tap Down *and* either tap Squad → or have the count math line up. Moving it to a SQL trigger makes it deterministic regardless of who's online.

## What's in the migration
\`auto_create_squad_on_first_other_down\` (AFTER INSERT/UPDATE on \`check_responses\`):

- Only acts on \`response = 'down'\`.
- Skips when \`NEW.user_id\` is the author — need at least one *other* person down.
- Skips if a non-archived squad already exists for the check. The companion \`auto_join_squad_on_down_response\` trigger from 20260217000008 still folds subsequent responders into the existing squad.
- Reactivates an archived squad for the check if one exists, mirroring the client's prior "rebuild the same squad" semantics.
- Otherwise creates the squad with author + responder, names it from the check text (trimmed to 30 chars), and posts a random opener so the chat doesn't open empty.

## Client cleanup
- \`CheckCard\` loses the Squad → button + the \`startSquadFromCheck\` prop.
- \`FeedView\` drops the matching pass-through.
- \`page.tsx\` no longer wires \`onAutoSquad\` on \`useChecks\`.
- \`useChecks\` drops the \`onAutoSquad\` option + the \`downCount >= 2\` setTimeout block in \`respondToCheck\`.

\`squadsHook.startSquadFromCheck\` stays exported — still used by the event pool flow elsewhere — but is no longer reachable from a check card.

## Test plan
- [ ] Author A makes a check, friend B taps Down → squad forms automatically; both see it without any extra taps; chat has the random opener as its first message
- [ ] Repeat with B going Down twice (race) → only one squad created (idempotent on \`squads.check_id\` constraint)
- [ ] Author A makes a check, then taps Down on it themselves → no squad until someone else also goes Down
- [ ] Friend B goes Down on a check whose squad was previously archived → squad reactivates and B joins, no duplicate row
- [ ] Existing squad already formed → second responder C just gets folded in by the existing companion trigger (regression check)
- [ ] CheckCard no longer renders "Squad →" anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)