### PR TITLE
perf: memoize FeedContext value and the accepted-friends list

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { usePullToRefresh } from "@/app/hooks/usePullToRefresh";
 import { useAppNavigation } from "@/app/hooks/useAppNavigation";
 import { useEvents } from "@/features/events/hooks/useEvents";
@@ -731,25 +731,57 @@ export default function Home() {
     (s) => s.status === "incoming",
   ).length;
 
+  // Accepted-friends list, projected to {id,name,avatar} — used by AddModal,
+  // CheckCard's mention pickers, and other consumers. Memoized to keep
+  // identity stable across renders; otherwise a fresh array fires on every
+  // Home re-render and downstream memoization is defeated.
+  const acceptedFriendsList = useMemo(
+    () => friendsHook.friends
+      .filter((f) => f.status === "friend")
+      .map((f) => ({ id: f.id, name: f.name, avatar: f.avatar })),
+    [friendsHook.friends],
+  );
+
+  // Memoize the FeedContext value so consumers don't all re-render on every
+  // unrelated state change in Home() (tabs, modals, viewing-user, etc.).
+  const feedContextValue = useMemo(() => ({
+    checks: checksHook.checks,
+    myCheckResponses: checksHook.myCheckResponses,
+    hiddenCheckIds: checksHook.hiddenCheckIds,
+    pendingDownCheckIds: checksHook.pendingDownCheckIds,
+    newlyAddedCheckId: checksHook.newlyAddedCheckId,
+    leftChecks: checksHook.leftChecks,
+    respondToCheck: checksHook.respondToCheck,
+    clearResponse: checksHook.clearResponse,
+    acceptCoAuthorTag: checksHook.acceptCoAuthorTag,
+    declineCoAuthorTag: checksHook.declineCoAuthorTag,
+    hideCheck: checksHook.hideCheck,
+    unhideCheck: checksHook.unhideCheck,
+    redownFromLeft: checksHook.redownFromLeft,
+    events: eventsHook.events,
+    newlyAddedEventId: eventsHook.newlyAddedId,
+    toggleDown: eventsHook.toggleDown,
+  }), [
+    checksHook.checks,
+    checksHook.myCheckResponses,
+    checksHook.hiddenCheckIds,
+    checksHook.pendingDownCheckIds,
+    checksHook.newlyAddedCheckId,
+    checksHook.leftChecks,
+    checksHook.respondToCheck,
+    checksHook.clearResponse,
+    checksHook.acceptCoAuthorTag,
+    checksHook.declineCoAuthorTag,
+    checksHook.hideCheck,
+    checksHook.unhideCheck,
+    checksHook.redownFromLeft,
+    eventsHook.events,
+    eventsHook.newlyAddedId,
+    eventsHook.toggleDown,
+  ]);
+
   return (
-    <FeedContext.Provider value={{
-      checks: checksHook.checks,
-      myCheckResponses: checksHook.myCheckResponses,
-      hiddenCheckIds: checksHook.hiddenCheckIds,
-      pendingDownCheckIds: checksHook.pendingDownCheckIds,
-      newlyAddedCheckId: checksHook.newlyAddedCheckId,
-      leftChecks: checksHook.leftChecks,
-      respondToCheck: checksHook.respondToCheck,
-      clearResponse: checksHook.clearResponse,
-      acceptCoAuthorTag: checksHook.acceptCoAuthorTag,
-      declineCoAuthorTag: checksHook.declineCoAuthorTag,
-      hideCheck: checksHook.hideCheck,
-      unhideCheck: checksHook.unhideCheck,
-      redownFromLeft: checksHook.redownFromLeft,
-      events: eventsHook.events,
-      newlyAddedEventId: eventsHook.newlyAddedId,
-      toggleDown: eventsHook.toggleDown,
-    }}>
+    <FeedContext.Provider value={feedContextValue}>
     <div className="flex flex-col h-dvh overflow-x-hidden">
       <Header
         unreadCount={notificationsHook.unreadCount}
@@ -1027,7 +1059,7 @@ export default function Home() {
         defaultMode={addModalDefaultMode}
         onSubmit={handleAddModalSubmit}
         onInterestCheck={checksHook.handleCreateCheck}
-        friends={friendsHook.friends.filter(f => f.status === 'friend').map(f => ({ id: f.id, name: f.name, avatar: f.avatar }))}
+        friends={acceptedFriendsList}
       />
       <EventLobby
         event={squadsHook.socialEvent}

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import * as db from "@/lib/db";
 import type { Profile } from "@/lib/types";
 import type { InterestCheck, Friend } from "@/lib/ui-types";
@@ -133,7 +133,13 @@ export default function CheckCard({
     } catch { /* user cancelled */ }
   };
 
-  const friendsList = friends.filter(f => f.status === 'friend').map(f => ({ id: f.id, name: f.name, avatar: f.avatar }));
+  // Memoized so the array identity is stable across renders — InlineCommentsBox,
+  // CheckDetailSheet, and EditCheckModal all receive this and would otherwise
+  // see a fresh reference on every parent render.
+  const friendsList = useMemo(
+    () => friends.filter((f) => f.status === "friend").map((f) => ({ id: f.id, name: f.name, avatar: f.avatar })),
+    [friends],
+  );
 
   return (
     <>


### PR DESCRIPTION
## Summary
Two related render-amplification fixes in `src/app/page.tsx`. Both came out of the recent codebase audit.

1. **`FeedContext.Provider` value was an inline object literal.** Every \`Home\` re-render — tab switch, modal open, viewing-user change, anything — produced a new value reference, which forced every \`FeedContext\` consumer (\`CheckCard\`, \`FeedView\`, etc.) to re-render even when none of the actual fields changed. Wrap the object in \`useMemo\` with the same set of dependencies it already reads.

2. **The "accepted friends" projection (\`friends.filter(f => f.status === 'friend').map(...)\`) was being recomputed inline at the AddModal call site, and again identically inside \`CheckCard\`.** Lift it to a memoized value at the top of \`Home\` so AddModal sees a stable array identity, and memoize the in-CheckCard copy too — its three consumers (\`InlineCommentsBox\`, \`CheckDetailSheet\`, \`EditCheckModal\`) all keep the prop and would otherwise see a fresh array on every parent render.

\`React.memo\` on the card components is intentionally **not** in this PR — its callback props (\`showToast\`, \`loadRealData\`, …) aren't stable yet, so a memo wrapper would be a no-op without a follow-up \`useCallback\` sweep. That's the next perf PR.

## Test plan
- [ ] App loads, feed renders, tabs switch
- [ ] Open AddModal — friend list still appears
- [ ] Comment on a check, mention a friend — mention picker still works
- [ ] React DevTools Profiler: confirm CheckCard / FeedView no longer re-render when an unrelated state change happens in Home (e.g. viewing-user toggles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)