### PR TITLE
perf: cap getSquads message fetch at 50 + trim sender profile

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1223,7 +1223,20 @@ export async function getSquads(): Promise<Squad[]> {
 
   const squadIds = memberOf.map(m => m.squad_id);
 
-  // Then fetch those squads with their data (exclude expired)
+  // Then fetch those squads with their data (exclude expired).
+  //
+  // Two perf trims here on the hot squad-list path:
+  //   1. Cap nested messages at the most recent 50. Was unlimited — a
+  //      busy squad pulled hundreds of messages on every list load.
+  //      No pagination yet, so older messages aren't visible until that
+  //      lands; acceptable trade-off given typical squad chat lengths.
+  //   2. Trim the embedded sender profile to just display_name (only field
+  //      actually rendered). Was `sender:profiles(*)` — ~15 columns × N
+  //      messages × M squads of waste.
+  //
+  // Messages are fetched DESC + limit so we get the newest 50, then
+  // reversed in JS so consumers (SquadChat / GroupsView) keep their
+  // existing oldest→newest expectation.
   const { data, error } = await supabase
     .from('squads')
     .select(`
@@ -1231,15 +1244,21 @@ export async function getSquads(): Promise<Squad[]> {
       event:events(*),
       check:interest_checks(author_id, event_time, event_date, location, text, date_flexible, time_flexible, max_squad_size, responses:check_responses(user_id, response, user:profiles!user_id(display_name, avatar_letter))),
       members:squad_members(*, user:profiles!user_id(*)),
-      messages(*, sender:profiles!sender_id(*))
+      messages(*, sender:profiles!sender_id(display_name))
     `)
     .in('id', squadIds)
     .is('archived_at', null)
     .or(`expires_at.gt.${new Date().toISOString()},expires_at.is.null`)
     .order('created_at', { ascending: false })
-    .order('created_at', { ascending: true, referencedTable: 'messages' });
+    .order('created_at', { ascending: false, referencedTable: 'messages' })
+    .limit(50, { referencedTable: 'messages' });
 
   if (error) throw error;
+  if (data) {
+    for (const squad of data) {
+      if (Array.isArray(squad.messages)) squad.messages.reverse();
+    }
+  }
   return data ?? [];
 }
 


### PR DESCRIPTION
## Summary
\`getSquads()\` is on the hot path — runs on initial app open, every squads-tab visit, every refresh, and after most squad mutations. Two compounding bandwidth trims:

1. **Cap nested messages at the 50 most recent.** The query was unlimited. A few chatty squads with a couple hundred messages each turned this into hundreds of KB per load. Fetched DESC + \`limit(50)\` so we get the newest, then reversed in JS to preserve consumers' oldest→newest expectation.

2. **Trim embedded sender profile to \`display_name\`.** Was \`sender:profiles!sender_id(*)\` — \`*\` pulled ~15 profile columns. The only sender field anything actually renders is \`display_name\` (verified across \`SquadChat\`, \`GroupsView\`, \`useSquads\`).

## Soft regression to flag
No older-messages pagination exists yet, so a squad with >50 messages will only show the latest 50 until a "load more" lands. Trade-off worth it given typical chat lengths and how often this query runs.

## Test plan
- [ ] Open app cold → squads tab loads, recent messages visible in each squad's preview
- [ ] Open a squad chat → renders last 50 messages oldest→newest, can send a new message
- [ ] GroupsView shows the right last-message preview for each squad
- [ ] Realtime: send a message from another client, both clients append it correctly
- [ ] System messages (\`is_system: true\`) still render correctly in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)