### PR TITLE
perf: skip the per-check comment fetch when initialCommentCount is 0

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -100,12 +100,6 @@ export default function CheckCard({
   } = useFeedContext();
   const hasComments = initialCommentCount > 0;
 
-
-
-
-
-
-  useEffect(() => { openComments(); }, [check.id]);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const [showReport, setShowReport] = useState(false);
@@ -117,6 +111,16 @@ export default function CheckCard({
     profile,
     initialCommentCount,
   });
+
+  // Eagerly fetch the comment list only when there's actually something to
+  // fetch — initialCommentCount is hydrated in batch by FeedView, so this
+  // skips one query per check that has zero comments. Realtime arrivals
+  // still get appended to `comments` via the always-on subscription in
+  // useCheckComments, so a previously-empty check that gets a new comment
+  // post-render still renders InlineCommentsBox correctly.
+  useEffect(() => {
+    if (hasComments) openComments();
+  }, [check.id, hasComments, openComments]);
 
 
 


### PR DESCRIPTION
## Summary
\`CheckCard\` had a \`useEffect\` that eagerly called \`openComments()\` on every mount, regardless of whether the check actually had any comments. With 30 checks in the feed, that was **30 Supabase round-trips on initial load** — most of them returning empty arrays for checks with zero comments.

\`initialCommentCount\` is already hydrated in one batched query by \`FeedView\` (\`getCheckCommentCounts\`), so we know which checks are empty before \`CheckCard\` even mounts. Gate the eager fetch on \`hasComments\`.

Realtime arrivals continue to flow through the always-on subscription in \`useCheckComments\`, so a previously-empty check that gets its first comment post-render still updates correctly:
- \`commentCount\` updates via \`realtimeCount\`
- \`comments\` list updates via the realtime handler
- Once \`comments.length > 0\`, \`InlineCommentsBox\` renders as before

Also moved the \`useEffect\` to sit *after* the \`useCheckComments\` call where \`openComments\` is declared. The original spelling worked (closure-after-render hoisting) but read confusingly.

## Test plan
- [ ] Open feed cold → checks with comments still show inline comments box
- [ ] Open feed cold → checks without comments don't trigger any \`getCheckComments\` queries (Network tab)
- [ ] Have someone post a new comment via realtime to a check that started empty — comment box appears
- [ ] Tap a check → detail sheet still shows full comment list
- [ ] Post a comment yourself → optimistic append works, count updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)