### PR TITLE
perf: useCallback sweep + React.memo on CheckCard/EventCard

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -87,37 +87,89 @@ export default function Home() {
   const clearAddGlowRef = useRef(() => {});
 
   // ─── Domain hooks ───────────────────────────────────────────────────────
+  // Order matters: hooks whose input lambdas reference *other* hooks need
+  // those other hooks declared first so the deps arrays of the useCallbacks
+  // below resolve. notificationsHook is up here because checksHook's
+  // onCoAuthorRespond touches it.
   const friendsHook = useFriends({
     userId,
     showToast,
     loadRealDataRef,
   });
 
+  const notificationsHook = useNotifications({ userId });
+
+  // ─── Stable input lambdas for the domain hooks ─────────────────────────
+  // Each domain hook captures these via closure. If they're inline, every
+  // Home render gives the hook a fresh callback identity, which cascades
+  // into every useCallback'd handler the hook returns and ultimately into
+  // the FeedContext value. Stabilizing them here is the prerequisite for
+  // React.memo on CheckCard / EventCard.
+
+  const onCheckCreated = useCallback(() => {
+    setTab("feed");
+    clearAddGlowRef.current();
+  }, [setTab]);
+
+  const onDownResponse = useCallback(() => {
+    loadRealDataRef.current();
+  }, []);
+
+  const onCoAuthorRespond = useCallback((checkId: string) => {
+    // Mark check_tag notification as read when user accepts/declines
+    const tagNotif = notificationsHook.notifications.find(
+      (n) => n.type === "check_tag" && n.related_check_id === checkId && !n.is_read
+    );
+    if (tagNotif) {
+      if (userId) db.markNotificationRead(tagNotif.id);
+      notificationsHook.setNotifications((prev) =>
+        prev.map((n) => n.id === tagNotif.id ? { ...n, is_read: true } : n)
+      );
+      notificationsHook.setUnreadCount((prev) => Math.max(0, prev - 1));
+    }
+  }, [
+    notificationsHook.notifications,
+    notificationsHook.setNotifications,
+    notificationsHook.setUnreadCount,
+    userId,
+  ]);
+
   const checksHook = useChecks({
     userId,
     profile,
     friendCount: friendsHook.friends.length,
     showToast,
-    onCheckCreated: () => { setTab("feed"); clearAddGlowRef.current(); },
-    onDownResponse: () => { loadRealDataRef.current(); },
-    onCoAuthorRespond: (checkId: string) => {
-      // Mark check_tag notification as read when user accepts/declines
-      const tagNotif = notificationsHook.notifications.find(
-        (n) => n.type === "check_tag" && n.related_check_id === checkId && !n.is_read
-      );
-      if (tagNotif) {
-        if (userId) db.markNotificationRead(tagNotif.id);
-        notificationsHook.setNotifications((prev) =>
-          prev.map((n) => n.id === tagNotif.id ? { ...n, is_read: true } : n)
-        );
-        notificationsHook.setUnreadCount((prev) => Math.max(0, prev - 1));
-      }
-    },
+    onCheckCreated,
+    onDownResponse,
+    onCoAuthorRespond,
   });
 
   // Keep a ref to the latest checks so useSquads can read current state without a stale closure
   const checksRef = useRef(checksHook.checks);
   checksRef.current = checksHook.checks;
+
+  // onSquadCreated forward-refs squadsHook.setAutoSelectSquadId (we're
+  // about to define squadsHook). The setter is a stable useState reference
+  // even though the wrapping object is reborn each render, so closure
+  // semantics give us the right setter at call time. tab goes in the deps
+  // array because we want the originating tab captured at squad-form
+  // moment (so the back-from-squad nav lands the user where they were).
+  const onSquadCreated = useCallback((squadId: string) => {
+    showToastWithAction("squad formed!", () => {
+      setSquadChatOrigin(tab);
+      squadsHook.setAutoSelectSquadId(squadId);
+    }, true);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, showToastWithAction, setSquadChatOrigin]);
+
+  const onAutoDown = useCallback(async (eventId: string) => {
+    await db.saveEvent(eventId).catch(() => {});
+    await db.toggleDown(eventId, true);
+    setEvents((prev) =>
+      prev.map((e) => e.id === eventId ? { ...e, isDown: true, saved: true } : e)
+    );
+    showToast("You're down! ✦");
+  }, [setEvents, showToast]);
 
   const squadsHook = useSquads({
     userId,
@@ -126,23 +178,9 @@ export default function Home() {
     dispatch: checksHook.dispatch,
     showToast,
     openSquadIdRef: selectedSquadIdRef,
-    onSquadCreated: (squadId: string) => {
-      showToastWithAction("squad formed!", () => {
-        setSquadChatOrigin(tab);
-        squadsHook.setAutoSelectSquadId(squadId);
-      }, true);
-    },
-    onAutoDown: async (eventId: string) => {
-      await db.saveEvent(eventId).catch(() => {});
-      await db.toggleDown(eventId, true);
-      setEvents((prev) =>
-        prev.map((e) => e.id === eventId ? { ...e, isDown: true, saved: true } : e)
-      );
-      showToast("You're down! ✦");
-    },
+    onSquadCreated,
+    onAutoDown,
   });
-
-  const notificationsHook = useNotifications({ userId });
 
   // ─── Onboarding hook ───────────────────────────────────────────────────
   const onboarding = useOnboarding({

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, memo } from "react";
 import * as db from "@/lib/db";
 import type { Profile } from "@/lib/types";
 import type { InterestCheck, Friend } from "@/lib/ui-types";
@@ -74,7 +74,7 @@ export interface CheckCardProps {
   isNew?: boolean;
 }
 
-export default function CheckCard({
+function CheckCard({
   check,
   userId,
   profile,
@@ -447,3 +447,10 @@ export default function CheckCard({
     </>
   );
 }
+
+// Memoized so a re-render in Home that doesn't change this check's props
+// (tab switches, modal toggles, viewing-user changes, etc.) skips the card
+// entirely. Default shallow compare works now that the upstream callbacks
+// are stable: showToast/showToastWithAction (#463), loadRealData (already
+// useCallback), and the in-FeedContext handlers from useChecks (this PR).
+export default memo(CheckCard);

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -188,7 +188,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     });
   }, [userId]);
 
-  const respondToCheck = (checkId: string) => {
+  const respondToCheck = useCallback((checkId: string) => {
     const check = checks.find((c) => c.id === checkId);
     dispatch({ type: CheckActionType.SET_RESPONSE, checkId, status: "down", avatarLetter: profile?.avatar_letter ?? "?", userId });
     showToast("You're down! ✦");
@@ -209,9 +209,9 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
           logError("respondToCheck", err, { checkId: check?.id });
         });
     }
-  };
+  }, [checks, profile?.avatar_letter, userId, showToast, onDownResponse, loadChecks]);
 
-  const handleCreateCheck = async (
+  const handleCreateCheck = useCallback(async (
     idea: string,
     expiresInHours: number | null,
     eventDate: string | null,
@@ -268,9 +268,9 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
         showToast("Failed to send - try again");
       }
     }
-  };
+  }, [userId, profile?.display_name, profile?.username, friendCount, showToast, onCheckCreated]);
 
-  const acceptCoAuthorTag = async (checkId: string) => {
+  const acceptCoAuthorTag = useCallback(async (checkId: string) => {
     try {
       await db.respondToCoAuthorTag(checkId, true);
       dispatch({ type: CheckActionType.SET_CO_AUTHOR, checkId, userId: userId!, accepted: true, avatarLetter: profile?.avatar_letter ?? "?" });
@@ -281,9 +281,9 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
       logError('acceptCoAuthorTag', err, { checkId });
       showToast('Failed to accept tag');
     }
-  };
+  }, [userId, profile?.avatar_letter, showToast, onCoAuthorRespond, loadChecks]);
 
-  const declineCoAuthorTag = async (checkId: string) => {
+  const declineCoAuthorTag = useCallback(async (checkId: string) => {
     try {
       await db.respondToCoAuthorTag(checkId, false);
       dispatch({ type: CheckActionType.SET_CO_AUTHOR, checkId, userId: userId!, accepted: false });
@@ -291,7 +291,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     } catch (err) {
       logError('declineCoAuthorTag', err, { checkId });
     }
-  };
+  }, [userId, onCoAuthorRespond]);
 
   const hydrateLeftChecks = useCallback((raw: Awaited<ReturnType<typeof db.getLeftChecks>>) => {
     const now = new Date();
@@ -329,19 +329,19 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     db.removeLeftCheck(checkId).catch((err) => logError('removeLeftCheck', err, { checkId }));
   }, [respondToCheck]);
 
-  const clearResponse = (checkId: string) => {
+  const clearResponse = useCallback((checkId: string) => {
     dispatch({ type: CheckActionType.CLEAR_RESPONSE, checkId, userId });
-  };
+  }, [userId]);
 
-  const hideCheck = async (checkId: string) => {
+  const hideCheck = useCallback(async (checkId: string) => {
     dispatch({ type: CheckActionType.SET_HIDDEN, checkId, hidden: true });
     db.hideCheck(checkId).catch((err) => logError("hideCheck", err, { checkId }));
-  };
+  }, []);
 
-  const unhideCheck = async (checkId: string) => {
+  const unhideCheck = useCallback(async (checkId: string) => {
     dispatch({ type: CheckActionType.SET_HIDDEN, checkId, hidden: false });
     db.unhideCheck(checkId).catch((err) => logError("unhideCheck", err, { checkId }));
-  };
+  }, []);
 
   // Recalculate expiry every 30s so stale checks auto-hide
   useEffect(() => {

--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, memo } from "react";
 import type { Event } from "@/lib/ui-types";
 import type { Profile } from "@/lib/types";
 import cn from "@/lib/tailwindMerge";
@@ -659,4 +659,10 @@ function SheetHero(props: SheetProps) {
   );
 }
 
-export default EventCard;
+// Memoized so a re-render in Home that doesn't change this event's props
+// (tab switches, modal toggles, viewing-user changes, etc.) skips the card
+// entirely. Default shallow compare is fine — all callback props
+// (onToggleDown, onOpenSocial, onEdit, onViewProfile) come through Home's
+// useCallback'd handlers (#463) and useEvents' useCallback'd toggleDown,
+// so identities are stable.
+export default memo(EventCard);

--- a/src/features/events/hooks/useEvents.ts
+++ b/src/features/events/hooks/useEvents.ts
@@ -162,7 +162,7 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
     setEvents((prev) => prev.map(enrichEvent));
   }, []);
 
-  const toggleDown = async (id: string) => {
+  const toggleDown = useCallback(async (id: string) => {
     const event = events.find((e) => e.id === id);
     if (!event) return;
     const newDown = !event.isDown;
@@ -190,9 +190,9 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
         }
       }
     }
-  };
+  }, [events, showToast, loadRealDataRef]);
 
-  const handleEditEvent = async (updated: { title: string; venue: string; date: string; time: string; vibe: string[]; note: string }) => {
+  const handleEditEvent = useCallback(async (updated: { title: string; venue: string; date: string; time: string; vibe: string[]; note: string }) => {
     if (!editingEvent) return;
 
     const dateISO = parseDateToISO(updated.date);
@@ -234,7 +234,7 @@ export function useEvents({ userId, showToast, loadRealDataRef }: UseEventsParam
     setEvents(updateList);
     setEditingEvent(null);
     showToast("Event updated!");
-  };
+  }, [editingEvent, userId, showToast]);
 
   return {
     events,

--- a/src/features/friends/hooks/useFriends.ts
+++ b/src/features/friends/hooks/useFriends.ts
@@ -68,7 +68,7 @@ export function useFriends({ userId, showToast, loadRealDataRef }: UseFriendsPar
     setSuggestions([...incomingFriends, ...outgoingFriends, ...suggestedFriends]);
   }, []);
 
-  const addFriend = async (id: string) => {
+  const addFriend = useCallback(async (id: string) => {
     try {
       const friendship = await db.sendFriendRequest(id);
       setSuggestions((prev) =>
@@ -79,9 +79,9 @@ export function useFriends({ userId, showToast, loadRealDataRef }: UseFriendsPar
       logError("sendFriendRequest", err, { friendId: id });
       showToast("Failed to send request");
     }
-  };
+  }, [showToast]);
 
-  const acceptRequest = async (id: string) => {
+  const acceptRequest = useCallback(async (id: string) => {
     const person = suggestions.find((s) => s.id === id);
     if (!person) return;
 
@@ -103,9 +103,9 @@ export function useFriends({ userId, showToast, loadRealDataRef }: UseFriendsPar
       logError("acceptFriendRequest", err, { friendId: person.id });
       showToast("Failed to accept request");
     }
-  };
+  }, [suggestions, showToast, loadRealDataRef]);
 
-  const removeFriend = async (id: string) => {
+  const removeFriend = useCallback(async (id: string) => {
     const person = friends.find((f) => f.id === id);
     if (!person) return;
 
@@ -124,9 +124,9 @@ export function useFriends({ userId, showToast, loadRealDataRef }: UseFriendsPar
       logError("removeFriend", err, { friendId: person.id });
       showToast("Failed to remove friend");
     }
-  };
+  }, [friends, showToast]);
 
-  const cancelRequest = async (id: string) => {
+  const cancelRequest = useCallback(async (id: string) => {
     const person = suggestions.find((f) => f.id === id && f.status === "pending");
     if (!person?.friendshipId) return;
 
@@ -138,9 +138,14 @@ export function useFriends({ userId, showToast, loadRealDataRef }: UseFriendsPar
       logError("cancelRequest", err, { friendId: person.id });
       showToast("Failed to cancel request");
     }
-  };
+  }, [suggestions, showToast]);
 
-  const searchUsers = userId ? async (query: string) => {
+  // Always return a function (was conditionally undefined when userId null,
+  // which made the prop identity flip and broke React.memo down-tree). When
+  // userId is null we just resolve with an empty list — consumers always
+  // mount the search UI inside an authed-only flow anyway.
+  const searchUsers = useCallback(async (query: string): Promise<Friend[]> => {
+    if (!userId) return [];
     // Fetch search results + outgoing pending requests in parallel
     const [results, outgoing] = await Promise.all([
       db.searchUsers(query),
@@ -167,7 +172,7 @@ export function useFriends({ userId, showToast, loadRealDataRef }: UseFriendsPar
         availability: p.availability,
         igHandle: p.ig_handle ?? undefined,
       }));
-  } : undefined;
+  }, [userId, friends, suggestions]);
 
   // Subscribe to realtime friendship changes
   useEffect(() => {

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -253,7 +253,7 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
     setEventToSquad(newEventToSquad);
   }, [userId, checksRef, dispatch]);
 
-  const startSquadFromCheck = async (check: InterestCheck) => {
+  const startSquadFromCheck = useCallback(async (check: InterestCheck) => {
     if (creatingSquad || check.squadId) return;
     setCreatingSquad(true);
     const maxSize = check.maxSquadSize ?? 5;
@@ -318,9 +318,9 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
 
     setCreatingSquad(false);
     onSquadCreated?.(newSquad.id);
-  };
+  }, [creatingSquad, userId, profile?.avatar_letter, onSquadCreated, dispatch]);
 
-  const startSquadFromEvent = async (event: Event, selectedUserIds: string[]) => {
+  const startSquadFromEvent = useCallback(async (event: Event, selectedUserIds: string[]) => {
     if (creatingSquad) return;
     if (event.id && eventToSquad.has(event.id)) {
       showToast("You're already in a squad for this event");
@@ -388,9 +388,9 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
     setSocialEvent(null);
     setCreatingSquad(false);
     onSquadCreated?.(newSquad.id);
-  };
+  }, [creatingSquad, eventToSquad, profile?.avatar_letter, userId, squadPoolMembers, inSquadPool, showToast, onSquadCreated]);
 
-  const handleJoinSquadPool = async (event: Event) => {
+  const handleJoinSquadPool = useCallback(async (event: Event) => {
     if (!event.id) return;
 
     try {
@@ -441,7 +441,7 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
       logError("joinSquadPool", err, { eventId: event.id });
       showToast("Something went wrong");
     }
-  };
+  }, [inSquadPool, userId, showToast, onAutoDown]);
 
   // Load squad pool members when EventLobby opens and enrich peopleDown with inPool + inSquad flags
   useEffect(() => {


### PR DESCRIPTION
## Summary
Final piece of the perf wave that started with #458 and #463. Cards in the feed were still re-rendering on every \`Home\` re-render because two layers of callback identities below them weren't stable: the input lambdas \`Home\` passes into \`useChecks\` / \`useSquads\`, and the functions those hooks return.

**Home (\`src/app/page.tsx\`):**
- \`useCallback\` the 5 input lambdas previously inline at the \`useChecks\` / \`useSquads\` call sites: \`onCheckCreated\`, \`onDownResponse\`, \`onCoAuthorRespond\`, \`onSquadCreated\`, \`onAutoDown\`.
- Reordered \`notificationsHook\` above \`checksHook\` so \`onCoAuthorRespond\` (which reads notifications) can include them in its deps array.
- \`onSquadCreated\` forward-refs \`squadsHook.setAutoSelectSquadId\` — the setter is a stable \`useState\` ref even though the wrapping object is reborn each render, so closure semantics give us the right setter at call time. \`exhaustive-deps\` suppressed for the forward ref.

**\`useChecks\`:** \`respondToCheck\`, \`handleCreateCheck\`, \`acceptCoAuthorTag\`, \`declineCoAuthorTag\`, \`clearResponse\`, \`hideCheck\`, \`unhideCheck\`. \`dispatch\` from \`useReducer\` is guaranteed stable so omitted from deps.

**\`useSquads\`:** \`startSquadFromCheck\`, \`startSquadFromEvent\`, \`handleJoinSquadPool\`.

**\`useFriends\`:** \`addFriend\`, \`acceptRequest\`, \`removeFriend\`, \`cancelRequest\`, \`searchUsers\`. \`searchUsers\` used to be \`userId ? async ... : undefined\` — always returning a function now (no-ops to empty list when \`userId\` is null) so the prop identity doesn't flip. Only consumer (\`FriendsModal\`) mounts inside an authed flow, so behaviorally equivalent.

**\`useEvents\`:** \`toggleDown\`, \`handleEditEvent\`.

**\`CheckCard\` / \`EventCard\`:** wrapped default exports with \`React.memo\` (default shallow compare). All callback props going into them now come through a stable chain (\`Home\` \`useCallback\` → hook \`useCallback\`). For tab switches / modal toggles / viewing-user changes / other \`Home\` state changes that don't touch the card's data, the cards now skip re-render entirely. When their actual data changes, they re-render as before.

## Test plan
- [ ] Feed loads, all checks + events render correctly
- [ ] Tap "Down" on a check → optimistic state, then real DB confirm; toast shows
- [ ] Create a check → navigates to feed, shows new check, toast
- [ ] Accept / decline a co-author tag → notification marked read, check updates
- [ ] Toggle down on an event card → optimistic update, then network confirm; toggling off triggers \`loadRealData\`
- [ ] Edit event → form saves, toast, state updated
- [ ] Send / accept / cancel / remove friend request — toasts + list updates
- [ ] Friend search opens, returns results, status flags correct
- [ ] Hide a check → it goes to "hidden"; unhide → comes back
- [ ] Squad form (auto from down on a check, manual from event) → toast with action, navigation works
- [ ] Join / leave squad pool from EventLobby → counts update, "looking for squad" reflects state
- [ ] React DevTools Profiler: switching tabs / opening modals no longer re-renders the visible \`CheckCard\` / \`EventCard\` instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)