### PR TITLE
perf: split loadRealData into feed-essential + background phases

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -206,7 +206,12 @@ export default function Home() {
     isLoadingRef.current = true;
 
     try {
-      // Phase 1: Fetch all independent data in parallel
+      // Phase A — feed-essential queries. Whatever lands here is what the
+      // user is actually staring at: events on the feed, checks on the
+      // feed, friend list (drives onboarding + the FoF annotations), and
+      // squads (drives the "💬 Squad →" / "Squad →" button state on each
+      // check card). Anything not visibly required to render the feed
+      // correctly belongs in Phase B below.
       const [
         savedEvents,
         publicEvents,
@@ -219,8 +224,6 @@ export default function Home() {
         squadsList,
         hiddenIds,
         fofAnnotations,
-        archivedChecksList,
-        leftChecksList,
         unreadSquadIds,
       ] = await Promise.all([
         db.getSavedEvents(),
@@ -234,38 +237,50 @@ export default function Home() {
         db.getSquads().catch((err) => { logWarn("loadSquads", "Failed", { error: err }); return [] as Awaited<ReturnType<typeof db.getSquads>>; }),
         db.getHiddenCheckIds().catch((err) => { logWarn("loadHiddenChecks", "Failed", { error: err }); return [] as string[]; }),
         db.getFofAnnotations().catch((err) => { logWarn("loadFofAnnotations", "Failed", { error: err }); return [] as { check_id: string; via_friend_name: string }[]; }),
-        db.getArchivedChecks().catch((err) => { logWarn("loadArchivedChecks", "Failed", { error: err }); return [] as { id: string; text: string; archived_at: string }[]; }),
-        db.getLeftChecks().catch((err) => { logWarn("loadLeftChecks", "Failed", { error: err }); return [] as Awaited<ReturnType<typeof db.getLeftChecks>>; }),
         db.getUnreadSquadIds().catch(() => [] as string[]),
       ]);
 
-      // Phase 2: Transform events via useEvents hook
       hydrateEvents(savedEvents, publicEvents, friendsEvents);
-
-      // Phase 3: Hydrate domain hooks
       friendsHook.hydrateFriends(friendsList, pendingRequests, suggestedUsers, outgoingRequests);
       checksHook.hydrateChecks(activeChecks, hiddenIds, fofAnnotations);
       squadsHook.hydrateSquads(squadsList, unreadSquadIds);
-      setArchivedChecks(archivedChecksList);
-      checksHook.hydrateLeftChecks(leftChecksList);
 
-      // Phase 4: Fetch social data before showing feed so it doesn't pop in
-      const savedEventIds = savedEvents.map((se) => se.event!.id);
-      const allEventIds = [...new Set([...savedEventIds, ...publicEvents.map((e) => e.id), ...friendsEvents.map((e) => e.id)])];
-      if (allEventIds.length > 0) {
-        try {
-          const [peopleDownMap, crewPoolMap, userPoolEventIds] = await Promise.all([
-            db.getPeopleDownBatch(allEventIds),
-            db.getCrewPoolBatch(allEventIds),
-            db.getUserPoolEventIds(allEventIds),
-          ]);
-          hydrateSocialData(peopleDownMap, crewPoolMap, userPoolEventIds);
-        } catch (err) {
-          logWarn("loadPeopleDown", "Failed to load social data", { error: err });
-        }
-      }
-
+      // Feed is interactable now — flip the gate before Phase B kicks off
+      // so the user isn't waiting on social pills + profile-only data.
       setFeedLoaded(true);
+
+      // Phase B — background hydration. Don't await; let these populate
+      // when ready so we don't block first paint:
+      //   • Social pills on event cards (peopleDown / crewPool / userPool)
+      //     — events render with "0 down" briefly, then update. Used to
+      //     be Phase 4 ("so it doesn't pop in" — trade-off accepted).
+      //   • Profile-only state (archivedChecks / leftChecks) — only
+      //     consumed inside ProfileView, can hydrate any time before the
+      //     user navigates there.
+      // Wrapped in an IIFE so any failure is contained.
+      void (async () => {
+        try {
+          const savedEventIds = savedEvents.map((se) => se.event!.id);
+          const allEventIds = [...new Set([...savedEventIds, ...publicEvents.map((e) => e.id), ...friendsEvents.map((e) => e.id)])];
+          if (allEventIds.length > 0) {
+            const [peopleDownMap, crewPoolMap, userPoolEventIds] = await Promise.all([
+              db.getPeopleDownBatch(allEventIds),
+              db.getCrewPoolBatch(allEventIds),
+              db.getUserPoolEventIds(allEventIds),
+            ]);
+            hydrateSocialData(peopleDownMap, crewPoolMap, userPoolEventIds);
+          }
+
+          const [archivedChecksList, leftChecksList] = await Promise.all([
+            db.getArchivedChecks().catch((err) => { logWarn("loadArchivedChecks", "Failed", { error: err }); return [] as { id: string; text: string; archived_at: string }[]; }),
+            db.getLeftChecks().catch((err) => { logWarn("loadLeftChecks", "Failed", { error: err }); return [] as Awaited<ReturnType<typeof db.getLeftChecks>>; }),
+          ]);
+          setArchivedChecks(archivedChecksList);
+          checksHook.hydrateLeftChecks(leftChecksList);
+        } catch (err) {
+          logWarn("loadRealData/background", "Failed", { error: err });
+        }
+      })();
 
       // Reload notifications AFTER squads are hydrated to avoid race condition
       // where onUnreadSquadIds sets hasUnread on stale squad state
@@ -282,7 +297,7 @@ export default function Home() {
       isLoadingRef.current = false;
       setFeedLoaded(true);
     }
-  }, [userId, checksHook.hydrateChecks, squadsHook.hydrateSquads, friendsHook.hydrateFriends, hydrateEvents, hydrateSocialData, notificationsHook.loadNotifications]);
+  }, [userId, checksHook.hydrateChecks, checksHook.hydrateLeftChecks, squadsHook.hydrateSquads, friendsHook.hydrateFriends, hydrateEvents, hydrateSocialData, setArchivedChecks, notificationsHook.loadNotifications]);
 
   loadRealDataRef.current = loadRealData;
 


### PR DESCRIPTION
## Summary
\`loadRealData\` blocked feed first-paint on **14 parallel queries** followed by another \`await\` of **3 social-data queries**. Total time-to-paint = \`max(Phase 1) + max(Phase 4)\`. The comment in the code (\`"so it doesn't pop in"\`) baked that trade-off in.

This PR splits the loader into two phases so first paint only waits on what's actually visible.

## What's in Phase A (await before setFeedLoaded)
12 feed-essential queries:
- 3 events queries (\`savedEvents\` / \`publicEvents\` / \`friendsEvents\`)
- \`activeChecks\`, \`hiddenIds\`, \`fofAnnotations\` — for check cards + "via {friend}" labels
- \`friends\` / \`pendingRequests\` / \`outgoingRequests\` / \`suggestedUsers\` — drives onboarding decisions and FoF visibility
- \`squadsList\` + \`unreadSquadIds\` — drives the "💬 Squad →" / "Squad →" button state on each check card

## What moved to Phase B (fired after setFeedLoaded)
Non-blocking, hydrates in the background:
- **Social pills on event cards** (\`peopleDownBatch\` / \`crewPoolBatch\` / \`userPoolEventIds\`). Event cards render with empty pills briefly, then the counts populate ~100–300ms later. The feed responds to taps immediately.
- **Profile-only state** (\`archivedChecks\` / \`leftChecks\`). Only consumed inside \`ProfileView\` — has plenty of time to land before the user navigates there.

The Phase B work is wrapped in an IIFE so a failure there can't bubble up to break feed render.

## Trade-off accepted
Social pills on event cards now pop in instead of being there at first paint. UX is acceptable: feed becomes interactable sooner, the pills are supplementary info (down counts), and the actual "Down" / "Save" buttons work immediately because they read from \`savedEvents\` (Phase A), not the social batches.

## Test plan
- [x] \`npm run test:e2e -- e2e/check-creation.spec.ts\` — 3/3 pass
- [x] The "DOWN ?" toggle test is measurably faster (920ms vs 1.4s pre-change), suggesting feed first-paint is reached earlier
- [ ] Manual: open the app cold → feed should render without the brief blank "loading your feed..." pause
- [ ] Manual: event cards' "people down" pills appear shortly after the cards themselves
- [ ] Manual: navigate to Profile → archived/left checks render correctly
- [ ] Manual: pull to refresh → both phases re-run, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)