### PR TITLE
refactor: extract useBottomSheet hook, dedupe 9 sheet components

### DIFF
--- a/src/app/components/SyncCalendarModal.tsx
+++ b/src/app/components/SyncCalendarModal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useEffect } from "react";
 import cn from "@/lib/tailwindMerge";
 import * as db from "@/lib/db";
 import { generateICSCalendar, downloadICS, buildGoogleCalendarUrl, type ICSEventParams } from "@/lib/ics";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 
 const SyncCalendarModal = ({
   open,
@@ -19,11 +20,7 @@ const SyncCalendarModal = ({
   const [calendarToken, setCalendarToken] = useState<string | null>(null);
   const [tokenLoading, setTokenLoading] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [closing, setClosing] = useState(false);
-  const [dragOffset, setDragOffset] = useState(0);
-  const touchStartY = useRef(0);
-  const isDragging = useRef(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const sheet = useBottomSheet({ open, onClose });
 
   useEffect(() => {
     if (open) {
@@ -39,38 +36,7 @@ const SyncCalendarModal = ({
     }
   }, [open]);
 
-  if (!open) return null;
-
-  const handleClose = () => {
-    setClosing(true);
-    setTimeout(() => { onClose(); setClosing(false); setDragOffset(0); }, 200);
-  };
-
-  const handleSwipeStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleSwipeMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
-  };
-  const handleSwipeEnd = () => {
-    if (dragOffset > 60) handleClose();
-    else setDragOffset(0);
-    isDragging.current = false;
-  };
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
-  };
-  const handleScrollTouchEnd = () => {
-    if (isDragging.current) handleSwipeEnd();
-  };
+  if (!sheet.visible) return null;
 
   const toggleItem = (id: string) => {
     setSyncSelected((prev) => {
@@ -113,29 +79,27 @@ const SyncCalendarModal = ({
       className="fixed inset-0 z-[9999] flex items-end justify-center"
     >
       <div
-        onClick={handleClose}
+        onClick={sheet.close}
         className="absolute inset-0"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: closing ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: closing ? "blur(0px)" : "blur(8px)",
-          opacity: closing ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
           transition: "opacity 0.2s ease, backdrop-filter 0.2s ease, -webkit-backdrop-filter 0.2s ease",
         }}
       />
       <div
         className="relative bg-surface rounded-t-3xl max-w-[420px] w-full max-h-[75vh] flex flex-col"
         style={{
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
         {/* Drag handle + header */}
         <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={handleSwipeEnd}
+          {...sheet.swipeProps}
           className="touch-none"
           style={{ padding: "16px 20px 0" }}
         >
@@ -201,10 +165,7 @@ const SyncCalendarModal = ({
             </div>
 
             <div
-              ref={scrollRef}
-              onTouchStart={handleScrollTouchStart}
-              onTouchMove={handleScrollTouchMove}
-              onTouchEnd={handleScrollTouchEnd}
+              {...sheet.scrollProps}
               className="flex-1 overflow-y-auto overscroll-contain"
               style={{ padding: "0 20px" }}
             >

--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from "react";
 import { color } from "@/lib/styles";
 import { parseNaturalDate, parseNaturalTime, parseDateToISO } from "@/lib/utils";
 import type { InterestCheck } from "@/lib/ui-types";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 import cn from "@/lib/tailwindMerge";
 
 const EditCheckModal = ({
@@ -42,12 +42,8 @@ const EditCheckModal = ({
   const [whereInput, setWhereInput] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
-  const { visible, entering, closing, close } = useModalTransition(open, onClose);
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const sheet = useBottomSheet({ open, onClose });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const isDragging = useRef(false);
 
   useEffect(() => {
     if (check && open) {
@@ -63,33 +59,7 @@ const EditCheckModal = ({
     }
   }, [check, open]);
 
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  const finishSwipe = () => {
-    if (dragOffset > 60) {
-      setDragOffset(0);
-      close();
-    } else {
-      setDragOffset(0);
-    }
-    isDragging.current = false;
-  };
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
-  };
-  const handleScrollTouchEnd = () => { if (isDragging.current) finishSwipe(); };
-
-  if (!visible || !check) return null;
+  if (!sheet.visible || !check) return null;
 
   const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
   const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
@@ -147,39 +117,31 @@ const EditCheckModal = ({
   return (
     <div className="fixed inset-0 z-[100] flex items-end justify-center">
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
           transition: "opacity 0.3s ease, backdrop-filter 0.3s ease, -webkit-backdrop-filter 0.3s ease",
         }}
       />
       <div
         className="relative bg-surface rounded-t-3xl w-full max-w-[420px] pt-5 px-6 max-h-[80vh] flex flex-col"
         style={{
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
         {/* Drag handle */}
-        <div
-          onTouchStart={(e) => { touchStartY.current = e.touches[0].clientY; isDragging.current = false; }}
-          onTouchMove={(e) => { const dy = e.touches[0].clientY - touchStartY.current; if (dy > 0) { isDragging.current = true; setDragOffset(dy); } }}
-          onTouchEnd={finishSwipe}
-          style={{ touchAction: "none" }}
-        >
+        <div {...sheet.swipeProps} style={{ touchAction: "none" }}>
           <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-5" />
         </div>
 
         <div
-          ref={scrollRef}
-          onTouchStart={handleScrollTouchStart}
-          onTouchMove={handleScrollTouchMove}
-          onTouchEnd={handleScrollTouchEnd}
+          {...sheet.scrollProps}
           className="overflow-y-auto overflow-x-hidden flex-1 pb-6"
         >
           {/* Title */}

--- a/src/features/events/components/EditEventModal.tsx
+++ b/src/features/events/components/EditEventModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { color } from "@/lib/styles";
 import { parseNaturalDate, parseNaturalTime, parseDateToISO } from "@/lib/utils";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 import cn from "@/lib/tailwindMerge";
 import type { Event, Squad } from "@/lib/ui-types";
 
@@ -31,11 +31,7 @@ const EditEventModal = ({
   const [whenInput, setWhenInput] = useState("");
   const [vibeText, setVibeText] = useState("");
   const [note, setNote] = useState("");
-  const { visible, entering, closing, close } = useModalTransition(open, onClose);
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isDragging = useRef(false);
+  const sheet = useBottomSheet({ open, onClose });
 
   useEffect(() => {
     if (event && open) {
@@ -51,33 +47,7 @@ const EditEventModal = ({
     }
   }, [event, open]);
 
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  const finishSwipe = () => {
-    if (dragOffset > 60) {
-      setDragOffset(0);
-      close();
-    } else {
-      setDragOffset(0);
-    }
-    isDragging.current = false;
-  };
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
-  };
-  const handleScrollTouchEnd = () => { if (isDragging.current) finishSwipe(); };
-
-  if (!visible || !event) return null;
+  if (!sheet.visible || !event) return null;
 
   const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
   const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
@@ -102,39 +72,34 @@ const EditEventModal = ({
   return (
     <div className="fixed inset-0 z-[100] flex items-end justify-center">
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
           transition: "opacity 0.3s ease, backdrop-filter 0.3s ease, -webkit-backdrop-filter 0.3s ease",
         }}
       />
       <div
         className="relative bg-surface rounded-t-3xl w-full max-w-[420px] px-6 pt-5 pb-0 max-h-[80vh] flex flex-col"
         style={{
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
         {/* Drag handle */}
         <div
-          onTouchStart={(e) => { touchStartY.current = e.touches[0].clientY; isDragging.current = false; }}
-          onTouchMove={(e) => { const dy = e.touches[0].clientY - touchStartY.current; if (dy > 0) { isDragging.current = true; setDragOffset(dy); } }}
-          onTouchEnd={finishSwipe}
+          {...sheet.swipeProps}
           style={{ touchAction: "none" }}
         >
           <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-5" />
         </div>
 
         <div
-          ref={scrollRef}
-          onTouchStart={handleScrollTouchStart}
-          onTouchMove={handleScrollTouchMove}
-          onTouchEnd={handleScrollTouchEnd}
+          {...sheet.scrollProps}
           className="overflow-y-auto overflow-x-hidden flex-1 pb-6"
         >
           <h3 className="font-serif text-2xl text-primary mb-5 font-normal">
@@ -219,7 +184,7 @@ const EditEventModal = ({
                   return (
                     <button
                       key={s.id}
-                      onClick={() => { close(); onOpenSquad(s.id); }}
+                      onClick={() => { sheet.close(); onOpenSquad(s.id); }}
                       className="flex items-center justify-between gap-2 w-full bg-deep border border-border-mid rounded-lg py-2.5 px-3 cursor-pointer text-left"
                     >
                       <span className="font-mono text-xs text-primary truncate flex-1 min-w-0">{s.name}</span>

--- a/src/features/events/components/EventLobby.tsx
+++ b/src/features/events/components/EventLobby.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import cn from "@/lib/tailwindMerge";
 import { color } from "@/lib/styles";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 import type { Event, Person } from "@/lib/ui-types";
 
 const EventLobby = ({
@@ -37,11 +37,7 @@ const EventLobby = ({
 }) => {
   const [selectingMembers, setSelectingMembers] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isDragging = useRef(false);
-  const { visible, entering, closing, close } = useModalTransition(open, onClose);
+  const sheet = useBottomSheet({ open, onClose });
 
   // Reset selection state when drawer opens/closes
   useEffect(() => {
@@ -51,34 +47,7 @@ const EventLobby = ({
     }
   }, [open]);
 
-  // Lock body scroll when open
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  const finishSwipe = () => {
-    if (dragOffset > 60) {
-      setDragOffset(0);
-      close();
-    } else {
-      setDragOffset(0);
-    }
-    isDragging.current = false;
-  };
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
-  };
-  const handleScrollTouchEnd = () => { if (isDragging.current) finishSwipe(); };
-
-  if (!visible || !event) return null;
+  if (!sheet.visible || !event) return null;
   const friends = event.peopleDown.filter((p) => p.mutual);
   const others = event.peopleDown.filter((p) => !p.mutual);
   const friendSquadmates = existingSquadId ? friends.filter((p) => p.inSquadId === existingSquadId) : [];
@@ -225,27 +194,27 @@ const EventLobby = ({
   return (
     <div className="fixed inset-0 z-[100] flex items-end justify-center">
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0 transition-[opacity,backdrop-filter,-webkit-backdrop-filter] duration-300 ease-in-out"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
         }}
       />
       <div
-        ref={scrollRef}
-        onTouchStart={handleScrollTouchStart}
-        onTouchMove={handleScrollTouchMove}
-        onTouchEnd={handleScrollTouchEnd}
+        {...sheet.scrollProps}
         className="relative bg-surface rounded-t-3xl w-full max-w-[420px] max-h-[70vh] overscroll-contain"
         style={{
           padding: "32px 24px 40px",
-          overflowY: isDragging.current ? "hidden" : "auto",
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: isDragging.current ? "none" : "transform 0.25s ease-out",
+          // Use dragOffset as the proxy for "currently dragging" — when the
+          // user is mid-pull we lock scroll and disable the transform
+          // transition so the panel tracks the finger.
+          overflowY: sheet.dragOffset > 0 ? "hidden" : "auto",
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.dragOffset > 0 ? "none" : "transform 0.25s ease-out",
         }}
       >
         <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-6" />
@@ -337,7 +306,7 @@ const EventLobby = ({
           {(friends.length > 0 || others.length > 0) && peopleReady && !isSelecting && (
             existingSquadId ? (
               <button
-                onClick={() => { onGoToSquad?.(existingSquadId); close(); }}
+                onClick={() => { onGoToSquad?.(existingSquadId); sheet.close(); }}
                 className="w-full bg-dt text-on-accent border-none rounded-xl p-3.5 font-mono text-xs font-bold cursor-pointer uppercase"
                 style={{ letterSpacing: "0.1em" }}
               >

--- a/src/features/friends/components/FriendsModal.tsx
+++ b/src/features/friends/components/FriendsModal.tsx
@@ -5,7 +5,7 @@ import cn from "@/lib/tailwindMerge";
 import type { Friend } from "@/lib/ui-types";
 import * as db from "@/lib/db";
 import { logError } from "@/lib/logger";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 
 const FriendsModal = ({
   open,
@@ -44,46 +44,11 @@ const FriendsModal = ({
   const searchTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [selectedFriend, setSelectedFriend] = useState<Friend | null>(null);
   const [requestedState, setRequestedState] = useState<"preview" | "expanded" | "collapsed">("preview");
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const { visible, entering, closing, close } = useModalTransition(open, onClose);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isDragging = useRef(false);
-
-  // Lock body scroll when open
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  const handleSwipeStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleSwipeMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
-  };
-  const finishSwipe = () => {
-    if (dragOffset > 60 && !preventClose) {
-      setDragOffset(0);
-      close();
-    } else {
-      setDragOffset(0);
-    }
-    isDragging.current = false;
-  };
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
-  };
-  const handleScrollTouchEnd = () => { if (isDragging.current) finishSwipe(); };
+  const sheet = useBottomSheet({
+    open,
+    onClose,
+    canClose: () => !preventClose,
+  });
 
   const hasAddedFriend = friends.length > 0 || suggestions.some((s) => s.status === "pending" || s.status === "incoming") || searchResults.some((s) => s.status === "pending");
 
@@ -143,41 +108,34 @@ const FriendsModal = ({
     }
   }, [open]);
 
-  if (!visible) return null;
+  if (!sheet.visible) return null;
 
   return (
     <div className="fixed inset-0 z-100 flex items-end justify-center">
       <div
-        onClick={preventClose ? undefined : close}
-        className={cn(
-          "absolute inset-0 transition-all duration-300 ease-in-out",
-          (entering || closing) ? "opacity-0" : "opacity-100"
-        )}
+        onClick={preventClose ? undefined : sheet.close}
+        className="absolute inset-0 transition-all duration-300 ease-in-out"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
         }}
       />
       <div
         className={cn(
           "relative bg-surface w-full max-w-[420px] flex flex-col",
-          !closing && "animate-slide-up"
+          !sheet.closing && "animate-slide-up"
         )}
         style={{
           borderRadius: "24px 24px 0 0",
           padding: "32px 24px 0",
           maxHeight: "85vh",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
-        <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={finishSwipe}
-          className="touch-none"
-        >
+        <div {...sheet.swipeProps} className="touch-none">
           <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-6" />
         </div>
 
@@ -228,10 +186,7 @@ const FriendsModal = ({
         />
 
         <div
-          ref={scrollRef}
-          onTouchStart={handleScrollTouchStart}
-          onTouchMove={handleScrollTouchMove}
-          onTouchEnd={handleScrollTouchEnd}
+          {...sheet.scrollProps}
           className="overflow-y-auto overflow-x-hidden flex-1 pb-10"
         >
         {tab === "friends" ? (

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useRef, useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import * as db from "@/lib/db";
 import { color } from "@/lib/styles";
 import { formatTimeAgo } from "@/lib/utils";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 import cn from "@/lib/tailwindMerge";
 import type { Tab } from "@/lib/ui-types";
 
@@ -62,99 +62,38 @@ const NotificationsPanel = ({
   onNavigate: (action: { type: "friends"; tab: "friends" | "add" } | { type: "groups"; squadId?: string } | { type: "feed"; checkId?: string }) => void;
   onDeletedCheck: (info: { checkId: string; isMine: boolean }) => void;
 }) => {
-  const { visible, entering, closing, close } = useModalTransition(open, onClose);
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const panelRef = useRef<HTMLDivElement>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isDragging = useRef(false);
+  const sheet = useBottomSheet({ open, onClose });
 
-  // Lock body scroll when panel is open
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  const handleSwipeStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleSwipeMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy > 0) {
-      isDragging.current = true;
-      setDragOffset(dy);
-    }
-  };
-  const handleSwipeEnd = () => {
-    if (dragOffset > 60) {
-      setDragOffset(0);
-      close();
-    } else {
-      setDragOffset(0);
-    }
-    isDragging.current = false;
-  };
-
-  // Scroll-area: start dragging when at top and pulling down
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) {
-      isDragging.current = true;
-      e.preventDefault();
-      setDragOffset(dy);
-    }
-  };
-  const handleScrollTouchEnd = () => {
-    if (isDragging.current) {
-      handleSwipeEnd();
-    }
-  };
-
-  if (!visible) return null;
+  if (!sheet.visible) return null;
 
   return (
     <div className="fixed inset-0 z-[100] flex items-end justify-center">
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
           transition: "opacity 0.3s ease, backdrop-filter 0.3s ease, -webkit-backdrop-filter 0.3s ease",
         }}
       />
       <div
-        ref={panelRef}
         className="relative bg-surface w-full max-w-[420px] flex flex-col pt-6"
         style={{
           borderRadius: "24px 24px 0 0",
           maxHeight: "80vh",
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
-        <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={handleSwipeEnd}
-          className="touch-none"
-        >
+        <div {...sheet.swipeProps} className="touch-none">
           <div className="w-10 h-1 bg-faint rounded-sm mx-auto mb-4" />
         </div>
         <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={handleSwipeEnd}
+          {...sheet.swipeProps}
           className="flex justify-between items-center px-5 pb-4 border-b border-border touch-none"
         >
           <h2 className="font-serif text-2xl text-primary font-normal">
@@ -183,11 +122,8 @@ const NotificationsPanel = ({
           )}
         </div>
         <div
-          ref={scrollRef}
-          onTouchStart={handleScrollTouchStart}
-          onTouchMove={handleScrollTouchMove}
-          onTouchEnd={handleScrollTouchEnd}
-          className={cn("overflow-x-hidden flex-1 pb-8", isDragging.current ? "overflow-y-hidden" : "overflow-y-auto")}
+          {...sheet.scrollProps}
+          className={cn("overflow-x-hidden flex-1 pb-8", sheet.dragOffset > 0 ? "overflow-y-hidden" : "overflow-y-auto")}
         >
           {notifications.length === 0 ? (
             <div className="py-10 px-5 text-center">

--- a/src/shared/components/CheckActionsSheet.tsx
+++ b/src/shared/components/CheckActionsSheet.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 
 /**
  * Small action sheet for a non-owned check in the feed. Opens from the
  * card's ⋯ kebab. Surfaces Hide + Report in a bottom sheet so the card
  * itself stays visually quiet.
- *
- * Mirrors the ReportSheet shell (backdrop, transitions, 60px swipe-to-dismiss).
  */
 interface CheckActionsSheetProps {
   onHide: () => void;
@@ -17,66 +14,37 @@ interface CheckActionsSheetProps {
 }
 
 const CheckActionsSheet = ({ onHide, onReport, onClose }: CheckActionsSheetProps) => {
-  const { visible, entering, closing, close } = useModalTransition(true, onClose);
+  const sheet = useBottomSheet({ open: true, onClose });
 
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const isDragging = useRef(false);
-
-  const handleSwipeStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleSwipeMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
-  };
-  const handleSwipeEnd = () => {
-    if (dragOffset > 60) { setDragOffset(0); close(); }
-    else { setDragOffset(0); }
-    isDragging.current = false;
-  };
-
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  if (!visible) return null;
+  if (!sheet.visible) return null;
 
   const actOn = (fn: () => void) => {
     fn();
-    close();
+    sheet.close();
   };
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-end justify-center">
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0 transition-[opacity,backdrop-filter] duration-300 ease-in-out"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
         }}
       />
       <div
         className="relative bg-surface w-full max-w-[420px] flex flex-col"
         style={{
           borderRadius: "24px 24px 0 0",
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
-        <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={handleSwipeEnd}
-          className="touch-none pt-3 pb-1 flex justify-center"
-        >
+        <div {...sheet.swipeProps} className="touch-none pt-3 pb-1 flex justify-center">
           <div className="w-10 h-1 rounded-sm" style={{ background: "#444" }} />
         </div>
 
@@ -96,7 +64,7 @@ const CheckActionsSheet = ({ onHide, onReport, onClose }: CheckActionsSheetProps
             Report
           </button>
           <button
-            onClick={close}
+            onClick={sheet.close}
             className="w-full bg-transparent border-none rounded-xl py-3 font-mono text-xs uppercase text-faint cursor-pointer mt-1"
             style={{ letterSpacing: "0.08em" }}
           >

--- a/src/shared/components/DetailSheet.tsx
+++ b/src/shared/components/DetailSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import React from "react";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 
 /**
  * Shared bottom-sheet shell: backdrop + blur + slide-up panel + drag-to-dismiss
@@ -22,45 +22,9 @@ export default function DetailSheet({
   onEdit?: () => void;
   children: React.ReactNode;
 }) {
-  const { visible, entering, closing, close } = useModalTransition(true, onClose);
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const isDragging = useRef(false);
+  const sheet = useBottomSheet({ open: true, onClose });
 
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
-
-  const handleSwipeStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleSwipeMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
-  };
-  const handleSwipeEnd = () => {
-    if (dragOffset > 60) { setDragOffset(0); close(); }
-    else { setDragOffset(0); }
-    isDragging.current = false;
-  };
-  const handleScrollTouchStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleScrollTouchMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
-    if (atTop && dy > 0) { isDragging.current = true; e.preventDefault(); setDragOffset(dy); }
-  };
-  const handleScrollTouchEnd = () => {
-    if (isDragging.current) handleSwipeEnd();
-  };
-
-  if (!visible) return null;
+  if (!sheet.visible) return null;
 
   return (
     <div
@@ -71,13 +35,13 @@ export default function DetailSheet({
     >
       {/* Backdrop */}
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0 transition-[opacity,backdrop-filter] duration-300 ease-in-out"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
         }}
       />
       {/* Panel */}
@@ -86,18 +50,13 @@ export default function DetailSheet({
         style={{
           maxWidth: 420,
           maxHeight: "80vh",
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
         {/* Drag handle */}
-        <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={handleSwipeEnd}
-          className="touch-none"
-        >
+        <div {...sheet.swipeProps} className="touch-none">
           <div className="flex justify-center px-5 pb-2">
             <div className="w-10 h-1 bg-faint rounded-sm" />
           </div>
@@ -105,17 +64,14 @@ export default function DetailSheet({
 
         {/* Scrollable content */}
         <div
-          ref={scrollRef}
-          onTouchStart={handleScrollTouchStart}
-          onTouchMove={handleScrollTouchMove}
-          onTouchEnd={handleScrollTouchEnd}
+          {...sheet.scrollProps}
           className="flex-1 overflow-y-auto overscroll-contain px-5 pb-5"
         >
           {children}
           {editLabel && onEdit && (
             <div className="mt-5 pt-4 border-t border-border">
               <button
-                onClick={() => { onEdit(); close(); }}
+                onClick={() => { onEdit(); sheet.close(); }}
                 className="w-full flex items-center justify-between py-2 font-mono text-xs text-dt font-bold uppercase tracking-[0.06em] cursor-pointer"
               >
                 <span>{editLabel}</span>

--- a/src/shared/components/ReportSheet.tsx
+++ b/src/shared/components/ReportSheet.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import * as db from "@/lib/db";
 import type { ReportReason, ReportTargetType } from "@/lib/db";
 import { logError } from "@/lib/logger";
 import cn from "@/lib/tailwindMerge";
-import { useModalTransition } from "@/shared/hooks/useModalTransition";
+import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
 
 const REASONS: { value: ReportReason; label: string }[] = [
   { value: "harassment",    label: "Harassment or bullying" },
@@ -25,35 +25,10 @@ interface ReportSheetProps {
 }
 
 const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }: ReportSheetProps) => {
-  const { visible, entering, closing, close } = useModalTransition(true, onClose);
+  const sheet = useBottomSheet({ open: true, onClose });
   const [reason, setReason] = useState<ReportReason | null>(null);
   const [details, setDetails] = useState("");
   const [submitting, setSubmitting] = useState(false);
-
-  // Swipe-to-dismiss — mirrors DetailSheet. 60px downward closes.
-  const touchStartY = useRef(0);
-  const [dragOffset, setDragOffset] = useState(0);
-  const isDragging = useRef(false);
-
-  const handleSwipeStart = (e: React.TouchEvent) => {
-    touchStartY.current = e.touches[0].clientY;
-    isDragging.current = false;
-  };
-  const handleSwipeMove = (e: React.TouchEvent) => {
-    const dy = e.touches[0].clientY - touchStartY.current;
-    if (dy > 0) { isDragging.current = true; setDragOffset(dy); }
-  };
-  const handleSwipeEnd = () => {
-    if (dragOffset > 60) { setDragOffset(0); close(); }
-    else { setDragOffset(0); }
-    isDragging.current = false;
-  };
-
-  useEffect(() => {
-    if (!visible) return;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = ""; };
-  }, [visible]);
 
   const submit = async () => {
     if (!reason || submitting) return;
@@ -61,27 +36,27 @@ const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }
     try {
       await db.reportContent(targetType, targetId, reason, details.trim() || null);
       onSubmitted?.();
-      close();
+      sheet.close();
     } catch (err) {
       logError("reportContent", err, { targetType, targetId });
       setSubmitting(false);
     }
   };
 
-  if (!visible) return null;
+  if (!sheet.visible) return null;
 
   const title = targetLabel ? `Report ${targetLabel}` : "Report";
 
   return (
     <div className="fixed inset-0 z-[9999] flex items-end justify-center">
       <div
-        onClick={close}
+        onClick={sheet.close}
         className="absolute inset-0 transition-[opacity,backdrop-filter] duration-300 ease-in-out"
         style={{
           background: "rgba(0,0,0,0.7)",
-          backdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          WebkitBackdropFilter: (entering || closing) ? "blur(0px)" : "blur(8px)",
-          opacity: (entering || closing) ? 0 : 1,
+          backdropFilter: sheet.backdropBlur,
+          WebkitBackdropFilter: sheet.backdropBlur,
+          opacity: sheet.backdropOpacity,
         }}
       />
       <div
@@ -89,18 +64,13 @@ const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }
         style={{
           borderRadius: "24px 24px 0 0",
           maxHeight: "80vh",
-          animation: closing ? undefined : "slideUp 0.3s ease-out",
-          transform: closing ? "translateY(100%)" : `translateY(${dragOffset}px)`,
-          transition: closing ? "transform 0.2s ease-in" : (dragOffset === 0 ? "transform 0.2s ease-out" : "none"),
+          animation: sheet.closing ? undefined : "slideUp 0.3s ease-out",
+          transform: sheet.panelTransform,
+          transition: sheet.panelTransition,
         }}
       >
         {/* Drag handle — touch target for swipe-to-dismiss */}
-        <div
-          onTouchStart={handleSwipeStart}
-          onTouchMove={handleSwipeMove}
-          onTouchEnd={handleSwipeEnd}
-          className="touch-none pt-3 pb-1 flex justify-center"
-        >
+        <div {...sheet.swipeProps} className="touch-none pt-3 pb-1 flex justify-center">
           <div className="w-10 h-1 rounded-sm" style={{ background: "#444" }} />
         </div>
 
@@ -141,7 +111,7 @@ const ReportSheet = ({ targetType, targetId, targetLabel, onClose, onSubmitted }
 
           <div className="flex gap-2.5">
             <button
-              onClick={close}
+              onClick={sheet.close}
               disabled={submitting}
               className="flex-1 bg-transparent border border-border-mid rounded-xl py-3 font-mono text-xs font-bold uppercase text-primary cursor-pointer"
               style={{ letterSpacing: "0.08em" }}

--- a/src/shared/hooks/useBottomSheet.ts
+++ b/src/shared/hooks/useBottomSheet.ts
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type React from "react";
+import { useModalTransition } from "./useModalTransition";
+
+const SWIPE_DISMISS_THRESHOLD_PX = 60;
+
+/**
+ * Bottom-sheet shell behavior in one place. Composes the open → entering →
+ * closing → unmounted lifecycle from useModalTransition with the
+ * swipe-to-dismiss + scroll-edge-drag logic that every sheet in this app
+ * had to reimplement.
+ *
+ * Returns:
+ *   • lifecycle flags from useModalTransition (visible, entering, closing,
+ *     close())
+ *   • props to spread onto the drag handle (`swipeProps`) and the
+ *     scrollable content (`scrollProps`)
+ *   • derived style values for the panel and backdrop, so consumers don't
+ *     have to recompute the transform/transition/blur strings themselves
+ *
+ * Sheet shells differ enough (max-height, padding, optional edit row,
+ * additional state) that a *hook* is the right shape rather than another
+ * wrapping component — `DetailSheet` is already the opinionated wrapper for
+ * the cases it covers, and this hook serves everything else.
+ */
+export function useBottomSheet({
+  open,
+  onClose,
+  closeDuration = 200,
+  canClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+  closeDuration?: number;
+  /**
+   * Optional gate on dismissal. Returns false to suppress close (the swipe
+   * still resets the drag offset, the backdrop just bounces back). Used by
+   * onboarding-style sheets that need the user to take an action before
+   * they can dismiss.
+   */
+  canClose?: () => boolean;
+}) {
+  const { visible, entering, closing, close } = useModalTransition(
+    open,
+    onClose,
+    closeDuration,
+  );
+
+  const touchStartY = useRef(0);
+  const isDragging = useRef(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [dragOffset, setDragOffset] = useState(0);
+
+  // Lock body scroll while the sheet is mounted.
+  useEffect(() => {
+    if (!visible) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [visible]);
+
+  const finishSwipe = () => {
+    if (
+      dragOffset > SWIPE_DISMISS_THRESHOLD_PX &&
+      (canClose === undefined || canClose())
+    ) {
+      close();
+    }
+    setDragOffset(0);
+    isDragging.current = false;
+  };
+
+  // Spread these onto the drag-handle (or any element that should always
+  // start a swipe regardless of scroll position).
+  const swipeProps = {
+    onTouchStart: (e: React.TouchEvent) => {
+      touchStartY.current = e.touches[0].clientY;
+      isDragging.current = false;
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      const dy = e.touches[0].clientY - touchStartY.current;
+      if (dy > 0) {
+        isDragging.current = true;
+        setDragOffset(dy);
+      }
+    },
+    onTouchEnd: finishSwipe,
+  };
+
+  // Spread these onto the scrollable content area. Dragging only initiates
+  // a dismiss when the scroll is already at the top — otherwise the user is
+  // scrolling content, not closing the sheet.
+  const scrollProps = {
+    ref: scrollRef,
+    onTouchStart: (e: React.TouchEvent) => {
+      touchStartY.current = e.touches[0].clientY;
+      isDragging.current = false;
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      const dy = e.touches[0].clientY - touchStartY.current;
+      const atTop = scrollRef.current ? scrollRef.current.scrollTop <= 0 : true;
+      if (atTop && dy > 0) {
+        isDragging.current = true;
+        e.preventDefault();
+        setDragOffset(dy);
+      }
+    },
+    onTouchEnd: () => {
+      if (isDragging.current) finishSwipe();
+    },
+  };
+
+  const panelTransform = closing
+    ? "translateY(100%)"
+    : `translateY(${dragOffset}px)`;
+  const panelTransition = closing
+    ? "transform 0.2s ease-in"
+    : dragOffset === 0
+      ? "transform 0.2s ease-out"
+      : "none";
+  const backdropBlur = entering || closing ? "blur(0px)" : "blur(8px)";
+  const backdropOpacity = entering || closing ? 0 : 1;
+
+  return {
+    visible,
+    entering,
+    closing,
+    close,
+    dragOffset,
+    swipeProps,
+    scrollProps,
+    panelTransform,
+    panelTransition,
+    backdropBlur,
+    backdropOpacity,
+  };
+}


### PR DESCRIPTION
## Summary
Every bottom-sheet in the app reimplemented the same swipe-to-dismiss + scroll-edge-drag + backdrop-blur transitions, with subtle drift between copies. New \`src/shared/hooks/useBottomSheet.ts\` owns:

- The lifecycle (composing \`useModalTransition\`)
- \`dragOffset\` state
- Swipe handlers as a spreadable \`swipeProps\` (drop on the drag handle / header)
- Scroll-area handlers as a spreadable \`scrollProps\` (drop on the scrollable content; only triggers dismiss when scroll is at top)
- Derived style values: \`panelTransform\`, \`panelTransition\`, \`backdropBlur\`, \`backdropOpacity\`

## Migrated (9 sheets)
- \`shared/components/DetailSheet.tsx\`
- \`shared/components/ReportSheet.tsx\`
- \`shared/components/CheckActionsSheet.tsx\`
- \`features/checks/components/EditCheckModal.tsx\`
- \`features/events/components/EditEventModal.tsx\`
- \`features/events/components/EventLobby.tsx\`
- \`features/friends/components/FriendsModal.tsx\`
- \`features/notifications/components/NotificationsPanel.tsx\`
- \`app/components/SyncCalendarModal.tsx\`

## Net diff
**-358 lines** across 9 sheets, behavior unchanged.

## Notes on edge cases
- **\`FriendsModal\`** has a \`preventClose\` flag (mandatory-action onboarding state). Hook accepts an optional \`canClose()\` callback that gates the swipe dismiss — bounce-back happens, sheet stays open.
- **\`SyncCalendarModal\`** had its own ad-hoc closing animation rather than \`useModalTransition\`; folded into the shared lifecycle so timing matches every other sheet.
- **\`EventLobby\`** was the only consumer that read \`isDragging\` directly (to freeze scrollY mid-drag). Hook keeps the ref internal; consumers use \`dragOffset > 0\` for the same signal.

## Test plan
- [x] \`npm run test:e2e\` — 6/6 pass in 9.1s
- [ ] Manual: open each sheet (notifications panel, friends modal, event lobby, edit check, edit event, report, check-actions, sync-calendar) — swipe to dismiss works, backdrop click works
- [ ] Manual: \`FriendsModal\` with \`preventClose\` (e.g. onboarding flow with no friends) — swipe bounces back, doesn't close

🤖 Generated with [Claude Code](https://claude.com/claude-code)