### PR TITLE
refactor: extract useDateTimeInput hook for natural-language date+time entry

### DIFF
--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useEffect, useRef } from "react";
 import { color } from "@/lib/styles";
-import { parseNaturalDate, parseNaturalTime, parseDateToISO } from "@/lib/utils";
+import { parseDateToISO } from "@/lib/utils";
 import type { InterestCheck } from "@/lib/ui-types";
 import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
+import { useDateTimeInput } from "@/shared/hooks/useDateTimeInput";
 import cn from "@/lib/tailwindMerge";
 
 const EditCheckModal = ({
@@ -38,7 +39,7 @@ const EditCheckModal = ({
   onDelete?: () => void;
 }) => {
   const [text, setText] = useState("");
-  const [whenInput, setWhenInput] = useState("");
+  const { whenInput, setWhenInput, parsedDate, parsedTime, whenPreview } = useDateTimeInput();
   const [whereInput, setWhereInput] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
@@ -60,16 +61,6 @@ const EditCheckModal = ({
   }, [check, open]);
 
   if (!sheet.visible || !check) return null;
-
-  const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
-  const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
-  const whenPreview = (() => {
-    if (!parsedDate && !parsedTime) return null;
-    const parts: string[] = [];
-    if (parsedDate) parts.push(parsedDate.label);
-    if (parsedTime) parts.push(parsedTime);
-    return parts.join(" ");
-  })();
 
   const handleSave = () => {
     const trimmed = text.trim();

--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useModalTransition } from '@/shared/hooks/useModalTransition';
+import { useDateTimeInput } from '@/shared/hooks/useDateTimeInput';
 import type { ScrapedEvent } from '@/lib/ui-types';
-import { parseNaturalDate, parseNaturalTime, sanitize } from '@/lib/utils';
+import { parseNaturalDate, sanitize } from '@/lib/utils';
 import { logError, logWarn } from '@/lib/logger';
 import * as db from '@/lib/db';
 import { API_BASE } from '@/lib/db';
@@ -105,19 +106,8 @@ const AddModal = ({
   }, [minSquadSize, squadSize]);
 
   // When/where inputs for date+time and location
-  const [whenInput, setWhenInput] = useState('');
+  const { whenInput, setWhenInput, parsedDate, parsedTime, whenPreview } = useDateTimeInput();
   const [whereInput, setWhereInput] = useState('');
-
-  // Live-parse the "when" input for date and time
-  const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
-  const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
-  const whenPreview = (() => {
-    if (!parsedDate && !parsedTime) return null;
-    const parts: string[] = [];
-    if (parsedDate) parts.push(parsedDate.label);
-    if (parsedTime) parts.push(parsedTime);
-    return parts.join(' ');
-  })();
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1); // cursor position of @
   const [loading, setLoading] = useState(false);

--- a/src/features/events/components/EditEventModal.tsx
+++ b/src/features/events/components/EditEventModal.tsx
@@ -2,8 +2,9 @@
 
 import { useState, useEffect } from "react";
 import { color } from "@/lib/styles";
-import { parseNaturalDate, parseNaturalTime, parseDateToISO } from "@/lib/utils";
+import { parseDateToISO } from "@/lib/utils";
 import { useBottomSheet } from "@/shared/hooks/useBottomSheet";
+import { useDateTimeInput } from "@/shared/hooks/useDateTimeInput";
 import cn from "@/lib/tailwindMerge";
 import type { Event, Squad } from "@/lib/ui-types";
 
@@ -28,7 +29,7 @@ const EditEventModal = ({
 }) => {
   const [title, setTitle] = useState("");
   const [venue, setVenue] = useState("");
-  const [whenInput, setWhenInput] = useState("");
+  const { whenInput, setWhenInput, parsedDate, parsedTime, whenPreview } = useDateTimeInput();
   const [vibeText, setVibeText] = useState("");
   const [note, setNote] = useState("");
   const sheet = useBottomSheet({ open, onClose });
@@ -48,16 +49,6 @@ const EditEventModal = ({
   }, [event, open]);
 
   if (!sheet.visible || !event) return null;
-
-  const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
-  const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
-  const whenPreview = (() => {
-    if (!parsedDate && !parsedTime) return null;
-    const parts: string[] = [];
-    if (parsedDate) parts.push(parsedDate.label);
-    if (parsedTime) parts.push(parsedTime);
-    return parts.join(" ");
-  })();
 
   // Resolve date/time for save. Only overwrite the existing date when we can
   // actually parse the input as a date — otherwise the user is editing something

--- a/src/shared/hooks/useDateTimeInput.ts
+++ b/src/shared/hooks/useDateTimeInput.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { parseNaturalDate, parseNaturalTime } from "@/lib/utils";
+
+/**
+ * "When" input for natural-language date+time entry. Three modals
+ * (EditCheckModal, EditEventModal, CreateModal) used to reimplement the
+ * exact same parse-as-you-type + preview logic verbatim — now they all
+ * share this.
+ *
+ * Returns the controlled input value, the setter, the parsed pieces (or
+ * null if unparseable), and a "preview" string ("Sat Apr 27 · 7pm") that
+ * the modals show under the input as live feedback.
+ */
+export function useDateTimeInput(initial = "") {
+  const [whenInput, setWhenInput] = useState(initial);
+
+  const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
+  const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
+
+  const whenPreview = (() => {
+    if (!parsedDate && !parsedTime) return null;
+    const parts: string[] = [];
+    if (parsedDate) parts.push(parsedDate.label);
+    if (parsedTime) parts.push(parsedTime);
+    return parts.join(" ");
+  })();
+
+  return { whenInput, setWhenInput, parsedDate, parsedTime, whenPreview };
+}


### PR DESCRIPTION
## Summary
Three modals reimplemented identical natural-language date+time entry + live preview logic verbatim:
- \`EditCheckModal\`
- \`EditEventModal\`
- \`CreateModal\` (the "Interest Check" mode)

Each had its own copy of:
\`\`\`tsx
const parsedDate = whenInput ? parseNaturalDate(whenInput) : null;
const parsedTime = whenInput ? parseNaturalTime(whenInput) : null;
const whenPreview = parsedDate || parsedTime ? ... : null;
\`\`\`

Plus the \`useState\` for \`whenInput\` itself.

Now in \`src/shared/hooks/useDateTimeInput.ts\`. Each modal pulls the state + parsed values + preview string from the hook directly.

## Net diff
-27 lines across the three modals, single source of truth for parse logic. e2e still 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)