### PR TITLE
chore: remove stale 'X removed' comments referencing deleted code

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -917,7 +917,6 @@ export default function Home() {
             opacity: scrolledDown ? 1 : 0,
           }}
         />
-        {/* Bottom fade — removed for cleaner look */}
         {/* Scroll container */}
         <div
           ref={scrollRef}

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -138,7 +138,6 @@ const SquadChat = ({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [entering, setEntering] = useState(true);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
-  // showImOutConfirm removed — "can't make it" is now a soft inline action
   const [kickTarget, setKickTarget] = useState<{ name: string; userId: string } | null>(null);
   const [showSquadPopup, setShowSquadPopup] = useState(false);
   const [showEditEvent, setShowEditEvent] = useState(false);
@@ -742,8 +741,6 @@ const SquadChat = ({
           </div>
         </div>
       )}
-
-      {/* I'm out confirmation removed — "can't make it" is now a soft action */}
 
       {/* Kick member confirmation */}
       {kickTarget && localSquad && (


### PR DESCRIPTION
## Summary
Three orphan markers pointing at code that was deleted ages ago. None help future readers — git blame is more honest.

- \`src/app/page.tsx\` — \`{/* Bottom fade — removed for cleaner look */}\`
- \`src/features/squads/components/SquadChat.tsx\` — \`// showImOutConfirm removed — "can't make it" is now a soft inline action\`
- Same file — \`{/* I'm out confirmation removed — "can't make it" is now a soft action */}\`

The \`DevProdBanner\` "TODO: re-enable banner — temporarily hidden while iterating on linen theme" stays — it's a forward-looking intent marker, not a backwards-looking tombstone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)