### PR TITLE
fix: re-register native push when iOS permission already granted

### DIFF
--- a/src/features/auth/hooks/usePushNotifications.ts
+++ b/src/features/auth/hooks/usePushNotifications.ts
@@ -29,7 +29,14 @@ export function usePushNotifications(
         // On native, the OS owns permission state. Mirror it into the toggle.
         const perm = await PushNotifications.checkPermissions();
         if (perm.receive === "granted") {
-          setPushEnabled(true);
+          // iOS preserves the permission grant across uninstall/reinstall, so
+          // a fresh build on an already-allowed device hits this branch on
+          // first sign-in. We still need to call register() so APNs hands us
+          // a fresh device token and we save it to push_subscriptions.
+          // registerNativePush is idempotent — re-calling on an already-
+          // granted device just refreshes the token.
+          const ok = await registerNativePush();
+          if (ok) setPushEnabled(true);
         } else if (
           perm.receive === "prompt" &&
           !localStorage.getItem("pushAutoPrompted")
@@ -61,9 +68,8 @@ export function usePushNotifications(
   const handleTogglePush = async () => {
     if (isNativePlatform()) {
       if (pushEnabled) {
-        // iOS doesn't let an app revoke its own push permission. Tell the user
-        // where to flip it, since the toggle in our UI can't do it directly.
-        showToast("Disable in iOS Settings → downto → Notifications");
+        // iOS doesn't let an app revoke its own push permission.
+        showToast("Disable in iOS Settings → downto");
         return;
       }
       const ok = await registerNativePush();
@@ -71,7 +77,7 @@ export function usePushNotifications(
         setPushEnabled(true);
         showToast("Push notifications enabled!");
       } else {
-        showToast("Push permission denied — enable in iOS Settings → downto");
+        showToast("Enable in iOS Settings → downto");
       }
       return;
     }


### PR DESCRIPTION
## Summary
\`ios:fresh\` uninstalls and reinstalls the app, but iOS preserves the "Allow Notifications" decision across that — the next install starts with \`checkPermissions()\` returning \`"granted"\`. The mount handler in \`usePushNotifications\` took the granted branch and just set \`pushEnabled=true\` without calling \`register()\`, so APNs never handed back a device token and nothing got written to \`push_subscriptions\`. Push appeared "enabled" in the UI but no row existed for fan-out to target.

Call \`registerNativePush()\` on the granted branch too. The plugin's \`register()\` is idempotent — re-calling on an already-granted device just refreshes the token and re-fires the registration listener, which saves the row.

Also shortened the iOS-settings nudge toast that was getting clipped on the right edge of the screen ("Disable in iOS Settings → downto → Notifications" → "Disable in iOS Settings → downto").

## Test plan
- [x] Bug repro: \`npm run ios:fresh\`, sign in → UI shows "Push Notifications: Enabled" but \`push_subscriptions\` has no iOS row
- [ ] After fix: \`npm run ios:fresh\`, sign in → iOS row appears in \`push_subscriptions\` with platform='ios' and device_token populated
- [ ] First-ever install (no prior permission decision): system prompt appears, Allow → row saves
- [ ] Toggle text fits on screen on iPhone 17 Pro

🤖 Generated with [Claude Code](https://claude.com/claude-code)