### PR TITLE
fix: mystery mode submit button always disabled in CreateModal

### DIFF
--- a/e2e/mystery-check.spec.ts
+++ b/e2e/mystery-check.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+import { loginAsTestUser } from "./helpers/auth";
+import { waitForAppLoaded } from "./helpers/nav";
+
+/**
+ * Mystery check creation — regression coverage for the prod bug where the
+ * Send button stayed permanently disabled when the mystery toggle was on
+ * (the CreateModal referenced an undefined `parsedDate` after the
+ * useDateTimeInput hook was refactored to expose `parsedDateISO` instead).
+ *
+ * Goldens this test guards:
+ *   1. Toggling the mystery switch flips the submit button's label to
+ *      "Send Mystery Check →" and disables it until idea + date + location
+ *      are all filled.
+ *   2. Filling only the date leaves the button disabled (location still
+ *      required by the DB CHECK constraint mirror in the UI gate).
+ *   3. Filling all three enables the button — *this* assertion is the one
+ *      that would have caught the prod bug before it shipped.
+ *   4. Submitting actually creates the check and renders it in the feed.
+ *      The author always sees their own mystery check unredacted, so the
+ *      idea text shows up directly without a "███████" name placeholder.
+ */
+test.describe("Mystery check creation", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsTestUser(page);
+    await waitForAppLoaded(page);
+  });
+
+  test("toggling mystery on with all fields filled enables the Send Mystery Check button", async ({ page }) => {
+    await page.getByRole("button", { name: "+" }).click();
+
+    const dateTimeInput = page.getByPlaceholder("e.g. tmr 7pm");
+    await expect(dateTimeInput).toBeVisible({ timeout: 5_000 });
+
+    const ideaText = `playwright mystery ${Date.now()}`;
+    const ideaTextarea = page.locator("textarea").first();
+    await ideaTextarea.fill(ideaText);
+
+    // Before toggling: regular Send button is enabled with just an idea.
+    const regularButton = page.getByRole("button", { name: /Send (Interest|Movie) Check/ });
+    await expect(regularButton).toBeEnabled();
+
+    // Toggle mystery mode on — the toggle is a button containing "Mystery mode".
+    await page.getByRole("button", { name: /Mystery mode/ }).click();
+
+    // The submit-button label should flip to the mystery variant…
+    const mysteryButton = page.getByRole("button", { name: /Send Mystery Check/ });
+    await expect(mysteryButton).toBeVisible();
+
+    // …and it should be disabled because date + location are missing.
+    await expect(mysteryButton).toBeDisabled();
+
+    // Fill date only — still disabled (location required).
+    await dateTimeInput.fill("tmr 7pm");
+    await expect(mysteryButton).toBeDisabled();
+
+    // Fill location — NOW the button enables. This is the regression check
+    // for the prod bug; before the fix this stayed disabled forever.
+    await page.getByPlaceholder("location").fill("Somewhere downtown");
+    await expect(mysteryButton).toBeEnabled({ timeout: 5_000 });
+
+    // Submit and confirm the check lands in the feed. The author always sees
+    // their own mystery check unredacted, so the idea text is searchable.
+    await mysteryButton.click();
+    await expect(dateTimeInput).toBeHidden({ timeout: 5_000 });
+    await expect(page.getByText(ideaText, { exact: false })).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("toggling mystery off after filling fields restores the regular Send Interest Check button", async ({ page }) => {
+    await page.getByRole("button", { name: "+" }).click();
+    await expect(page.getByPlaceholder("e.g. tmr 7pm")).toBeVisible({ timeout: 5_000 });
+
+    await page.locator("textarea").first().fill(`playwright toggle ${Date.now()}`);
+
+    // Toggle on, then off.
+    const toggle = page.getByRole("button", { name: /Mystery mode/ });
+    await toggle.click();
+    await expect(page.getByRole("button", { name: /Send Mystery Check/ })).toBeVisible();
+    await toggle.click();
+
+    // Back to the regular label, enabled even without date/location.
+    const regularButton = page.getByRole("button", { name: /Send (Interest|Movie) Check/ });
+    await expect(regularButton).toBeVisible();
+    await expect(regularButton).toBeEnabled();
+  });
+});

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -7,15 +7,11 @@ import type { InterestCheck } from "@/lib/ui-types";
 import { logError, logWarn } from "@/lib/logger";
 import { formatTimeAgo } from "@/lib/utils";
 import { checksReducer, initialChecksState, CheckActionType } from "@/features/checks/reducers/checksReducer";
+import { isMysteryUnrevealed } from "@/features/checks/lib/mystery";
 
 // ─── Shared transform helpers ──────────────────────────────────────────────
 
 type ActiveCheck = Awaited<ReturnType<typeof db.getActiveChecks>>[number];
-
-/** YYYY-MM-DD in the viewer's local tz; matches how event_date is stored. */
-function localTodayISO(now: Date): string {
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-}
 
 function transformCheck(c: ActiveCheck, userId: string | null, displayName?: string): InterestCheck {
   const now = new Date();
@@ -28,8 +24,10 @@ function transformCheck(c: ActiveCheck, userId: string | null, displayName?: str
   // someone else's account.
   const isMystery = !!(c as unknown as { mystery?: boolean }).mystery;
   const isAuthor = c.author_id === userId;
-  const isUnrevealed = isMystery && !isAuthor && (
-    !c.event_date || c.event_date > localTodayISO(now)
+  const isUnrevealed = isMysteryUnrevealed(
+    { mystery: isMystery, authorId: c.author_id, eventDate: c.event_date },
+    userId,
+    now,
   );
 
   let expiresIn: string;

--- a/src/features/checks/lib/mystery.test.ts
+++ b/src/features/checks/lib/mystery.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the mystery-check reveal logic.
+ *
+ * Anchors:
+ *   - "today" in every test is FROZEN_NOW (Mon 2026-04-27, 14:00 local).
+ *     vi.useFakeTimers + vi.setSystemTime pin it. localTodayISO is computed
+ *     from the *passed-in* Date though, so we mostly construct fresh Dates
+ *     per case rather than relying on the frozen clock.
+ *   - All event_date values are local-tz YYYY-MM-DD, mirroring how the
+ *     creation path stores them.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { isMysteryUnrevealed, localTodayISO } from "./mystery";
+
+// Mon Apr 27 2026, 14:00:00 in the local timezone.
+const FROZEN_NOW = new Date(2026, 3, 27, 14, 0, 0);
+
+beforeAll(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_NOW);
+});
+
+afterAll(() => {
+  vi.useRealTimers();
+});
+
+const AUTHOR = "00000000-0000-0000-0000-000000000aaa";
+const VIEWER = "00000000-0000-0000-0000-000000000bbb";
+
+describe("localTodayISO", () => {
+  it("formats in local tz, not UTC (avoids the toISOString() midnight-shift trap)", () => {
+    // 2026-04-27 14:00 local = guaranteed to be 2026-04-27 in any non-equator
+    // timezone. The point is to lock down that we're NOT going through
+    // toISOString() which would emit a UTC date.
+    expect(localTodayISO(FROZEN_NOW)).toBe("2026-04-27");
+  });
+
+  it("zero-pads single-digit months and days", () => {
+    expect(localTodayISO(new Date(2026, 0, 5, 9, 0, 0))).toBe("2026-01-05");
+  });
+});
+
+describe("isMysteryUnrevealed", () => {
+  describe("non-mystery checks", () => {
+    it("returns false when mystery=false, regardless of viewer or date", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: false, authorId: AUTHOR, eventDate: "2030-01-01" },
+          VIEWER,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false when mystery=false even with no event_date", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: false, authorId: AUTHOR, eventDate: null },
+          VIEWER,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("author viewing their own mystery check", () => {
+    it("never redacts — author always sees their own check unredacted", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2030-01-01" },
+          AUTHOR,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it("not redacted even when event_date is past (irrelevant for the author)", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2025-01-01" },
+          AUTHOR,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it("not redacted with no event_date either", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: null },
+          AUTHOR,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("non-author viewing a mystery check", () => {
+    it("redacts when event_date is in the future", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2026-04-30" },
+          VIEWER,
+          FROZEN_NOW,
+        ),
+      ).toBe(true);
+    });
+
+    it("REVEALS on the event_date itself (event_date == today, not >)", () => {
+      // This is the load-bearing assertion: the spec says "reveals on the
+      // day of the event", which means equal-to-today should reveal, not
+      // redact. localTodayISO(FROZEN_NOW) === "2026-04-27", so an event_date
+      // of "2026-04-27" should NOT be unrevealed.
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2026-04-27" },
+          VIEWER,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it("reveals when event_date is in the past", () => {
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2026-04-26" },
+          VIEWER,
+          FROZEN_NOW,
+        ),
+      ).toBe(false);
+    });
+
+    it("redacts (treats as unrevealed) when event_date is missing", () => {
+      // The DB CHECK constraint should make this unreachable in prod, but
+      // defensively we treat null as 'still hidden' rather than 'reveal' —
+      // failing safe avoids accidental author leak.
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: null },
+          VIEWER,
+          FROZEN_NOW,
+        ),
+      ).toBe(true);
+    });
+
+    it("redacts logged-out viewers (userId=null) too", () => {
+      // Shared-link / guest path: no auth, so by definition not the author.
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2026-04-30" },
+          null,
+          FROZEN_NOW,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("reveal boundary across local midnight", () => {
+    it("redacted at 23:59 the day before event", () => {
+      const lateNight = new Date(2026, 3, 27, 23, 59, 0); // Mon 23:59
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2026-04-28" },
+          VIEWER,
+          lateNight,
+        ),
+      ).toBe(true);
+    });
+
+    it("revealed at 00:00 on the event day", () => {
+      const justAfterMidnight = new Date(2026, 3, 28, 0, 0, 0); // Tue 00:00
+      expect(
+        isMysteryUnrevealed(
+          { mystery: true, authorId: AUTHOR, eventDate: "2026-04-28" },
+          VIEWER,
+          justAfterMidnight,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/features/checks/lib/mystery.ts
+++ b/src/features/checks/lib/mystery.ts
@@ -1,0 +1,44 @@
+/**
+ * Mystery-check reveal logic, factored out of transformCheck so it can be
+ * unit-tested without dragging in React. Mirrors the spec encoded in the
+ * 20260427000001_mystery_checks.sql migration:
+ *
+ *   - mystery=false → never redacted (existing checks behave unchanged)
+ *   - mystery=true → author + responder list hidden from *non-authors* until
+ *     the event date arrives in the viewer's local tz, then everything reveals
+ *   - the author of a mystery check always sees their own check unredacted
+ */
+
+/** YYYY-MM-DD in the viewer's local tz; matches how event_date is stored. */
+export function localTodayISO(now: Date): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+}
+
+export interface MysteryRevealInput {
+  mystery: boolean;
+  authorId: string;
+  /** YYYY-MM-DD or null. Mystery=true rows always have this set per the DB
+   *  CHECK constraint, but we still tolerate null defensively. */
+  eventDate: string | null;
+}
+
+/**
+ * Should this check be shown in redacted form to the given viewer right now?
+ *
+ * Returns true iff the check is mystery, the viewer is not the author, and
+ * the event date is still in the future (in the viewer's local tz). The
+ * author always sees their own check unredacted regardless of date.
+ *
+ * `userId` may be null for logged-out viewers — they're treated as
+ * non-authors, so unrevealed mystery checks stay redacted.
+ */
+export function isMysteryUnrevealed(
+  check: MysteryRevealInput,
+  userId: string | null,
+  now: Date,
+): boolean {
+  if (!check.mystery) return false;
+  if (userId !== null && check.authorId === userId) return false;
+  if (!check.eventDate) return true;
+  return check.eventDate > localTodayISO(now);
+}

--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -935,7 +935,11 @@ const AddModal = ({
                 <p className="font-mono text-tiny text-dim mt-1.5 leading-relaxed">
                   date + location required so guests know where + when to show up.
                   who you are, and who else is in, reveals on{' '}
-                  {parsedDate?.label?.toLowerCase() ?? 'the day of the event'}.
+                  {parsedDateISO
+                    ? new Date(parsedDateISO + 'T00:00:00')
+                        .toLocaleDateString('en-US', { weekday: 'long' })
+                        .toLowerCase()
+                    : 'the day of the event'}.
                 </p>
               )}
             </div>
@@ -982,10 +986,10 @@ const AddModal = ({
                   close();
                 }
               }}
-              disabled={!idea.trim() || (mystery && (!parsedDate || !whereInput.trim()))}
+              disabled={!idea.trim() || (mystery && (!parsedDateISO || !whereInput.trim()))}
               className={cn(
                 'w-full border-none rounded-xl py-3.5 font-mono text-sm font-bold uppercase',
-                idea.trim() && (!mystery || (parsedDate && whereInput.trim()))
+                idea.trim() && (!mystery || (parsedDateISO && whereInput.trim()))
                   ? 'bg-dt text-on-accent cursor-pointer'
                   : 'bg-border-mid text-dim cursor-not-allowed'
               )}


### PR DESCRIPTION
## Summary

Mystery mode was completely broken in prod — the submit button stayed permanently disabled when the toggle was on, so no one could post a mystery check.

**Root cause:** the mystery PR (#484) referenced `parsedDate?.label` in three places in `CreateModal`. The very next PR (#485) refactored `useDateTimeInput` to expose `parsedDateISO: string | null` instead of `parsedDate: { label, iso } | null`, but the mystery references weren't updated. With `parsedDate` undefined, `!parsedDate` was permanently `true`, so the gate `(mystery && (!parsedDate || !whereInput.trim()))` always resolved to disabled. TypeScript flagged this as TS2552 — it slipped past the Vercel build.

## Fix

- `src/features/events/components/CreateModal.tsx` — three `parsedDate` → `parsedDateISO` replacements (caption text, disabled gate, button styling). Reveal-day caption now formats the ISO date as a long weekday ("reveals on thursday").

## Tests

- `src/features/checks/lib/mystery.ts` — extracted `isMysteryUnrevealed` + `localTodayISO` out of `useChecks.transformCheck` so the reveal logic is unit-testable (vitest config restricts to `.test.ts`, no React/DOM).
- `src/features/checks/lib/mystery.test.ts` — 14 cases covering non-mystery (always revealed), author-self (always revealed), non-author future (redacted), `event_date == today` (revealed — load-bearing for "reveals on the day"), null `event_date` (defensively redacted), logged-out viewer, and the local-midnight reveal boundary.
- `e2e/mystery-check.spec.ts` — Playwright regression that toggles the mystery switch, asserts the submit button is disabled until idea + date + location are all filled, then asserts it flips to enabled and that submission actually lands the check in the feed. This is the exact assertion that would have caught the prod bug.

## Test plan

- [x] `npx tsc --noEmit` clean (the three TS2552s on `parsedDate` are gone)
- [x] `npx vitest run` — 69/69 passing (14 new mystery cases + 55 existing)
- [ ] `npm run test:e2e -- e2e/mystery-check.spec.ts` (needs local Supabase; not run in this environment — please verify locally before merge)
- [ ] Manual smoke: toggle mystery on in CreateModal, fill idea+date+location, confirm Send button enables and the check posts

https://claude.ai/code/session_01FcUrvkdKkioqt4tuZeQLKq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcUrvkdKkioqt4tuZeQLKq)_