### PR TITLE
feat: preserve user's typed "or" phrase on interest checks

### DIFF
--- a/src/features/auth/hooks/useOnboarding.tsx
+++ b/src/features/auth/hooks/useOnboarding.tsx
@@ -84,6 +84,8 @@ interface UseOnboardingParams {
     timeFlexible?: boolean,
     taggedFriendIds?: string[],
     location?: string | null,
+    mystery?: boolean,
+    eventDateLabel?: string | null,
   ) => void;
   // Friends
   suggestions: Friend[];
@@ -416,8 +418,8 @@ export function useOnboarding({
     if (showFirstCheck) {
       return (
         <FirstCheckScreen
-          onComplete={(idea, expiresInHours, eventDate, maxSquadSize, eventTime, dateFlexible, timeFlexible, location) => {
-            handleCreateCheck(idea, expiresInHours, eventDate, maxSquadSize, undefined, eventTime, dateFlexible, timeFlexible, undefined, location);
+          onComplete={(idea, expiresInHours, eventDate, maxSquadSize, eventTime, dateFlexible, timeFlexible, location, eventDateLabel) => {
+            handleCreateCheck(idea, expiresInHours, eventDate, maxSquadSize, undefined, eventTime, dateFlexible, timeFlexible, undefined, location, undefined, eventDateLabel);
             setShowFirstCheck(false);
           }}
           onSkip={() => {

--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -431,7 +431,7 @@ function CheckCard({
         onSave={async (updates) => {
           setEditModalOpen(false);
           try {
-            await db.updateInterestCheck(check.id, { text: updates.text, event_date: updates.eventDate, event_time: updates.eventTime, date_flexible: updates.dateFlexible, time_flexible: updates.timeFlexible, location: updates.location });
+            await db.updateInterestCheck(check.id, { text: updates.text, event_date: updates.eventDate, event_date_label: updates.eventDateLabel, event_time: updates.eventTime, date_flexible: updates.dateFlexible, time_flexible: updates.timeFlexible, location: updates.location });
             if (updates.taggedFriendIds && updates.taggedFriendIds.length > 0) await db.tagCoAuthors(check.id, updates.taggedFriendIds);
             if (check.squadId) await db.updateSquadName(check.squadId, updates.text);
           } catch (err) {

--- a/src/features/checks/components/EditCheckModal.tsx
+++ b/src/features/checks/components/EditCheckModal.tsx
@@ -38,7 +38,7 @@ const EditCheckModal = ({
   onDelete?: () => void;
 }) => {
   const [text, setText] = useState("");
-  const { whenInput, setWhenInput, parsedDateISO, parsedTime, whenPreview } = useDateTimeInput();
+  const { whenInput, setWhenInput, parsedDateISO, parsedDates, parsedTime, whenPreview } = useDateTimeInput();
   const [whereInput, setWhereInput] = useState("");
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1);
@@ -84,9 +84,14 @@ const EditCheckModal = ({
     // Resolve date: parsed > existing. parseWhen inside useDateTimeInput
     // already covers the "Sat, Feb 15"/M-D fallback, so no separate
     // parseDateToISO chain here.
+    //
+    // Label is only stored when the parse implied multiple dates ("thurs
+    // or fri") — single-date inputs leave it null so the display layer
+    // formats event_date itself. Editing a compound input down to a single
+    // date clears the previously-stored label so the auto-format takes over.
     const resolvedDateISO = parsedDateISO ?? check.eventDate ?? null;
     const resolvedDateLabel = parsedDateISO
-      ? whenInput.trim()
+      ? (parsedDates.length > 1 ? whenInput.trim() : null)
       : (check.eventDateLabel ?? null);
     const resolvedTime = parsedTime ?? check.eventTime ?? null;
 

--- a/src/features/checks/components/FirstCheckScreen.tsx
+++ b/src/features/checks/components/FirstCheckScreen.tsx
@@ -10,7 +10,7 @@ const FirstCheckScreen = ({
   onComplete,
   onSkip,
 }: {
-  onComplete: (idea: string, expiresInHours: number | null, eventDate: string | null, maxSquadSize: number | null, eventTime?: string | null, dateFlexible?: boolean, timeFlexible?: boolean, location?: string | null) => void;
+  onComplete: (idea: string, expiresInHours: number | null, eventDate: string | null, maxSquadSize: number | null, eventTime?: string | null, dateFlexible?: boolean, timeFlexible?: boolean, location?: string | null, eventDateLabel?: string | null) => void;
   onSkip: () => void;
 }) => {
   const [idea, setIdea] = useState("");
@@ -163,7 +163,10 @@ const FirstCheckScreen = ({
             const eventTime = parsedTime;
             const location = whereInput.trim() || null;
             const title = sanitize(idea, 280);
-            onComplete(title, checkTimer, eventDate, squadSize === 0 ? null : squadSize, eventTime, true, true, location);
+            // Preserve typed phrase only when it implied multiple dates;
+            // otherwise let the display fall back to the auto-formatted date.
+            const typedDateLabel = (parsed?.dates.length ?? 0) > 1 ? whenInput.trim() : null;
+            onComplete(title, checkTimer, eventDate, squadSize === 0 ? null : squadSize, eventTime, true, true, location, typedDateLabel);
           }
         }}
         disabled={!idea.trim()}

--- a/src/features/checks/hooks/useChecks.ts
+++ b/src/features/checks/hooks/useChecks.ts
@@ -107,7 +107,11 @@ function transformCheck(c: ActiveCheck, userId: string | null, displayName?: str
     inSquad: !!userId && !!(c.squads?.find((s) => !s.archived_at)?.members?.some((m) => (m as { user_id?: string }).user_id === userId && (m as { role?: string }).role !== 'waitlist')),
     isWaitlisted: !!userId && !!(c.squads?.find((s) => !s.archived_at)?.members?.some((m) => (m as { user_id?: string }).user_id === userId && (m as { role?: string }).role === 'waitlist')),
     eventDate: c.event_date ?? undefined,
-    eventDateLabel: c.event_date ? new Date(c.event_date + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }) : undefined,
+    // Prefer the user's typed phrase (only stored when the parse implied
+    // multiple dates, e.g. "next thurs or next fri"). Fall back to the
+    // auto-formatted single-date display.
+    eventDateLabel: c.event_date_label
+      ?? (c.event_date ? new Date(c.event_date + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }) : undefined),
     eventTime: c.event_time?.replace(/\s*[Aa][Mm]/g, 'am').replace(/\s*[Pp][Mm]/g, 'pm') ?? undefined,
     dateFlexible: c.date_flexible,
     timeFlexible: c.time_flexible,
@@ -259,9 +263,15 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
     taggedFriendIds?: string[],
     location?: string | null,
     mystery?: boolean,
+    /** When the user typed something like "next thurs or next fri", the
+     *  caller passes the original phrase here. Stored verbatim and shown
+     *  in place of the auto-formatted "Mon, Mmm DD" label. NULL/undefined
+     *  for ordinary single-date inputs. */
+    eventDateLabel?: string | null,
   ) => {
     const expiresLabel = expiresInHours == null ? "open" : expiresInHours >= 24 ? "24h" : `${expiresInHours}h`;
-    const dateLabel = eventDate ? new Date(eventDate + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }) : undefined;
+    const dateLabel = eventDateLabel
+      ?? (eventDate ? new Date(eventDate + "T00:00:00").toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" }) : undefined);
     const movieFields = movieData ? {
       movieTitle: movieData.title,
       year: movieData.year,
@@ -273,7 +283,7 @@ export function useChecks({ userId, profile, friendCount, showToast, onCheckCrea
 
     if (userId) {
       try {
-        const dbCheck = await db.createInterestCheck(idea, expiresInHours, eventDate, maxSquadSize, movieData, eventTime ?? null, dateFlexible ?? true, timeFlexible ?? true, location ?? null, !!mystery);
+        const dbCheck = await db.createInterestCheck(idea, expiresInHours, eventDate, maxSquadSize, movieData, eventTime ?? null, dateFlexible ?? true, timeFlexible ?? true, location ?? null, !!mystery, eventDateLabel ?? null);
         if (taggedFriendIds && taggedFriendIds.length > 0) {
           await db.tagCoAuthors(dbCheck.id, taggedFriendIds);
         }

--- a/src/features/events/components/CreateModal.tsx
+++ b/src/features/events/components/CreateModal.tsx
@@ -61,7 +61,8 @@ const AddModal = ({
     timeFlexible?: boolean,
     taggedFriendIds?: string[],
     location?: string | null,
-    mystery?: boolean
+    mystery?: boolean,
+    eventDateLabel?: string | null,
   ) => void;
   defaultMode?: 'paste' | 'idea' | 'manual' | null;
   friends?: { id: string; name: string; avatar: string }[];
@@ -109,7 +110,7 @@ const AddModal = ({
   }, [minSquadSize, squadSize]);
 
   // When/where inputs for date+time and location
-  const { whenInput, setWhenInput, parsedDateISO, parsedTime, whenPreview } = useDateTimeInput();
+  const { whenInput, setWhenInput, parsedDateISO, parsedDates, parsedTime, whenPreview } = useDateTimeInput();
   const [whereInput, setWhereInput] = useState('');
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionIdx, setMentionIdx] = useState(-1); // cursor position of @
@@ -970,6 +971,11 @@ const AddModal = ({
                     )
                     .map((f) => f.id);
                   const title = sanitize(idea, 280);
+                  // Preserve the user's typed phrase only when it implied
+                  // multiple dates ("next thurs or next fri"). Single-date
+                  // inputs leave it undefined so display falls back to the
+                  // auto-formatted "Mon, Mmm DD".
+                  const typedDateLabel = parsedDates.length > 1 ? whenInput.trim() : null;
                   onInterestCheck(
                     title,
                     checkTimer,
@@ -981,7 +987,8 @@ const AddModal = ({
                     true,
                     taggedIds.length > 0 ? taggedIds : undefined,
                     location,
-                    mystery
+                    mystery,
+                    typedDateLabel,
                   );
                   close();
                 }

--- a/src/lib/db/checks.ts
+++ b/src/lib/db/checks.ts
@@ -185,6 +185,10 @@ export async function createInterestCheck(
   timeFlexible: boolean = true,
   location: string | null = null,
   mystery: boolean = false,
+  /** User's typed phrase, only when the parse implied multiple dates
+   *  (e.g. "next thurs or next fri"). NULL for single-date inputs — the
+   *  display layer falls back to formatting event_date itself. */
+  eventDateLabel: string | null = null,
 ): Promise<InterestCheck> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
@@ -205,6 +209,7 @@ export async function createInterestCheck(
     text,
     expires_at: expiresAt,
     event_date: eventDate,
+    event_date_label: eventDateLabel,
     event_time: eventTime,
     event_tz: eventTz,
     date_flexible: dateFlexible,
@@ -286,7 +291,7 @@ export async function getArchivedChecks(): Promise<{ id: string; text: string; a
 
 export async function updateInterestCheck(
   checkId: string,
-  updates: { text?: string; max_squad_size?: number; event_date?: string | null; event_time?: string | null; date_flexible?: boolean; time_flexible?: boolean; location?: string | null }
+  updates: { text?: string; max_squad_size?: number; event_date?: string | null; event_date_label?: string | null; event_time?: string | null; date_flexible?: boolean; time_flexible?: boolean; location?: string | null }
 ): Promise<void> {
   const { error } = await supabase
     .from('interest_checks')

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,7 @@ export interface InterestCheck {
   text: string;
   expires_at: string | null;
   event_date: string | null; // ISO date from natural language parsing
+  event_date_label: string | null; // user's typed phrase when it implied multiple dates ("next thurs or next fri"); NULL for single-date inputs
   event_time: string | null; // display time like "7 PM"
   event_tz: string | null;   // IANA tz of author at insert; resolves "today" for check_is_active()
   mystery: boolean;          // true → author + responders hidden from non-authors until event_date arrives

--- a/supabase/migrations/20260428000001_check_event_date_label.sql
+++ b/supabase/migrations/20260428000001_check_event_date_label.sql
@@ -1,0 +1,22 @@
+-- Preserve the user's typed "when" phrase when it implied multiple dates.
+--
+-- parseWhen() (PR #485) lets the user type "next thurs or next fri at 7pm"
+-- in a check input. The schema only has a single event_date column though,
+-- so the second date silently disappears: the check is created with
+-- Thursday's ISO and the displayed label is recomputed as "Thu, Apr 30",
+-- losing the "or fri" part the author intended.
+--
+-- Adding event_date_label as the *typed* phrase to round-trip — populated
+-- only when the parse produced multiple dates. Single-date inputs leave it
+-- NULL and consumers fall back to the auto-formatted "Mon, Mmm DD" display
+-- (transformCheck in src/features/checks/hooks/useChecks.ts), so single-day
+-- checks look identical to before.
+--
+-- This is the cheapest of the three options laid out in the parseWhen PR
+-- discussion: captures intent without committing to a multi-date data
+-- model. If/when we want true multi-date checks we'd add an event_dates
+-- DATE[] (or pivot table) and update RLS / the cron archiver / the
+-- date-update notification trigger to handle the array shape.
+
+ALTER TABLE public.interest_checks
+  ADD COLUMN IF NOT EXISTS event_date_label TEXT;


### PR DESCRIPTION
## Summary
PR #485 made \`parseWhen\` accept compound inputs like \`"next thurs or next fri"\` everywhere. But the check schema is single-date (\`interest_checks.event_date DATE\`), so the second half silently disappeared on save and the feed card recomputed the label from \`event_date\` alone. The author's "or fri" intent vanished.

This adds a tiny \`event_date_label TEXT\` column. When the parse implies >1 date the call site stores the user's trimmed input there; \`transformCheck\` prefers that over the auto-formatted display. Single-date inputs leave it NULL and look identical to before.

## Why option 1 (typed-label preservation) and not the others
From the post-#485 discussion:

- **(1) Typed label** ← *this PR*. Cheapest. Captures intent, schema gymnastics minimal, no RLS / cron / trigger churn since canonical \`event_date\` stays single-valued.
- **(2) Multi-date checks** (\`event_dates DATE[]\`). Bigger lift — RLS, \`check_is_active()\`, the date-update notification trigger, FoF visibility, edit modal all need to learn the array shape.
- **(3) Refuse "or" at the boundary**. Makes the parser pointless for checks.

(1) doesn't preclude growing into (2) later — \`event_date_label\` would just become the human-readable rendering layer over the array.

## What changed
- \`supabase/migrations/20260428000001_check_event_date_label.sql\` — new nullable column.
- \`types.ts\` — \`InterestCheck\` row gains \`event_date_label\`.
- \`db/checks.ts\` — \`createInterestCheck\` takes an \`eventDateLabel\` arg (default null); \`updateInterestCheck\` extends its updates shape.
- \`useChecks.ts\` — \`handleCreateCheck\` threads the label through; \`transformCheck\` reads \`c.event_date_label\` first, falls back to the existing auto-format.
- \`FirstCheckScreen\` / \`CreateModal\` / \`EditCheckModal\` — pass \`whenInput.trim()\` as the label only when \`parsedDates.length > 1\`. Editing a compound input down to a single date clears the stored label so the auto-format takes over again.
- \`CheckCard\`'s \`onSave\` — forwards \`updates.eventDateLabel\` to \`db.updateInterestCheck\`.
- \`useOnboarding\`'s \`handleCreateCheck\` signature widens to forward the new arg.

## Test plan
- [x] \`npm test\` — 69 tests passing (parseWhen suite + the existing mystery suite); type-check clean.
- [ ] Type \`"next thurs or next fri at 7pm"\` into a new check → card displays the typed phrase ("next thurs or next fri") on the chip, not "Thu, Apr 30".
- [ ] Type \`"thursday at 7pm"\` (single date) into a new check → card displays "Thu, Apr 30" via the auto-format (regression).
- [ ] Edit a compound check down to a single date → label is cleared; card now shows the auto-format.
- [ ] Edit a single-date check up to compound → label is stored; card shows the typed phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)