### PR TITLE
Mystery hangouts: host-view comments + squad-side redaction polish

### DIFF
--- a/src/features/checks/components/CheckDetailSheet.tsx
+++ b/src/features/checks/components/CheckDetailSheet.tsx
@@ -152,6 +152,9 @@ export default function CheckDetailSheet({
         userId={userId}
         friends={friends}
         onPost={onPostComment}
+        anonymizeCommenters={check.mysteryGuestsHidden}
+        hostUserId={check.authorId}
+        threadSeed={check.id}
       />
     </DetailSheet>
   );

--- a/src/features/squads/components/ChatHeader.tsx
+++ b/src/features/squads/components/ChatHeader.tsx
@@ -69,15 +69,29 @@ export default function ChatHeader({
       <div className="flex items-center justify-between cursor-pointer">
         <button
           onClick={(e) => { e.stopPropagation(); onBack(); }}
-          className={`bg-transparent border-none text-dt text-lg cursor-pointer p-0 mr-2 shrink-0 ${hasDetails ? "self-start" : "self-center"}`}
+          aria-label="Back"
+          // self-center puts the chevron's center at the header's vertical
+          // midline; mt-2.5 then shifts it down by half the SVG (20px / 2)
+          // so the chevron's top edge — not its middle — sits on the midline.
+          className="bg-transparent border-none text-dt cursor-pointer py-0 pl-1 pr-2 shrink-0 leading-none flex items-center self-center mt-2.5"
         >
-          ‹
+          <svg width="20" height="20" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true">
+            <path d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z" />
+          </svg>
         </button>
         <div
           onClick={onOpenSettings}
           className="flex items-center justify-between flex-1 min-w-0"
         >
           <div className="min-w-0 flex-1">
+            {squad.mystery && (
+              <span
+                className="inline-block font-mono text-[9px] uppercase tracking-widest border rounded px-[5px] py-px mb-1"
+                style={{ color: "#ff00d4", borderColor: "#ff00d4" }}
+              >
+                ✦ mystery
+              </span>
+            )}
             <h2 className="font-serif text-lg text-primary font-normal m-0 line-clamp-2 leading-snug tracking-[-0.01em]">
               {squad.name}
             </h2>

--- a/src/features/squads/components/GroupsView.tsx
+++ b/src/features/squads/components/GroupsView.tsx
@@ -132,6 +132,14 @@ const SquadRow = ({
       <Countdown squad={squad} />
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5 min-w-0">
+          {squad.mystery && (
+            <span
+              className="font-mono text-[9px] uppercase tracking-widest border rounded px-[5px] py-px shrink-0"
+              style={{ color: "#ff00d4", borderColor: "#ff00d4" }}
+            >
+              ✦ mystery
+            </span>
+          )}
           <span className="font-serif text-xs text-primary font-normal truncate leading-tight tracking-[-0.02em]">
             {squad.name}
           </span>

--- a/src/features/squads/components/MessageComposer.tsx
+++ b/src/features/squads/components/MessageComposer.tsx
@@ -21,12 +21,17 @@ interface MessageComposerProps {
     image?: { blob: Blob; width: number; height: number }
   ) => Promise<void>;
   onOpenPollCreator?: () => void;
+  /** Pass true while the squad's mystery check is pre-reveal. Disables image
+   *  attach (photos are an obvious identity leak) and the poll creator
+   *  (poll proposers leak too). Re-enables automatically post-reveal. */
+  mysteryRestricted?: boolean;
 }
 
 export default function MessageComposer({
   members,
   onSend,
   onOpenPollCreator,
+  mysteryRestricted = false,
 }: MessageComposerProps) {
   const [newMsg, setNewMsg] = useState("");
   const [chatMentionQuery, setChatMentionQuery] = useState<string | null>(null);
@@ -173,6 +178,7 @@ export default function MessageComposer({
             if (file) handlePickImage(file);
           }}
         />
+        {!mysteryRestricted && (
         <button
           onClick={() => fileInputRef.current?.click()}
           disabled={preparingImage}
@@ -181,7 +187,8 @@ export default function MessageComposer({
         >
           <svg width="18" height="18" viewBox="0 0 256 256" fill="currentColor"><path d="M208,56H180.28L166.65,35.56A8,8,0,0,0,160,32H96a8,8,0,0,0-6.65,3.56L75.71,56H48A24,24,0,0,0,24,80V192a24,24,0,0,0,24,24H208a24,24,0,0,0,24-24V80A24,24,0,0,0,208,56Zm8,136a8,8,0,0,1-8,8H48a8,8,0,0,1-8-8V80a8,8,0,0,1,8-8H80a8,8,0,0,0,6.66-3.56L100.28,48h55.43l13.63,20.44A8,8,0,0,0,176,72h32a8,8,0,0,1,8,8ZM128,88a44,44,0,1,0,44,44A44.05,44.05,0,0,0,128,88Zm0,72a28,28,0,1,1,28-28A28,28,0,0,1,128,160Z"/></svg>
         </button>
-        {onOpenPollCreator && (
+        )}
+        {onOpenPollCreator && !mysteryRestricted && (
           <button
             onClick={onOpenPollCreator}
             className="bg-none border-none p-0 text-xl opacity-60 cursor-pointer leading-none mb-2"

--- a/src/features/squads/components/SquadChat.tsx
+++ b/src/features/squads/components/SquadChat.tsx
@@ -7,6 +7,7 @@ import type { Squad } from "@/lib/ui-types";
 import { logError } from "@/lib/logger";
 import { formatTimeAgo } from "@/lib/utils";
 import { parseWhen } from "@/lib/dateParse";
+import { kaomojiForUser } from "@/lib/censor";
 import ChatHeader from "./ChatHeader";
 import MessageComposer from "./MessageComposer";
 import ChatMessage from "./ChatMessage";
@@ -133,8 +134,10 @@ const SquadChat = ({
       maxSquadSize: squad.maxSquadSize,
       expiresAt: squad.expiresAt,
       meetingSpot: squad.meetingSpot,
+      mystery: squad.mystery,
+      mysteryGuestsHidden: squad.mysteryGuestsHidden,
     }));
-  }, [squad.dateStatus, squad.eventIsoDate, squad.eventTime, squad.members, squad.waitlistedMembers, squad.downResponders, squad.maxSquadSize, squad.expiresAt, squad.meetingSpot]);
+  }, [squad.dateStatus, squad.eventIsoDate, squad.eventTime, squad.members, squad.waitlistedMembers, squad.downResponders, squad.maxSquadSize, squad.expiresAt, squad.meetingSpot, squad.mystery, squad.mysteryGuestsHidden]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [entering, setEntering] = useState(true);
@@ -407,20 +410,31 @@ const SquadChat = ({
     let stale = false;
     db.getSquadMessages(localSquad.id).then((raw) => {
       if (stale) return;
-      const msgs = raw.map((msg) => ({
-        id: msg.id,
-        sender: msg.is_system || !msg.sender_id ? "system" : (msg.sender_id === userId ? "You" : (msg.sender?.display_name ?? "Unknown")),
-        text: msg.text ?? "",
-        time: formatTimeAgo(new Date(msg.created_at)),
-        isYou: msg.sender_id === userId,
-        ...(msg.message_type === 'date_confirm' ? { messageType: 'date_confirm' as const, messageId: msg.id } : {}),
-        ...(msg.message_type === 'poll' ? { messageType: 'poll' as const, messageId: msg.id } : {}),
-        ...(msg.image_path ? {
-          imagePath: msg.image_path,
-          imageWidth: msg.image_width ?? undefined,
-          imageHeight: msg.image_height ?? undefined,
-        } : {}),
-      }));
+      const guestsHidden = !!localSquad.mysteryGuestsHidden;
+      const msgs = raw
+        // Match the hydrateSquads filter: pre-reveal drops system + poll +
+        // date_confirm messages so their name-baked bodies don't leak.
+        .filter((msg) => !guestsHidden || (!msg.is_system && msg.message_type !== 'poll' && msg.message_type !== 'date_confirm'))
+        .map((msg) => ({
+          id: msg.id,
+          sender: msg.is_system || !msg.sender_id
+            ? "system"
+            : msg.sender_id === userId
+              ? "You"
+              : guestsHidden
+                ? kaomojiForUser(localSquad.id, msg.sender_id)
+                : (msg.sender?.display_name ?? "Unknown"),
+          text: msg.text ?? "",
+          time: formatTimeAgo(new Date(msg.created_at)),
+          isYou: msg.sender_id === userId,
+          ...(msg.message_type === 'date_confirm' ? { messageType: 'date_confirm' as const, messageId: msg.id } : {}),
+          ...(msg.message_type === 'poll' ? { messageType: 'poll' as const, messageId: msg.id } : {}),
+          ...(msg.image_path ? {
+            imagePath: msg.image_path,
+            imageWidth: msg.image_width ?? undefined,
+            imageHeight: msg.image_height ?? undefined,
+          } : {}),
+        }));
       const last = msgs.length > 0 ? msgs[msgs.length - 1] : null;
       // Merge: keep any realtime messages that arrived before this fetch completed
       setMessages((prev) => {
@@ -471,8 +485,19 @@ const SquadChat = ({
     const channel = db.subscribeToMessages(localSquad.id, (newMessage) => {
       // Skip messages from current user (already added optimistically)
       if (userId && newMessage.sender_id === userId) return;
+      // Mystery squad pre-reveal: drop system messages (their bodies bake in
+      // real display names) + polls + date_confirms (leak proposers/confirmers)
+      // entirely, and replace sender names on chat messages with kaomoji
+      // deterministic by (squad.id, user.id) — same primitive as hydrateSquads.
+      if (localSquad.mysteryGuestsHidden && (newMessage.is_system || newMessage.message_type === 'poll' || newMessage.message_type === 'date_confirm')) {
+        return;
+      }
       const isSystem = newMessage.is_system || newMessage.sender_id === null;
-      const senderName = isSystem ? "system" : (newMessage.sender?.display_name ?? "Unknown");
+      const senderName = isSystem
+        ? "system"
+        : localSquad.mysteryGuestsHidden && newMessage.sender_id
+          ? kaomojiForUser(localSquad.id, newMessage.sender_id)
+          : (newMessage.sender?.display_name ?? "Unknown");
       const msg = {
         id: newMessage.id,
         sender: senderName,
@@ -1127,6 +1152,7 @@ const SquadChat = ({
             setPollVariant(localSquad.eventIsoDate ? 'text' : 'dates');
             setShowPollCreator(true);
           } : undefined}
+          mysteryRestricted={localSquad.mysteryGuestsHidden}
         />
       </div>
       )}

--- a/src/features/squads/components/SquadMembersView.tsx
+++ b/src/features/squads/components/SquadMembersView.tsx
@@ -31,6 +31,11 @@ export default function SquadMembersView({
   onLocalSquadUpdate,
 }: SquadMembersViewProps) {
   const [memberMenu, setMemberMenu] = useState<{ name: string; userId: string } | null>(null);
+  // Pre-reveal: every non-self member is a kaomoji. Tapping into their
+  // profile would obviously blow the mystery, so the row is non-interactive.
+  // Kick/move-to-waitlist still leak (the action targets a specific user_id),
+  // so the per-row menu is suppressed too.
+  const guestsHidden = !!squad.mysteryGuestsHidden;
 
   return (
     <>
@@ -53,14 +58,14 @@ export default function SquadMembersView({
             <React.Fragment key={m.name}>
               <div
                 onClick={() => {
-                  if (m.name !== "You" && m.userId) {
+                  if (m.name !== "You" && m.userId && !guestsHidden) {
                     onClose();
                     onViewProfile?.(m.userId);
                   }
                 }}
                 className={cn("flex items-center gap-2.5", {
-                  "cursor-pointer": m.name !== "You" && !!m.userId,
-                  "cursor-default": m.name === "You" || !m.userId,
+                  "cursor-pointer": m.name !== "You" && !!m.userId && !guestsHidden,
+                  "cursor-default": m.name === "You" || !m.userId || guestsHidden,
                   "opacity-35": isGrayed,
                 })}
               >
@@ -84,7 +89,7 @@ export default function SquadMembersView({
                     {isConfirmed ? "down" : confirmResponse === "no" ? "out" : "pending"}
                   </span>
                 )}
-                {m.name !== "You" && m.userId && (
+                {m.name !== "You" && m.userId && !guestsHidden && (
                   <div className="flex gap-2 ml-auto items-center">
                     <button
                       onClick={(e) => {
@@ -151,12 +156,12 @@ export default function SquadMembersView({
               <div
                 key={m.userId}
                 onClick={() => {
-                  if (m.userId) {
+                  if (m.userId && !guestsHidden) {
                     onClose();
                     onViewProfile?.(m.userId);
                   }
                 }}
-                className={cn("flex items-center gap-2.5", m.userId ? "cursor-pointer" : "cursor-default")}
+                className={cn("flex items-center gap-2.5", m.userId && !guestsHidden ? "cursor-pointer" : "cursor-default")}
               >
                 <div className="size-7 rounded-full flex items-center justify-center font-mono text-xs font-bold shrink-0 bg-neutral-800 text-neutral-500">
                   {m.avatar}

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -180,10 +180,11 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
           userId: r.user_id,
         }));
       const sortedRawMessages = (s.messages ?? [])
-        // Pre-reveal: drop poll + date_confirm messages entirely. They leak
-        // proposers (and date_confirm replies leak who confirmed). Plain text
-        // chat survives but with sender names anonymized.
-        .filter((msg) => !guestsHidden || (msg.message_type !== 'poll' && msg.message_type !== 'date_confirm'))
+        // Pre-reveal: drop poll + date_confirm messages (leak proposers /
+        // confirmers) AND system messages (their bodies bake in real display
+        // names — "{name} just entered the chat", "{name} left", etc.). Plain
+        // text chat survives with sender names anonymized.
+        .filter((msg) => !guestsHidden || (!msg.is_system && msg.message_type !== 'poll' && msg.message_type !== 'date_confirm'))
         .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
       const lastRawMessage = sortedRawMessages.length > 0 ? sortedRawMessages[sortedRawMessages.length - 1] : null;
       const messages = sortedRawMessages.map((msg) => {
@@ -340,20 +341,37 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
       }
     }
 
+    // Mystery + pre-reveal: don't bake the host's real name into local
+    // members or system-message bodies. The DB hydration will replace this
+    // local newSquad shortly anyway, but in the gap we keep the kaomoji vibe.
+    const localMystery = !!check.mystery && check.mysteryGuestsHidden !== false;
+    const localSquadId = squadDbId ?? `local-squad-${Date.now()}`;
+    const authorKaomoji = localMystery && check.authorId
+      ? kaomojiForUser(localSquadId, check.authorId)
+      : null;
     const newSquad: Squad = {
-      id: squadDbId ?? `local-squad-${Date.now()}`,
+      id: localSquadId,
       name: squadName,
-      event: `${check.author}'s idea \u00b7 ${check.expiresIn} left`,
+      event: localMystery
+        ? `mystery host \u00b7 ${check.expiresIn} left`
+        : `${check.author}'s idea \u00b7 ${check.expiresIn} left`,
       members: [
         { name: "You", avatar: profile?.avatar_letter ?? "?" },
         ...downPeople.map((p) => ({ name: p.name, avatar: p.avatar })),
-        ...(!check.isYours ? [{ name: check.author, avatar: check.author.charAt(0).toUpperCase() }] : []),
+        ...(!check.isYours
+          ? [{
+              name: authorKaomoji ?? check.author,
+              avatar: authorKaomoji ?? check.author.charAt(0).toUpperCase(),
+            }]
+          : []),
       ],
-      messages: [
-        { sender: "system", text: pickFormedMessage(check.text), time: "now" },
-        { sender: "system", text: pickContextCheck(check.author), time: "now" },
-        { sender: "You", text: opener, time: "now", isYou: true },
-      ],
+      messages: localMystery
+        ? [{ sender: "You", text: opener, time: "now", isYou: true }]
+        : [
+            { sender: "system", text: pickFormedMessage(check.text), time: "now" },
+            { sender: "system", text: pickContextCheck(check.author), time: "now" },
+            { sender: "You", text: opener, time: "now", isYou: true },
+          ],
       lastMsg: `You: ${opener}`,
       time: "now",
     };

--- a/src/lib/db/squads.ts
+++ b/src/lib/db/squads.ts
@@ -37,7 +37,7 @@ export async function getSquads(): Promise<Squad[]> {
     .select(`
       *,
       event:events(*),
-      check:interest_checks(author_id, event_time, event_date, location, text, date_flexible, time_flexible, max_squad_size, responses:check_responses(user_id, response, user:profiles!user_id(display_name, avatar_letter))),
+      check:interest_checks(author_id, event_time, event_date, location, text, date_flexible, time_flexible, max_squad_size, mystery, responses:check_responses(user_id, response, user:profiles!user_id(display_name, avatar_letter))),
       members:squad_members(*, user:profiles!user_id(*)),
       messages(*, sender:profiles!sender_id(display_name))
     `)

--- a/src/shared/components/InlineCommentsBox.tsx
+++ b/src/shared/components/InlineCommentsBox.tsx
@@ -76,34 +76,38 @@ export default function InlineCommentsBox({
       ) : (
         <>
           {(showAll ? comments : comments.slice(-3)).map((c) => {
-            // For mystery+pre-reveal: redact every commenter except the viewer
-            // themselves. The viewer always sees their own messages as "You".
-            const redact = anonymizeCommenters && !c.isYours;
+            // Mystery+pre-reveal: every commenter (including the viewer) renders
+            // as a kaomoji so writing-style is the only identity tell. The viewer's
+            // own kaomoji is colored with the accent so they can still pick out
+            // their own messages at a glance.
+            const redact = anonymizeCommenters;
             const isHost = !!hostUserId && c.userId === hostUserId;
             const displayName = redact && threadSeed
               ? kaomojiForUser(threadSeed, c.userId)
               : c.userName;
-            const displayAvatar = redact && threadSeed
-              ? kaomojiForUser(threadSeed, c.userId)
-              : c.userAvatar;
             const displayText = anonymizeCommenters ? stripAtMentions(c.text) : c.text;
             return (
             <div key={c.id} className="flex items-center gap-2 min-w-0">
-              {/* Avatar slot — skipped entirely when redacted, since the kaomoji
-                  in the name slot already carries identity. Two kaomoji per
-                  comment reads as noise. */}
+              {/* Non-mystery: avatar pill. Mystery: avatar is dropped — the
+                  kaomoji in the name column carries identity, so a second
+                  glyph would just be noise. */}
               {!redact && (
                 <div
                   className={`shrink-0 flex items-center justify-center font-mono leading-none w-5 h-5 rounded-full text-[9px] font-bold ${c.isYours ? "bg-dt text-on-accent" : "bg-border-light text-dim"}`}
                 >
-                  {displayAvatar}
+                  {c.userAvatar}
                 </div>
               )}
-              <span className="font-mono text-tiny text-muted shrink-0 leading-snug">
-                {displayName}
+              {/* Fixed-width right-aligned name column so every comment's text
+                  starts at the same x. Names that overflow get truncated. */}
+              <span
+                className={`font-mono text-tiny shrink-0 leading-snug truncate text-right ${redact && c.isYours ? "text-dt font-bold" : "text-muted"}`}
+                style={{ width: "5.5rem" }}
+              >
                 {isHost && !c.isYours && (
-                  <span className="ml-1 text-faint italic font-normal">host</span>
+                  <span className="mr-1 text-faint italic font-normal">host</span>
                 )}
+                {displayName}
               </span>
               <span className="font-mono text-tiny text-primary min-w-0 break-words leading-snug">
                 {displayText.split(/(https?:\/\/[^\s),]+|@\S+)/g).map((part, pi) => {

--- a/supabase/migrations/20260428000001_mystery_aware_notification_bodies.sql
+++ b/supabase/migrations/20260428000001_mystery_aware_notification_bodies.sql
@@ -1,0 +1,289 @@
+-- v0.2 of mystery checks: notification bodies don't reveal sender names
+-- pre-reveal. The push notification preview in iOS/Android shows the body
+-- text in plain language, so a notif like "Sara responded down to your
+-- check" defeats the entire mystery if your check is in mystery mode.
+--
+-- This migration wraps the affected notify_* triggers with a mystery-aware
+-- branch. When the check is currently in its mystery period, body strings
+-- replace the sender's display name with "someone" (the simplest noun that
+-- works in both "someone responded" and "someone commented").
+--
+-- The helper is_check_in_mystery_period(check_id) does the gating. Returns
+-- true iff the check exists, is mystery=true, and event_date is either NULL
+-- or still in the future (CURRENT_DATE comparison; uses server tz which is
+-- close-enough to UTC, the small fence-post error here is acceptable for
+-- notif body redaction).
+
+
+-- =============================================================================
+-- 1. Helper
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.is_check_in_mystery_period(p_check_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.interest_checks ic
+    WHERE ic.id = p_check_id
+      AND ic.mystery = TRUE
+      AND (ic.event_date IS NULL OR ic.event_date > CURRENT_DATE)
+  );
+$$;
+
+
+-- =============================================================================
+-- 2. notify_friend_check — fires when a check is posted, alerts friends.
+--    For mystery checks: drop the author's name from the title.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.notify_friend_check()
+RETURNS TRIGGER AS $$
+DECLARE
+  author_name TEXT;
+  friend_id UUID;
+  v_is_mystery BOOLEAN := COALESCE(NEW.mystery, FALSE);
+BEGIN
+  IF NOT v_is_mystery THEN
+    SELECT display_name INTO author_name
+    FROM public.profiles WHERE id = NEW.author_id;
+  END IF;
+
+  FOR friend_id IN
+    SELECT CASE
+      WHEN requester_id = NEW.author_id THEN addressee_id
+      ELSE requester_id
+    END
+    FROM public.friendships
+    WHERE status = 'accepted'
+      AND (requester_id = NEW.author_id OR addressee_id = NEW.author_id)
+  LOOP
+    INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_check_id)
+    VALUES (
+      friend_id,
+      'friend_check',
+      CASE
+        WHEN v_is_mystery THEN 'a mystery hang ✦'
+        ELSE COALESCE(author_name, 'someone')
+      END,
+      LEFT(NEW.text, 80),
+      -- Don't expose author_id in the notif row when mystery. The notif row
+      -- itself is server-stored, so even if the client respects the redaction
+      -- in render, we don't want a determined viewer pulling related_user_id.
+      CASE WHEN v_is_mystery THEN NULL ELSE NEW.author_id END,
+      NEW.id
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- =============================================================================
+-- 3. notify_check_response — fires when someone says down. For mystery:
+--    don't reveal the responder.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.notify_check_response()
+RETURNS TRIGGER AS $$
+DECLARE
+  responder_name TEXT;
+  v_check_author_id UUID;
+  v_check_text TEXT;
+  v_is_mystery BOOLEAN;
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.response = NEW.response THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT ic.author_id, ic.text, COALESCE(ic.mystery, FALSE)
+    INTO v_check_author_id, v_check_text, v_is_mystery
+  FROM public.interest_checks ic WHERE ic.id = NEW.check_id;
+
+  -- Author responding to own check: never notify (existing behavior).
+  IF v_check_author_id = NEW.user_id THEN
+    RETURN NEW;
+  END IF;
+
+  -- Mystery + pre-reveal? Use a redacted form.
+  IF v_is_mystery AND public.is_check_in_mystery_period(NEW.check_id) THEN
+    INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_check_id)
+    VALUES (
+      v_check_author_id,
+      'check_response',
+      'someone is in ✦',
+      'a mystery guest responded to "' || LEFT(v_check_text, 40) || '"',
+      NULL,  -- redact responder identity
+      NEW.check_id
+    );
+    RETURN NEW;
+  END IF;
+
+  -- Default: existing non-mystery behavior.
+  SELECT display_name INTO responder_name
+  FROM public.profiles WHERE id = NEW.user_id;
+
+  INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_check_id)
+  VALUES (
+    v_check_author_id,
+    'check_response',
+    'New response to your check',
+    COALESCE(responder_name, 'someone') || ' is ' || NEW.response || ' for "' || LEFT(v_check_text, 40) || '"',
+    NEW.user_id,
+    NEW.check_id
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- =============================================================================
+-- 4. notify_check_comment — fires when someone comments on a check (or event).
+--    For mystery checks: redact the commenter's name + drop the comment body
+--    (writing style still leaks identity, but the push preview shouldn't).
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.notify_check_comment()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_commenter_name TEXT;
+  v_body TEXT;
+  v_root_author UUID;
+  v_thread_label TEXT;
+  v_recipient UUID;
+  v_is_mystery BOOLEAN := FALSE;
+BEGIN
+  -- Only check threads can be mystery; events have no mystery flag.
+  IF NEW.check_id IS NOT NULL THEN
+    v_is_mystery := public.is_check_in_mystery_period(NEW.check_id);
+  END IF;
+
+  IF v_is_mystery THEN
+    v_commenter_name := 'a mystery guest';
+    v_body := '(comment hidden until reveal)';
+  ELSE
+    SELECT display_name INTO v_commenter_name
+    FROM public.profiles WHERE id = NEW.user_id;
+    v_commenter_name := COALESCE(v_commenter_name, 'Someone');
+    v_body := LEFT(NEW.text, 80);
+  END IF;
+
+  IF NEW.check_id IS NOT NULL THEN
+    SELECT author_id INTO v_root_author
+    FROM public.interest_checks WHERE id = NEW.check_id;
+    v_thread_label := 'check';
+
+    FOR v_recipient IN
+      SELECT DISTINCT user_id FROM (
+        SELECT v_root_author AS user_id WHERE v_root_author IS NOT NULL
+        UNION
+        SELECT DISTINCT cc.user_id FROM public.check_comments cc
+        WHERE cc.check_id = NEW.check_id
+      ) t
+      WHERE user_id IS NOT NULL AND user_id <> NEW.user_id
+    LOOP
+      INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_check_id)
+      VALUES (
+        v_recipient,
+        'check_comment',
+        CASE WHEN v_recipient = v_root_author
+          THEN v_commenter_name || ' commented'
+          ELSE v_commenter_name || ' replied'
+        END,
+        v_body,
+        CASE WHEN v_is_mystery THEN NULL ELSE NEW.user_id END,
+        NEW.check_id
+      );
+    END LOOP;
+  ELSIF NEW.event_id IS NOT NULL THEN
+    -- Events: unchanged, no mystery flag on events.
+    SELECT created_by INTO v_root_author
+    FROM public.events WHERE id = NEW.event_id;
+    v_thread_label := 'event';
+
+    FOR v_recipient IN
+      SELECT DISTINCT user_id FROM (
+        SELECT v_root_author AS user_id WHERE v_root_author IS NOT NULL
+        UNION
+        SELECT DISTINCT cc.user_id FROM public.check_comments cc
+        WHERE cc.event_id = NEW.event_id
+      ) t
+      WHERE user_id IS NOT NULL AND user_id <> NEW.user_id
+    LOOP
+      INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_event_id)
+      VALUES (
+        v_recipient,
+        'event_comment',
+        CASE WHEN v_recipient = v_root_author
+          THEN v_commenter_name || ' commented'
+          ELSE v_commenter_name || ' replied'
+        END,
+        v_body,
+        NEW.user_id,
+        NEW.event_id
+      );
+    END LOOP;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+-- =============================================================================
+-- 5. notify_squad_message — fires on every chat message. For mystery squads
+--    (i.e. the squad's underlying check is mystery + pre-reveal): redact
+--    sender name + chat body. Sender already routes through kaomoji on the
+--    client; don't undo that work via the OS push preview.
+-- =============================================================================
+CREATE OR REPLACE FUNCTION public.notify_squad_message()
+RETURNS TRIGGER AS $$
+DECLARE
+  sender_name TEXT;
+  squad_name TEXT;
+  member_id UUID;
+  v_squad_check_id UUID;
+  v_is_mystery BOOLEAN := FALSE;
+BEGIN
+  -- System messages don't notify (existing behavior — sender_id IS NULL).
+  IF NEW.sender_id IS NULL OR NEW.is_system THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT s.name, s.check_id INTO squad_name, v_squad_check_id
+  FROM public.squads s WHERE s.id = NEW.squad_id;
+
+  IF v_squad_check_id IS NOT NULL THEN
+    v_is_mystery := public.is_check_in_mystery_period(v_squad_check_id);
+  END IF;
+
+  IF v_is_mystery THEN
+    sender_name := 'a mystery guest';
+  ELSE
+    SELECT display_name INTO sender_name
+    FROM public.profiles WHERE id = NEW.sender_id;
+    sender_name := COALESCE(sender_name, 'someone');
+  END IF;
+
+  FOR member_id IN
+    SELECT user_id FROM public.squad_members
+    WHERE squad_id = NEW.squad_id AND user_id != NEW.sender_id
+  LOOP
+    INSERT INTO public.notifications (user_id, type, title, body, related_user_id, related_squad_id)
+    VALUES (
+      member_id,
+      'squad_message',
+      squad_name,
+      CASE
+        WHEN v_is_mystery THEN sender_name || ' said something'
+        ELSE sender_name || ': ' || COALESCE(LEFT(NEW.text, 80), '')
+      END,
+      CASE WHEN v_is_mystery THEN NULL ELSE NEW.sender_id END,
+      NEW.squad_id
+    );
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary

Locks down identity leaks across the mystery-hangout flow and adds visual affordances so mystery squads stand out from regular ones.

### Comments (mystery checks)
- Host can no longer peek at responder identities through their own check's comment thread
- Self comments render as a colored kaomoji too (so the avatar/kaomoji rows finally line up); viewer's own kaomoji is tinted with the accent so they can still pick out their own messages
- `host` tag moved to the left of the kaomoji
- @-mentions stripped from displayed comment text in mystery mode

### Squads (pre-reveal)
- `getSquads` now selects the `mystery` column from `interest_checks` — the entire kaomoji + system-message-drop chain was effectively dead before this; `checkMystery` always evaluated false
- DB system messages ("X just entered the chat", "X left the squad", etc.) bake real display names into their bodies — drop them client-side in mystery mode across all three message paths (hydrate / fetch-fresh-on-open / realtime sub)
- Fetch-fresh-on-open now applies kaomoji to senders, matching `hydrateSquads`
- `SquadMembersView`: profile taps + `•••` kick/waitlist menu suppressed when `guestsHidden` (would obviously blow the cover)
- Local `newSquad` from `startSquadFromCheck` no longer bakes the host's real name into members or the `pickContextCheck` system message in the brief pre-hydration window
- `SquadChat` localSquad sync now includes `mystery` + `mysteryGuestsHidden` so any mid-session flag flip propagates

### Visual identifiers
- Magenta `✦ mystery` pill in the squad list rows + at the top of the chat header

### Squad chat header polish
- Replaced the `‹` font glyph (clipped tip in IBM Plex Mono) with a Phosphor caret-left SVG
- Top of chevron now aligns with the header's vertical midline, so it sits naturally with the mystery pill above the title

## Test plan
- [x] `npm run test` — 69 tests passing across 2 files
- [x] `npx tsc --noEmit` — clean
- [ ] Mystery check on feed: comments hidden, kaomoji per (check, user), self colored, host tag positioned left
- [ ] Mystery squad list: magenta `✦ mystery` pill renders next to squad name
- [ ] Mystery squad chat: header shows `✦ mystery` pill, chevron back-button uncut and vertically aligned
- [ ] Mystery squad chat: no `{name} just entered/left` system messages; non-self senders show kaomoji on initial load and via realtime
- [ ] Mystery squad settings: tapping a member is a no-op; `•••` menu hidden
- [ ] Post-reveal (event_date in the past): everything flips back to plain names

🤖 Generated with [Claude Code](https://claude.com/claude-code)