### PR TITLE
fix: kaomoji collisions hid mystery squad members from React's render

### DIFF
--- a/src/features/squads/components/ChatHeader.tsx
+++ b/src/features/squads/components/ChatHeader.tsx
@@ -124,7 +124,14 @@ export default function ChatHeader({
                     : m.name === "You" ? "#000" : color.dim;
                 return (
                   <div
-                    key={m.name}
+                    // userId is the only collision-safe key. m.name is a
+                    // kaomoji on mystery+pre-reveal squads, drawn from a
+                    // 20-element pool. Pre-PR #494 hydration could hand
+                    // out duplicates; React's dedupe then dropped one,
+                    // showing 2 avatars in a 4-person squad. The hydration
+                    // is fixed too, but using userId as the key is the
+                    // belt-and-suspenders guarantee.
+                    key={m.userId ?? `${idx}-${m.name}`}
                     className={`size-6 rounded-full flex items-center justify-center font-mono text-tiny font-bold border-2 border-card ${idx === 0 ? "" : "-ml-1.5"}`}
                     style={{ background: avatarBg, color: avatarColor, zIndex: 4 - idx, position: "relative" }}
                   >

--- a/src/features/squads/components/SquadMembersView.tsx
+++ b/src/features/squads/components/SquadMembersView.tsx
@@ -47,7 +47,7 @@ export default function SquadMembersView({
       </button>
 
       <div className="flex flex-col gap-3">
-        {squad.members.map((m) => {
+        {squad.members.map((m, idx) => {
           const isLocked = squad.dateStatus === "locked";
           const isProposed = squad.dateStatus === "proposed";
           const confirmResponse = m.userId ? dateConfirms.get(m.userId) : undefined;
@@ -55,7 +55,10 @@ export default function SquadMembersView({
           const isGrayed = isProposed && dateConfirms.size > 0 && !isConfirmed;
           const showDateStatus = isLocked || (isProposed && dateConfirms.size > 0);
           return (
-            <React.Fragment key={m.name}>
+            // userId is collision-safe; name can be a kaomoji on mystery
+            // squads and the pool is small enough that two members hit
+            // the same glyph without the per-squad dedup in hydration.
+            <React.Fragment key={m.userId ?? `${idx}-${m.name}`}>
               <div
                 onClick={() => {
                   if (m.name !== "You" && m.userId && !guestsHidden) {

--- a/src/features/squads/hooks/useSquads.ts
+++ b/src/features/squads/hooks/useSquads.ts
@@ -8,7 +8,7 @@ import { type ChecksAction, CheckActionType } from "@/features/checks/reducers/c
 import { logError, logWarn } from "@/lib/logger";
 import { formatTimeAgo } from "@/lib/utils";
 import { isMysteryGuestsHidden } from "@/features/checks/lib/mystery";
-import { kaomojiForUser } from "@/lib/censor";
+import { kaomojiForUser, kaomojiAssignmentForUsers } from "@/lib/censor";
 
 const SQUAD_FORMED_MESSAGES = [
   '"{title}" squad just dropped',
@@ -144,10 +144,21 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
       );
       const myMembership = (s.members ?? []).find((m) => m.user_id === userId);
       const isWaitlisted = myMembership?.role === 'waitlist';
+      // Mystery+pre-reveal: pre-assign kaomojis with collision resolution so
+      // every non-self member gets a unique glyph. Calling kaomojiForUser per
+      // user independently can collide (~15% with 3 users, ~25% with 4) and
+      // React's key={m.name} dedupe then drops the colliding entries —
+      // surfaced as "I see only 2 people in a 4-person squad" on prod.
+      const otherMemberIds = guestsHidden
+        ? (s.members ?? []).filter((m) => m.user_id !== userId).map((m) => m.user_id)
+        : [];
+      const memberKaomojis = guestsHidden
+        ? kaomojiAssignmentForUsers(s.id, otherMemberIds)
+        : null;
       const members = (s.members ?? []).filter((m) => m.role !== 'waitlist').map((m) => {
         const isYou = m.user_id === userId;
         if (guestsHidden && !isYou) {
-          const k = kaomojiForUser(s.id, m.user_id);
+          const k = memberKaomojis!.get(m.user_id) ?? kaomojiForUser(s.id, m.user_id);
           return { name: k, avatar: k, userId: m.user_id };
         }
         return {
@@ -158,7 +169,7 @@ export function useSquads({ userId, profile, checksRef, dispatch, showToast, onS
       });
       const waitlistedMembers = (s.members ?? []).filter((m) => m.role === 'waitlist' && m.user_id !== userId).map((m) => {
         if (guestsHidden) {
-          const k = kaomojiForUser(s.id, m.user_id);
+          const k = memberKaomojis!.get(m.user_id) ?? kaomojiForUser(s.id, m.user_id);
           return { name: k, avatar: k, userId: m.user_id };
         }
         return {

--- a/src/lib/censor.ts
+++ b/src/lib/censor.ts
@@ -99,6 +99,49 @@ export function kaomojiForUser(threadSeed: string, userId: string): string {
   return KAOMOJI_POOL[hashSeed(`${threadSeed}::${userId}`) % KAOMOJI_POOL.length];
 }
 
+/**
+ * Assign a *unique* kaomoji to each user in a fixed-order roster, avoiding
+ * the birthday-paradox collisions you'd hit calling `kaomojiForUser` per
+ * user independently (with a 20-emoji pool, 3 users collide ~15% of the
+ * time, 4 users ~25%). Each user's preferred kaomoji is computed first;
+ * if it's already taken in the current set, we walk forward through the
+ * pool until we find an unused one. The walk is deterministic given the
+ * same `userIds` ordering, so re-renders are stable.
+ *
+ * If `userIds.length` exceeds `KAOMOJI_POOL.length` (20), later users
+ * fall back to their unscoped preferred kaomoji and may duplicate — but
+ * a 20+ person squad isn't the mystery use case we care about.
+ */
+export function kaomojiAssignmentForUsers(
+  threadSeed: string,
+  userIds: string[],
+): Map<string, string> {
+  const used = new Set<string>();
+  const out = new Map<string, string>();
+  for (const uid of userIds) {
+    const preferred = kaomojiForUser(threadSeed, uid);
+    if (!used.has(preferred)) {
+      used.add(preferred);
+      out.set(uid, preferred);
+      continue;
+    }
+    if (used.size >= KAOMOJI_POOL.length) {
+      out.set(uid, preferred);
+      continue;
+    }
+    const startIdx = KAOMOJI_POOL.indexOf(preferred);
+    for (let step = 1; step < KAOMOJI_POOL.length; step++) {
+      const candidate = KAOMOJI_POOL[(startIdx + step) % KAOMOJI_POOL.length];
+      if (!used.has(candidate)) {
+        used.add(candidate);
+        out.set(uid, candidate);
+        break;
+      }
+    }
+  }
+  return out;
+}
+
 /** Replace `@username` mentions in body text with `@???` for pre-reveal renders. */
 export function stripAtMentions(text: string): string {
   return text.replace(/@\S+/g, "@???");


### PR DESCRIPTION
## Symptom
Author of a 4-person mystery squad reported seeing only 2 avatars on the squad chat header. \`squad_members\` on prod had 4 rows; the UI just rendered 2.

## Cause
Two layers were both unsafe; together they silently dropped members.

1. **Hydration handed every non-self member a kaomoji via `kaomojiForUser(squad.id, user.id)` independently.** With a 20-emoji pool, birthday-paradox collisions are ~15% likely with 3 non-self members and ~25% with 4. The author hit the dice and two members rendered with the same kaomoji.

2. **`ChatHeader` and `SquadMembersView` used `key={m.name}` for member rows.** When two members had the same kaomoji, React dedupes duplicate keys and drops one. Author saw "You" + 1 visible kaomoji instead of "You" + 3 distinct kaomojis.

## Fix (two layers)
- `useSquads.hydrateSquads` pre-builds a `kaomojiAssignmentForUsers` map. Each user's preferred kaomoji is computed first; if that's already taken in the current squad, the helper walks forward through the pool until it finds an unused one. Walk is deterministic given the same `userIds` ordering, so re-renders are stable.
- `ChatHeader` and `SquadMembersView` swap `key={m.name}` for `m.userId` (with an `idx-name` fallback for the rare missing-userId case). Belt-and-suspenders against any future name-key drift.

Net effect: the author sees 4 distinct avatars. Each kaomoji is stable across re-renders within one squad and different across squads.

## Test plan
- [ ] On a mystery squad with ≥3 non-self members, header shows N distinct avatars (no missing slots).
- [ ] Members view lists all members (no missing rows).
- [ ] Re-rendering the squad doesn't reshuffle which kaomoji a given user gets.
- [ ] Non-mystery squads still render real avatar letters (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)