### PR TITLE
fix: settings modal shows "5" for unlimited squad + author squad UI never refreshes after late joins

### DIFF
--- a/src/app/hooks/useRealtimeNotifications.ts
+++ b/src/app/hooks/useRealtimeNotifications.ts
@@ -117,6 +117,17 @@ export function useRealtimeNotifications({
       } else if (newNotif.type === "check_tag") {
         if (newNotif.body) showToastRef.current(newNotif.title + ": " + newNotif.body);
         loadRealDataRef.current();
+      } else if (newNotif.type === "check_response") {
+        // Author received a "down" response on their check. The squad may
+        // have just formed (auto_create_squad_on_first_other_down) or grown
+        // (auto_join_squad_on_down_response). Realtime on check_responses
+        // refreshes the *checks* list via useChecks's own sub, but it
+        // doesn't re-fetch squads — squad_members has no client-side
+        // realtime sub. Without this branch, the author's squad UI stays
+        // stuck on whatever member count was loaded at page open and never
+        // sees later joiners. Surfaced as "I see only 2 members in a 4-
+        // person squad" on prod.
+        loadRealDataRef.current();
       } else if (newNotif.type === "check_archived" || newNotif.type === "check_revived") {
         // Realtime on `interest_checks` is RLS-gated: once a check is
         // archived, the recipient loses SELECT visibility and so the

--- a/src/features/squads/components/SquadSettingsModal.tsx
+++ b/src/features/squads/components/SquadSettingsModal.tsx
@@ -49,9 +49,15 @@ export default function SquadSettingsModal({
   const location = squad.meetingSpot ?? squad.eventLocation ?? null;
   const metaParts = [dateLabel, timeLabel, location].filter(Boolean);
 
-  const currentSize = squad.maxSquadSize ?? 5;
-  const canShrink = currentSize > squad.members.length;
-  const canGrow = currentSize < 20;
+  // null max_squad_size means unlimited ("∞" at create time). Don't paper
+  // over it with a fake "5" — that misleads the host into thinking they
+  // capped their squad when they explicitly chose unlimited. Display ∞ and
+  // disable both stepper buttons; users who want a real cap have to set it
+  // through some future "switch to capped" affordance (TODO if asked).
+  const isUnlimited = squad.maxSquadSize == null;
+  const currentSize = squad.maxSquadSize;
+  const canShrink = !isUnlimited && currentSize! > squad.members.length;
+  const canGrow = !isUnlimited && currentSize! < 20;
 
   return (
     <DetailSheet onClose={onClose}>
@@ -133,7 +139,8 @@ export default function SquadSettingsModal({
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => {
-                      const newSize = currentSize - 1;
+                      if (isUnlimited) return;
+                      const newSize = currentSize! - 1;
                       if (newSize >= squad.members.length) {
                         onUpdateSquadSize(squad.checkId!, newSize);
                         onLocalSquadUpdate((prev) => ({ ...prev, maxSquadSize: newSize }));
@@ -151,11 +158,12 @@ export default function SquadSettingsModal({
                     −
                   </button>
                   <span className="font-mono text-sm text-dt font-bold min-w-5 text-center">
-                    {currentSize}
+                    {isUnlimited ? "∞" : currentSize}
                   </span>
                   <button
                     onClick={() => {
-                      const newSize = currentSize + 1;
+                      if (isUnlimited) return;
+                      const newSize = currentSize! + 1;
                       if (newSize <= 20) {
                         onUpdateSquadSize(squad.checkId!, newSize);
                         onLocalSquadUpdate((prev) => ({ ...prev, maxSquadSize: newSize }));


### PR DESCRIPTION
## Summary
Two prod-reported bugs on the same mystery check, distinct causes.

### 1. \`SquadSettingsModal\` showed "5" for unlimited squads
\`SquadSettingsModal.tsx:52\` was \`const currentSize = squad.maxSquadSize ?? 5\`. \`null\` means "∞" (the unlimited option at create time), but the modal coerced it to 5 and rendered "5" in the stepper. Author saw "5" and concluded they'd capped at 5 even though they explicitly chose unlimited.

**Fix:** detect null and render "∞", disable both stepper buttons. (Users who want to switch from unlimited to a real cap need an explicit affordance — out of scope; comment flags it.)

### 2. Author saw only 2 members despite 4 in \`squad_members\`
Author created a check, the first non-author "down" tap formed the squad with author + first responder = 2 members. The next two "down" taps triggered \`auto_join_squad_on_down_response\` server-side, which inserted two more rows. **The author's client never re-fetched squads though** — \`getSquads\` is called once on page open, and the only realtime sub that fires loadRealData is on \`notifications\`. The check-responses realtime sub in \`useChecks\` refreshes checks but not squads. \`squad_members\` has no realtime sub of its own.

**Fix:** \`useRealtimeNotifications\` already calls \`loadRealDataRef.current()\` for \`friend_check\` / \`check_tag\` / \`squad_invite\` / \`check_archived\` / \`check_revived\`. Add \`check_response\` to that list. The author gets a \`check_response\` notification every time someone taps Down on their check; that fan-out now triggers a full re-hydrate including squads.

Cheaper than adding a realtime sub on \`squad_members\` directly (would need its own RLS-aware path). Notification fan-out is already RLS-scoped to \`user_id = auth.uid()\`, so it's safe.

## Test plan
- [ ] On a mystery squad with unlimited size: open settings → counter shows ∞, stepper buttons disabled.
- [ ] On a mystery squad with explicit size: open settings → counter shows the number, − and + work as before.
- [ ] As the author of a check: friend taps Down → squad's member count in the modal updates without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)