### PR TITLE
perf(feed): batch event-comment fetch — kills N+1 from Sentry 7447165522

### DIFF
--- a/src/features/events/components/EventCard.tsx
+++ b/src/features/events/components/EventCard.tsx
@@ -2,11 +2,29 @@
 
 import { useState, useRef, useEffect, useCallback, memo } from "react";
 import type { Event } from "@/lib/ui-types";
-import type { Profile } from "@/lib/types";
+import type { Profile, CheckComment } from "@/lib/types";
 import cn from "@/lib/tailwindMerge";
 import * as db from "@/lib/db";
 import InlineCommentsBox from "@/shared/components/InlineCommentsBox";
 import DetailSheet from "@/shared/components/DetailSheet";
+
+interface EvCommentUI {
+  id: string;
+  userId: string;
+  userName: string;
+  userAvatar: string;
+  text: string;
+  isYours: boolean;
+}
+
+const toEvCommentUI = (c: CheckComment, viewerId?: string | null): EvCommentUI => ({
+  id: c.id,
+  userId: c.user_id,
+  userName: c.user?.display_name ?? "Unknown",
+  userAvatar: c.user?.avatar_letter ?? "?",
+  text: c.text,
+  isYours: c.user_id === viewerId,
+});
 
 const EventCard = ({
   event,
@@ -17,6 +35,7 @@ const EventCard = ({
   onEdit,
   onViewProfile,
   isNew,
+  initialComments,
 }: {
   event: Event;
   userId?: string | null;
@@ -26,24 +45,23 @@ const EventCard = ({
   onEdit?: () => void;
   onViewProfile?: (userId: string) => void;
   isNew?: boolean;
+  /** Comments pre-fetched by the parent feed in a single batched query.
+   *  Undefined while the batch is still loading. */
+  initialComments?: CheckComment[];
 }) => {
   const [hovered, setHovered] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
   const touchMoved = useRef(false);
   const touchStartPos = useRef({ x: 0, y: 0 });
-  // Event comments — state owned by card, sheet posts via callback
-  const [evComments, setEvComments] = useState<{ id: string; userId: string; userName: string; userAvatar: string; text: string; isYours: boolean }[]>([]);
+  // Event comments — state owned by card, sheet posts via callback. Seeded
+  // from the parent's batched fetch (avoids the N+1 we used to spawn here).
+  const [evComments, setEvComments] = useState<EvCommentUI[]>(
+    () => (initialComments ?? []).map((c) => toEvCommentUI(c, userId)),
+  );
   useEffect(() => {
-    if (!event.id) return;
-    db.getEventComments(event.id).then((fetched) => {
-      setEvComments(fetched.map((c) => ({
-        id: c.id, userId: c.user_id,
-        userName: c.user?.display_name ?? "Unknown",
-        userAvatar: c.user?.avatar_letter ?? "?",
-        text: c.text, isYours: c.user_id === userId,
-      })));
-    }).catch(() => {});
-  }, [event.id, userId]);
+    if (!initialComments) return;
+    setEvComments(initialComments.map((c) => toEvCommentUI(c, userId)));
+  }, [initialComments, userId]);
   const postCmt = useCallback(async (text: string, _mentions?: string[]) => {
     const t = text.trim();
     if (!t || !event.id) return;

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -99,6 +99,20 @@ export default function FeedView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [checks.map((c) => c.id).join(',')]);
 
+  // Batch-fetch event comments in one round-trip. Each EventCard used to
+  // fetch its own — Sentry caught the N+1 (issue 7447165522). Cards now
+  // receive their slice via the initialComments prop.
+  const [eventComments, setEventComments] = useState<
+    Record<string, Awaited<ReturnType<typeof db.getEventComments>>>
+  >({});
+  useEffect(() => {
+    if (!events.length) return;
+    db.getEventCommentsBatch(events.map((e) => e.id).filter(Boolean))
+      .then(setEventComments)
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [events.map((e) => e.id).join(',')]);
+
   const [mockEnabled] = useDevMockFeed();
   const effectiveChecks = mockEnabled ? DEV_MOCK_CHECKS : checks;
   const mockNewSet = React.useMemo(() => new Set(DEV_MOCK_NEW_IDS), []);
@@ -232,6 +246,7 @@ export default function FeedView({
                   onViewProfile={onViewProfile}
                   isNew={item.data.id === newlyAddedEventId || newItemIds.has(item.data.id)}
                   profile={profile}
+                  initialComments={eventComments[item.data.id]}
                 />
               )
             )}

--- a/src/lib/db/event-comments.ts
+++ b/src/lib/db/event-comments.ts
@@ -17,6 +17,28 @@ export async function getEventComments(eventId: string): Promise<CheckComment[]>
   return data ?? [];
 }
 
+/** One round-trip for many event ids — replaces N parallel getEventComments
+ *  calls when the feed is rendering a batch of event cards. Returns a map
+ *  keyed by event_id so each card can pluck its own slice. */
+export async function getEventCommentsBatch(
+  eventIds: string[]
+): Promise<Record<string, CheckComment[]>> {
+  if (eventIds.length === 0) return {};
+  const { data, error } = await supabase
+    .from('check_comments')
+    .select(`*, user:profiles!user_id(${COMMENT_USER_COLS})`)
+    .in('event_id', eventIds)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  const byEvent: Record<string, CheckComment[]> = {};
+  for (const id of eventIds) byEvent[id] = [];
+  for (const c of (data ?? [])) {
+    if (c.event_id) (byEvent[c.event_id] ??= []).push(c);
+  }
+  return byEvent;
+}
+
 export async function postEventComment(eventId: string, text: string): Promise<CheckComment> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');


### PR DESCRIPTION
## Summary
Sentry's performance monitor caught an N+1 on the home feed: each `EventCard` was spawning its own `getEventComments(event.id)` round-trip in a `useEffect`, so a feed with 6 events fired 6 parallel `GET /rest/v1/check_comments?event_id=eq.<uuid>` requests just to seed inline comments.

## Fix
- New `getEventCommentsBatch(eventIds)` in `src/lib/db/event-comments.ts` — single `.in('event_id', ids)` query, returns a map keyed by event_id.
- `FeedView` batches the call once (mirroring the existing `getCheckCommentCounts` pattern) and passes each card its slice as `initialComments`.
- `EventCard` seeds local state from the prop, drops its per-card useEffect → fetch.
- Posting still uses the optimistic local-state path. Realtime behavior unchanged (EventCard didn't subscribe before either).

## Sentry issue
- ID: 7447165522
- Type: `performance_n_plus_one_api_calls`
- Endpoint: `https://*.supabase.co/rest/v1/check_comments?event_id=*`
- 6 repeating spans per `/` transaction, 8 events / 6 users affected at last check.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 69/69 passing
- [ ] Hit `/` with multiple events → confirm only one `/check_comments?event_id=in.(...)` request in DevTools Network tab
- [ ] Post a comment on an event → still appears optimistically + persists after refresh
- [ ] Open the event detail sheet → comments still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)