### PR TITLE
fix(check-card): match EventCard's NEW pill

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -246,18 +246,8 @@ function CheckCard({
               </span>
             )}
             {isNew && (
-              <span
-                className="font-mono text-[9px] font-bold uppercase shrink-0 py-1 pl-4 pr-5 leading-none"
-                style={{
-                  background: "#C2FF8A", // guava chartreuse
-                  color: "#ff00d4",        // electric fuchsia
-                  letterSpacing: "0.12em",
-                  marginRight: -16,       // cancel the card's p-4 right padding so the bg reaches the card's right edge
-                  borderTopLeftRadius: 3,
-                  borderBottomLeftRadius: 3,
-                }}
-              >
-                NEW
+              <span className="bg-dt text-on-accent font-mono text-[9px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded-full leading-none shrink-0 ml-2">
+                new
               </span>
             )}
           </div>


### PR DESCRIPTION
## Summary
The "NEW" pill on check cards and event cards looked different — different shape, different colors, different placement. CheckCard was hardcoded for the guava theme (`#C2FF8A` chartreuse on `#ff00d4` fuchsia, banner-bleed) while EventCard used theme tokens (`bg-dt text-on-accent`, compact pill). On any non-guava theme they read as inconsistent.

## Fix
Replace CheckCard's pill with the EventCard pill verbatim — same className, same theme tokens, same shape.

## Before / After
Before: large banner-style pill bleeding to the card's right edge with hardcoded guava colors.
After: small `bg-dt text-on-accent` rounded-full pill that matches the EventCard's "new" pill.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 69/69
- [ ] Visual: load feed with at least one new check + one new event → both pills look identical
- [ ] Visual: switch themes (acid, firefly, midnight) → both pills follow the active accent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)