### PR TITLE
perf(feed): batch check-comment fetch (kills N+1 from Sentry 7447165522)

### DIFF
--- a/src/features/checks/components/CheckCard.tsx
+++ b/src/features/checks/components/CheckCard.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useMemo, memo } from "react";
 import * as db from "@/lib/db";
-import type { Profile } from "@/lib/types";
+import type { Profile, CheckComment } from "@/lib/types";
 import type { InterestCheck, Friend } from "@/lib/ui-types";
 import { logError } from "@/lib/logger";
 import { useCheckComments } from "@/features/checks/hooks/useCheckComments";
@@ -22,6 +22,9 @@ export interface CheckCardProps {
   friends: Friend[];
   sharedCheckId?: string | null;
   initialCommentCount: number;
+  /** Comments pre-fetched by the parent feed in a single batched query.
+   *  Undefined while the batch is still loading. */
+  initialComments?: CheckComment[];
   onNavigateToGroups: (squadId?: string) => void;
   onViewProfile?: (userId: string) => void;
   showToast: (msg: string) => void;
@@ -37,6 +40,7 @@ function CheckCard({
   friends,
   sharedCheckId,
   initialCommentCount,
+  initialComments,
   onNavigateToGroups,
   onViewProfile,
   showToast,
@@ -66,6 +70,7 @@ function CheckCard({
     userId,
     profile,
     initialCommentCount,
+    initialComments,
   });
 
   // Eagerly fetch the comment list only when there's actually something to

--- a/src/features/checks/hooks/useCheckComments.ts
+++ b/src/features/checks/hooks/useCheckComments.ts
@@ -34,11 +34,16 @@ export function useCheckComments({
   userId,
   profile,
   initialCommentCount = 0,
+  initialComments,
 }: {
   checkId: string;
   userId: string | null;
   profile: Profile | null;
   initialCommentCount?: number;
+  /** Comments pre-fetched in batch by FeedView. When provided, the hook
+   *  seeds local state from this and treats itself as already-loaded so the
+   *  eager per-card fetch (the original Sentry N+1) becomes a no-op. */
+  initialComments?: CheckComment[];
 }) {
   const [comments, setComments] = useState<CommentUI[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -46,6 +51,16 @@ export function useCheckComments({
 
   // Dev-mode fixture checks aren't real rows — skip DB calls for them.
   const isMockCheck = checkId.startsWith("dev-mock-");
+
+  // Seed from FeedView's batched fetch. initialComments is undefined on the
+  // first render before the feed query resolves; once it lands, mark loaded
+  // so the eager fetch in CheckCard's useEffect early-returns.
+  useEffect(() => {
+    if (!initialComments || loaded) return;
+    setComments(initialComments.map(c => toCommentUI(c, userId)));
+    setLoaded(true);
+    setRealtimeCount(0);
+  }, [initialComments, userId, loaded]);
 
   // Always-on subscription — open when check card mounts
   useEffect(() => {
@@ -70,7 +85,7 @@ export function useCheckComments({
     } catch (err) {
       logError("loadCheckComments", err, { checkId });
     }
-  }, [checkId, userId, isMockCheck]);
+  }, [checkId, userId, isMockCheck, loaded]);
 
   const postComment = useCallback(async (text: string, mentions: string[] = []) => {
     if (!userId || !profile) return;

--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -113,6 +113,22 @@ export default function FeedView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [events.map((e) => e.id).join(',')]);
 
+  // Same N+1 fix for check comments — CheckCard auto-fetches comments on
+  // mount when initialCommentCount > 0, which fires one /check_comments
+  // request per check. Sentry's still flagging this URL pattern even after
+  // the events fix landed. Pre-fetch in batch and seed each card via the
+  // initialComments prop.
+  const [checkComments, setCheckComments] = useState<
+    Record<string, Awaited<ReturnType<typeof db.getCheckComments>>>
+  >({});
+  useEffect(() => {
+    if (!checks.length) return;
+    db.getCheckCommentsBatch(checks.map((c) => c.id))
+      .then(setCheckComments)
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [checks.map((c) => c.id).join(',')]);
+
   const [mockEnabled] = useDevMockFeed();
   const effectiveChecks = mockEnabled ? DEV_MOCK_CHECKS : checks;
   const mockNewSet = React.useMemo(() => new Set(DEV_MOCK_NEW_IDS), []);
@@ -204,6 +220,7 @@ export default function FeedView({
                 friends={friends}
                 sharedCheckId={sharedCheckId}
                 initialCommentCount={commentCounts[check.id] ?? 0}
+                initialComments={checkComments[check.id]}
                 onNavigateToGroups={onNavigateToGroups}
                 onViewProfile={onViewProfile}
                 showToast={showToast}
@@ -224,6 +241,7 @@ export default function FeedView({
                   friends={friends}
                   sharedCheckId={sharedCheckId}
                   initialCommentCount={commentCounts[item.data.id] ?? 0}
+                  initialComments={checkComments[item.data.id]}
                   onNavigateToGroups={onNavigateToGroups}
                   onViewProfile={onViewProfile}
                   showToast={showToast}

--- a/src/lib/db/check-comments.ts
+++ b/src/lib/db/check-comments.ts
@@ -34,6 +34,28 @@ export async function getCheckComments(checkId: string): Promise<CheckComment[]>
   return data ?? [];
 }
 
+/** One round-trip for many check ids — replaces N parallel getCheckComments
+ *  calls when the feed is rendering a batch of check cards. Returns a map
+ *  keyed by check_id so each card can pluck its own slice. */
+export async function getCheckCommentsBatch(
+  checkIds: string[]
+): Promise<Record<string, CheckComment[]>> {
+  if (checkIds.length === 0) return {};
+  const { data, error } = await supabase
+    .from('check_comments')
+    .select(`*, user:profiles!user_id(${COMMENT_USER_COLS})`)
+    .in('check_id', checkIds)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  const byCheck: Record<string, CheckComment[]> = {};
+  for (const id of checkIds) byCheck[id] = [];
+  for (const c of (data ?? [])) {
+    if (c.check_id) (byCheck[c.check_id] ??= []).push(c);
+  }
+  return byCheck;
+}
+
 export async function postCheckComment(checkId: string, text: string, mentions: string[] = []): Promise<CheckComment> {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');


### PR DESCRIPTION
## Summary
- Mirrors the event-comments fix in #498 for the `check_comments` URL pattern that's still firing in Sentry [issue 7447165522](https://downto.sentry.io/issues/7447165522/) — `lastSeen` is post-#498, with 6 affected users in 10 events.
- Adds `getCheckCommentsBatch(checkIds)` — one round-trip for many ids — and pre-fetches it in `FeedView`, then passes each card's slice down via `initialComments`.
- `useCheckComments` seeds local state when `initialComments` lands, marks itself loaded, so `CheckCard`'s eager `openComments()` becomes a no-op (the original N+1 site).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 69/69 pass
- [ ] Smoke: Feed loads checks with comments — comments render in the inline box without a per-card request to `/rest/v1/check_comments?check_id=eq...`
- [ ] Smoke: Posting a new comment still works (optimistic UI + persistence)
- [ ] Smoke: Real-time arrivals from another client still append to the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)