### PR TITLE
feat(auth): pre-flight email validity to stop dead-account orphans

### DIFF
--- a/src/features/auth/components/AuthScreen.tsx
+++ b/src/features/auth/components/AuthScreen.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/lib/supabase";
 import { color } from "@/lib/styles";
+import { isValidEmailShape, suggestEmailFix } from "@/lib/emailValidity";
 import Grain from "@/app/components/Grain";
 
 const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
@@ -25,12 +26,16 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const trimmedEmail = email.trim();
+  const emailShapeOk = isValidEmailShape(trimmedEmail);
+  const typoFix = emailShapeOk ? suggestEmailFix(trimmedEmail) : null;
+
   const handleSendCode = async () => {
-    if (!email.includes("@")) return;
+    if (!emailShapeOk) return;
     setLoading(true);
     setError(null);
 
-    const { error } = await supabase.auth.signInWithOtp({ email });
+    const { error } = await supabase.auth.signInWithOtp({ email: trimmedEmail });
 
     setLoading(false);
     if (error) {
@@ -115,16 +120,28 @@ const AuthScreen = ({ onLogin }: { onLogin: () => void }) => {
             onChange={(e) => setEmail(e.target.value)}
             onKeyDown={(e) => e.key === "Enter" && handleSendCode()}
             placeholder="you@email.com"
-            className="bg-card border border-border-mid rounded-xl p-4 text-primary font-mono text-lg outline-none mb-4"
+            className="bg-card border border-border-mid rounded-xl p-4 text-primary font-mono text-lg outline-none mb-2"
           />
+          {/* "Did you mean…" — non-blocking nudge for common domain typos
+              (gnail.com, gmail.con, etc). Sending without correcting still
+              works; this just spares the user a dead-end signup. */}
+          {typoFix && (
+            <button
+              type="button"
+              onClick={() => setEmail(typoFix)}
+              className="self-start bg-transparent border-none text-dt font-mono text-xs underline underline-offset-2 cursor-pointer p-0 mb-2 text-left"
+            >
+              did you mean {typoFix}?
+            </button>
+          )}
           <button
             onClick={handleSendCode}
-            disabled={!email.includes("@") || loading}
-            className="border-none rounded-xl p-4 font-mono text-sm font-bold uppercase"
+            disabled={!emailShapeOk || loading}
+            className="border-none rounded-xl p-4 font-mono text-sm font-bold uppercase mt-2"
             style={{
-              background: email.includes("@") ? color.accent : color.borderMid,
-              color: email.includes("@") ? "#000" : color.dim,
-              cursor: email.includes("@") ? "pointer" : "not-allowed",
+              background: emailShapeOk ? color.accent : color.borderMid,
+              color: emailShapeOk ? "#000" : color.dim,
+              cursor: emailShapeOk ? "pointer" : "not-allowed",
               letterSpacing: "0.1em",
             }}
           >

--- a/src/lib/emailValidity.test.ts
+++ b/src/lib/emailValidity.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { isValidEmailShape, suggestEmailFix } from "./emailValidity";
+
+describe("isValidEmailShape", () => {
+  it("accepts well-formed emails", () => {
+    expect(isValidEmailShape("a@b.co")).toBe(true);
+    expect(isValidEmailShape("perezkh@gmail.com")).toBe(true);
+    expect(isValidEmailShape("first.last+tag@sub.example.org")).toBe(true);
+  });
+
+  it("rejects the prod typo cases that produced dead accounts", () => {
+    // missing TLD — old `.includes("@")` accepted these
+    expect(isValidEmailShape("sarah.an.ferguson@gmail")).toBe(false);
+    expect(isValidEmailShape("anyone@gmail")).toBe(false);
+    // single-letter TLD
+    expect(isValidEmailShape("user@gmail.c")).toBe(false);
+  });
+
+  it("rejects shapes that aren't emails at all", () => {
+    expect(isValidEmailShape("")).toBe(false);
+    expect(isValidEmailShape("@")).toBe(false);
+    expect(isValidEmailShape("noatsign.com")).toBe(false);
+    expect(isValidEmailShape("user@")).toBe(false);
+    expect(isValidEmailShape("@example.com")).toBe(false);
+    expect(isValidEmailShape("with space@ex.com")).toBe(false);
+  });
+
+  it("trims surrounding whitespace before checking", () => {
+    expect(isValidEmailShape("  a@b.co  ")).toBe(true);
+  });
+});
+
+describe("suggestEmailFix", () => {
+  it("flags the prod typo cases with the right correction", () => {
+    expect(suggestEmailFix("perezkh@gmail.con")).toBe("perezkh@gmail.com");
+    expect(suggestEmailFix("perezkh@gnail.com")).toBe("perezkh@gmail.com");
+  });
+
+  it("preserves the local-part casing while normalising the domain", () => {
+    expect(suggestEmailFix("Mixed.Case@Gmail.Con")).toBe("Mixed.Case@gmail.com");
+  });
+
+  it("catches common provider typos", () => {
+    expect(suggestEmailFix("u@gmial.com")).toBe("u@gmail.com");
+    expect(suggestEmailFix("u@hotmial.com")).toBe("u@hotmail.com");
+    expect(suggestEmailFix("u@yaho.com")).toBe("u@yahoo.com");
+    expect(suggestEmailFix("u@iclou.com")).toBe("u@icloud.com");
+  });
+
+  it("returns null for valid emails and unknown domains", () => {
+    expect(suggestEmailFix("u@gmail.com")).toBeNull();
+    expect(suggestEmailFix("u@example.org")).toBeNull();
+    expect(suggestEmailFix("u@")).toBeNull();
+    expect(suggestEmailFix("no-at-sign")).toBeNull();
+    expect(suggestEmailFix("")).toBeNull();
+  });
+});

--- a/src/lib/emailValidity.ts
+++ b/src/lib/emailValidity.ts
@@ -1,0 +1,68 @@
+/**
+ * Tiny pre-flight email validity helpers for the auth flow.
+ *
+ * Real email validation is unsolvable client-side — RFC 5321 allows things
+ * that no SMTP server will deliver to, and the only definitive answer is
+ * "did the OTP arrive?" But we can still catch the cases that produced
+ * dead-account orphans in our prod data:
+ *
+ *   - perezkh@gmail.con      (TLD typo)
+ *   - perezkh@gnail.com      (domain typo)
+ *   - sarah.an.ferguson@gmail (missing TLD)
+ *
+ * `isValidEmailShape` enforces the structural floor: local-part `@`
+ * domain `.` TLD-of-2+-chars. Stricter than the previous `.includes("@")`
+ * but deliberately not RFC-compliant — we want false positives, not false
+ * negatives.
+ *
+ * `suggestEmailFix` does fuzzy detection for the common typos and returns
+ * a corrected version (or null when nothing obvious is wrong). The auth
+ * screen surfaces it as "did you mean X?" — non-blocking; the user can
+ * tap to fix or proceed anyway.
+ */
+
+const COMMON_DOMAIN_TYPOS: Record<string, string> = {
+  // Gmail
+  "gmial.com": "gmail.com",
+  "gnail.com": "gmail.com",
+  "gmai.com": "gmail.com",
+  "gmaill.com": "gmail.com",
+  "gmail.co": "gmail.com",
+  "gmail.cm": "gmail.com",
+  "gmail.con": "gmail.com",
+  "gmail.cim": "gmail.com",
+  // Hotmail / Outlook
+  "hotmial.com": "hotmail.com",
+  "hotmal.com": "hotmail.com",
+  "hotmail.con": "hotmail.com",
+  "outlok.com": "outlook.com",
+  "outloook.com": "outlook.com",
+  // Yahoo
+  "yaho.com": "yahoo.com",
+  "yahooo.com": "yahoo.com",
+  "yahoo.con": "yahoo.com",
+  // iCloud
+  "iclou.com": "icloud.com",
+  "icloud.co": "icloud.com",
+  "icloud.con": "icloud.com",
+};
+
+/** Local-part `@` domain `.` TLD of at least 2 letters. Permissive — catches
+ *  the structural failures (no `@`, missing TLD) without trying to be RFC. */
+const SHAPE_RE = /^[^\s@]+@[^\s@]+\.[a-z]{2,}$/i;
+
+export function isValidEmailShape(email: string): boolean {
+  return SHAPE_RE.test(email.trim());
+}
+
+/** Returns a corrected email (e.g. `gmail.com` for `gnail.com`) or null
+ *  when nothing obvious is wrong. Domain match is case-insensitive. */
+export function suggestEmailFix(email: string): string | null {
+  const trimmed = email.trim();
+  const at = trimmed.lastIndexOf("@");
+  if (at <= 0 || at === trimmed.length - 1) return null;
+  const local = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1).toLowerCase();
+  const fix = COMMON_DOMAIN_TYPOS[domain];
+  return fix ? `${local}@${fix}` : null;
+}


### PR DESCRIPTION
## Why

Audit of prod auth users found 3 unreachable accounts created by typos that the previous email check (a literal `.includes("@")`) happily accepted:

- `perezkh@gmail.con` — `.con` instead of `.com`
- `perezkh@gnail.com` — `gnail` instead of `gmail`
- `sarah.an.ferguson@gmail` — no TLD at all

The OTP was emailed to nonexistent addresses, the users never got their code, and they bounced. Orphan profile rows have been cleaned up out of band; this PR closes the hole that created them.

## What

`src/lib/emailValidity.ts` — two helpers:

1. **`isValidEmailShape`** — `local @ domain . TLD-of-2+`. Stricter than `.includes("@")` but deliberately *not* RFC-compliant (we want false positives, not false negatives). Catches missing-TLD and missing-`@` shapes. Gates the Send Code button.
2. **`suggestEmailFix`** — fuzzy lookup against a small table of common provider typos (`gnail`, `gmial`, `hotmial`, `yaho`, `iclou`, plus `.con`/`.cm`/`.co` when paired with a known provider). Surfaces a non-blocking "did you mean X?" link under the input that fills in the correction when tapped. Doesn't block submission.

Real email validation is unsolvable client-side; the only definitive answer is "did the OTP arrive?" These checks just close the specific failure modes seen in prod.

## Test plan

- [x] 8 new unit tests for `isValidEmailShape` + `suggestEmailFix` (77/77 total passing)
- [x] `npx tsc --noEmit` — clean
- [ ] Type a valid email → Send Code button enables, no suggestion shown
- [ ] Type `you@gmail.con` → Send Code stays enabled, "did you mean you@gmail.com?" appears, tap to apply
- [ ] Type `you@gmail` → Send Code stays disabled (missing TLD)
- [ ] Type `you` → Send Code stays disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)