### PR TITLE
dev(mock-feed): mock events so NEW pill is reviewable on both card types

### DIFF
--- a/src/features/feed/components/FeedView.tsx
+++ b/src/features/feed/components/FeedView.tsx
@@ -11,6 +11,7 @@ import InstallBanner from './InstallBanner';
 import DevMockFeedToggle from './DevMockFeedToggle';
 import { useDevMockFeed } from '../useDevMockFeed';
 import { DEV_MOCK_CHECKS, DEV_MOCK_NEW_IDS } from '../devMockChecks';
+import { DEV_MOCK_EVENTS, DEV_MOCK_NEW_EVENT_IDS } from '../devMockEvents';
 import { useFeedContext } from '@/features/checks/context/FeedContext';
 import { Linkify } from '@/shared/components/Linkify';
 
@@ -131,9 +132,13 @@ export default function FeedView({
 
   const [mockEnabled] = useDevMockFeed();
   const effectiveChecks = mockEnabled ? DEV_MOCK_CHECKS : checks;
+  const effectiveEvents = mockEnabled ? DEV_MOCK_EVENTS : events;
   const mockNewSet = React.useMemo(() => new Set(DEV_MOCK_NEW_IDS), []);
+  const mockNewEventSet = React.useMemo(() => new Set(DEV_MOCK_NEW_EVENT_IDS), []);
   const checkIsNew = (id: string) =>
     mockEnabled ? mockNewSet.has(id) : newItemIds.has(id);
+  const eventIsNew = (id: string) =>
+    mockEnabled ? mockNewEventSet.has(id) : (id === newlyAddedEventId || newItemIds.has(id));
 
   // Derived feed slices. Memoized so the O(n) filter/map and the O(n log n)
   // sort on chronoItems don't run every render — and so the array identities
@@ -168,7 +173,7 @@ export default function FeedView({
       ...visibleChecks
         .filter((c) => c.expiresIn === 'open')
         .map((c) => ({ kind: 'check' as const, data: c })),
-      ...events.map((e) => ({ kind: 'event' as const, data: e })),
+      ...effectiveEvents.map((e) => ({ kind: 'event' as const, data: e })),
     ];
 
     if (sortBy === 'recent') {
@@ -193,9 +198,9 @@ export default function FeedView({
     }
 
     return items;
-  }, [visibleChecks, events, sortBy]);
+  }, [visibleChecks, effectiveEvents, sortBy]);
 
-  const hasContent = checks.length > 0 || events.length > 0;
+  const hasContent = effectiveChecks.length > 0 || effectiveEvents.length > 0;
 
   return (
     <>
@@ -262,7 +267,7 @@ export default function FeedView({
                       : undefined
                   }
                   onViewProfile={onViewProfile}
-                  isNew={item.data.id === newlyAddedEventId || newItemIds.has(item.data.id)}
+                  isNew={eventIsNew(item.data.id)}
                   profile={profile}
                   initialComments={eventComments[item.data.id]}
                 />

--- a/src/features/feed/devMockChecks.ts
+++ b/src/features/feed/devMockChecks.ts
@@ -47,7 +47,9 @@ export const DEV_MOCK_CHECKS: InterestCheck[] = [
     movieTitle: "Spirited Away",
     year: "2001",
     director: "Hayao Miyazaki",
-    thumbnail: "https://a.ltrbxd.com/resized/film-poster/5/1/3/8/5138-spirited-away-0-230-0-345-crop.jpg",
+    // Letterboxd CDN hotlink-blocks; Wikimedia serves the same poster
+    // and accepts cross-origin <img> requests.
+    thumbnail: "https://upload.wikimedia.org/wikipedia/en/d/db/Spirited_Away_Japanese_poster.png",
     vibes: ["cozy", "nostalgia"],
     commentCount: 2,
     createdAt: hoursAgo(0.1),
@@ -178,5 +180,29 @@ export const DEV_MOCK_CHECKS: InterestCheck[] = [
     location: "Lilia",
     createdAt: hoursAgo(0.1),
     expiresAt: hoursFromNow(24),
+  },
+  {
+    // Mystery hangout pre-reveal: full ?-rectangle border, redacted
+    // wingdings author, hidden responder list, kaomoji-fied comments.
+    // mysteryUnrevealed and mysteryGuestsHidden are normally derived in
+    // useChecks.transformCheck; we set them directly here so the mock
+    // doesn't depend on event_date math at render time.
+    id: uuid(9),
+    text: "downto come to a mystery hangout",
+    author: "???",
+    authorId: uuid(117),
+    timeAgo: "30m",
+    expiresIn: "23h",
+    expiryPercent: 4,
+    responses: [],
+    eventDate: new Date(now + 9 * 86400_000).toISOString().slice(0, 10),
+    eventDateLabel: "Sat, May 9",
+    eventTime: "8pm",
+    location: "secret location · revealed day-of",
+    mystery: true,
+    mysteryUnrevealed: true,
+    mysteryGuestsHidden: true,
+    createdAt: hoursAgo(0.5),
+    expiresAt: hoursFromNow(23),
   },
 ];

--- a/src/features/feed/devMockEvents.ts
+++ b/src/features/feed/devMockEvents.ts
@@ -1,0 +1,97 @@
+import type { Event } from "@/lib/ui-types";
+
+// Curated kitchen-sink of event variations for dev-mode previewing,
+// parallel to devMockChecks. Lets us see how event cards render with
+// the NEW pill, public/friends visibility, peopleDown, pool state,
+// hero images, etc — without having to wait for a real event to come
+// in or fiddle with createdAt timestamps.
+//
+// Toggled together with DEV_MOCK_CHECKS via the same MOCK switch.
+
+const now = Date.now();
+const hoursAgo = (h: number) => new Date(now - h * 3600_000).toISOString();
+
+const uuid = (n: number) => `dev-mock-event-${String(n).padStart(8, "0")}`;
+
+/**
+ * Mock event IDs that should always render with the "NEW" pill when
+ * mock mode is on. Matches the DEV_MOCK_NEW_IDS pattern for checks.
+ */
+export const DEV_MOCK_NEW_EVENT_IDS: string[] = [
+  uuid(1), // Bladee — fresh, has hero image
+  uuid(3), // Persian dinner — friends-only with comments
+];
+
+export const DEV_MOCK_EVENTS: Event[] = [
+  {
+    id: uuid(1),
+    title: "Bladee @ Elsewhere (Rooftop)",
+    venue: "Elsewhere",
+    date: "Sat, Jun 14",
+    time: "10pm",
+    rawDate: new Date(now + 7 * 86400_000).toISOString().slice(0, 10),
+    vibe: ["live", "rooftop"],
+    image: "https://images.unsplash.com/photo-1493676304819-0d7a8d026dcf?w=600&q=80",
+    igHandle: "elsewherebrooklyn",
+    igUrl: "https://instagram.com/elsewherebrooklyn",
+    saved: false,
+    isDown: false,
+    peopleDown: [
+      { name: "Finn",  avatar: "F", mutual: true },
+      { name: "Blake", avatar: "B", mutual: true },
+      { name: "Quinn", avatar: "Q", mutual: false },
+    ],
+    isPublic: true,
+    visibility: "public",
+    posterName: "elsewhere",
+    posterAvatar: "E",
+    socialLoaded: true,
+    createdAt: hoursAgo(0.2),
+  },
+  {
+    id: uuid(2),
+    title: "Joji",
+    venue: "Barclays Center",
+    date: "Fri, Jun 26",
+    time: "7pm",
+    rawDate: new Date(now + 21 * 86400_000).toISOString().slice(0, 10),
+    vibe: [],
+    image: "",
+    igHandle: "",
+    saved: false,
+    isDown: false,
+    peopleDown: [
+      { name: "gian", avatar: "G", mutual: true },
+    ],
+    isPublic: false,
+    visibility: "friends",
+    posterName: "sarah f",
+    posterAvatar: "S",
+    socialLoaded: true,
+    createdAt: hoursAgo(8),
+  },
+  {
+    id: uuid(3),
+    title: "Come over for homemade Persian food",
+    venue: "383 bushwick ave",
+    date: "Mon, May 11",
+    time: "7pm",
+    rawDate: new Date(now + 10 * 86400_000).toISOString().slice(0, 10),
+    vibe: ["dinner", "homemade"],
+    image: "",
+    igHandle: "",
+    saved: false,
+    isDown: false,
+    peopleDown: [
+      { name: "aidanfox", avatar: "A", mutual: true },
+      { name: "minnie",   avatar: "M", mutual: true },
+      { name: "haowie",   avatar: "H", mutual: true },
+    ],
+    isPublic: false,
+    visibility: "friends",
+    posterName: "ashkon",
+    posterAvatar: "A",
+    socialLoaded: true,
+    createdAt: hoursAgo(0.5),
+  },
+];


### PR DESCRIPTION
## Why
The MOCK toggle in the feed only swapped checks; events stayed real. So after restyling the NEW pill in PR #500 it was easy to QA the new look on a check card but not on an event card without waiting for a fresh event to come in.

## What
- New `src/features/feed/devMockEvents.ts` parallel to `devMockChecks.ts` — 3 events covering the states worth seeing:
  - **Bladee** — fresh + NEW + hero image, public event
  - **Joji** — older friends-only without NEW (so we can compare against the with-NEW version)
  - **Persian food** — fresh + NEW + friends-only dinner with peopleDown
- `DEV_MOCK_NEW_EVENT_IDS` mirrors the check-side `DEV_MOCK_NEW_IDS` pattern.
- `FeedView` now flips both lists when MOCK is on, with `eventIsNew()` mirroring `checkIsNew()`.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run test` — 69/69
- [ ] Toggle MOCK on the feed → both a check and an event with the NEW pill render side-by-side, identical styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)