### PR TITLE
feat: daily pg_cron sweep of abandoned-onboarding accounts

### DIFF
--- a/supabase/migrations/20260501000001_abandoned_onboarding_sweep.sql
+++ b/supabase/migrations/20260501000001_abandoned_onboarding_sweep.sql
@@ -1,0 +1,27 @@
+-- Daily sweep of abandoned-onboarding accounts.
+--
+-- If a signup hasn't completed onboarding within 24h of creating their auth
+-- row, the cohort almost never comes back to finish (we ran the cleanup by
+-- hand once and confirmed each account had zero check/comment/friend/squad
+-- footprint). Auto-deleting the auth row cascades cleanly:
+--   profiles.id REFERENCES auth.users(id) ON DELETE CASCADE, and every
+--   downstream table FKs to profiles.id ON DELETE CASCADE.
+
+CREATE OR REPLACE FUNCTION public.process_abandoned_onboarding()
+RETURNS void AS $$
+BEGIN
+  DELETE FROM auth.users
+  WHERE id IN (
+    SELECT id FROM public.profiles
+    WHERE onboarded = false
+      AND created_at < NOW() - INTERVAL '24 hours'
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Daily at 06:00 UTC (low-traffic window).
+SELECT cron.schedule(
+  'abandoned-onboarding-sweep',
+  '0 6 * * *',
+  $$SELECT public.process_abandoned_onboarding()$$
+);


### PR DESCRIPTION
## Summary
- Adds `process_abandoned_onboarding()` and a `pg_cron` job (`0 6 * * *`, daily at 06:00 UTC) that deletes `auth.users` rows where `profiles.onboarded = false AND created_at < now() - interval '24 hours'`.
- We just ran this manually for 4 stale accounts (created Feb–Apr, never onboarded) — all had zero check/comment/friend/squad footprint. The cohort doesn't come back to finish, so automating it.
- Cascade is already in place: `profiles.id REFERENCES auth.users(id) ON DELETE CASCADE`, plus every dependent table FKs to `profiles.id ON DELETE CASCADE` — a single `DELETE FROM auth.users` sweeps out everything.

## Test plan
- [x] Dry-ran the predicate against prod (0 rows currently match — expected since we just cleaned up)
- [ ] After merge: verify `SELECT * FROM cron.job WHERE jobname = 'abandoned-onboarding-sweep'` shows the schedule
- [ ] First nightly run: confirm `cron.job_run_details` shows status `succeeded`
- [ ] Spot-check next time a real abandoned signup ages past 24h that they get swept

🤖 Generated with [Claude Code](https://claude.com/claude-code)