### PR TITLE
fix(push): prune stale web subs from same browser on resubscribe

### DIFF
--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -55,6 +55,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Missing subscription fields' }, { status: 400 });
   }
 
+  const ua = typeof userAgent === 'string' ? userAgent : null;
+
   const { error } = await supabase
     .from('push_subscriptions')
     .upsert(
@@ -64,13 +66,34 @@ export async function POST(request: NextRequest) {
         p256dh,
         auth: authKey,
         platform: 'web',
-        user_agent: typeof userAgent === 'string' ? userAgent : null,
+        user_agent: ua,
       },
       { onConflict: 'user_id,endpoint' }
     );
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Prune older web subs from the same browser on this user. Same user_id +
+  // same user_agent ⇒ same physical install; the previous endpoint is dead
+  // (PWA was reinstalled / SW re-registered) but Apple Web Push keeps
+  // accepting handoffs to it for weeks before returning 410, so the
+  // 410-based cleanup in sendPushToUser never fires. Without this prune,
+  // every reinstall adds a row, fan-out hits phantom endpoints, and the
+  // server falsely logs status=sent while the device receives nothing.
+  //
+  // Skipped when ua is null — pre-2026-04-26 rows and clients that don't
+  // send the header land here, and we can't tell them apart from legit
+  // other-device rows.
+  if (ua) {
+    await supabase
+      .from('push_subscriptions')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('platform', 'web')
+      .eq('user_agent', ua)
+      .neq('endpoint', endpoint);
   }
 
   return NextResponse.json({ ok: true });


### PR DESCRIPTION
## Summary
- When a PWA is reinstalled or its SW re-registers, Safari mints a brand-new `web.push.apple.com` endpoint while the old one stays "valid" in Apple's view for weeks before eventually returning 410. The existing upsert key is `(user_id, endpoint)`, so the new row inserts alongside the old one instead of replacing it.
- The 410-based cleanup in `sendPushToUser` never fires (Apple keeps replying 2xx), so `push_logs` shows `status=sent` while the actual device receives nothing.
- Fix: after the web push upsert in `/api/push/subscribe`, delete other web subs for the same `(user_id, user_agent)` that aren't the just-saved endpoint. Same user + same UA ⇒ same physical browser. NULL `user_agent` rows are left alone — those predate the column (added 2026-04-26) and aren't safely distinguishable from legit other-device rows.

## How I found it
Debugging my own PWA: 3 orphan Apple Web Push endpoints accumulated from prior reinstalls (Apr 5 / Apr 17 / Apr 20), every send logged `status=sent`, no notifications on the device. Manually wiping the rows and re-toggling produced one fresh endpoint with a real `user_agent`, and a test push landed. This PR stops the same orphans from re-accumulating going forward.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 77/77 pass
- [ ] Smoke after deploy: re-toggle push on the PWA, verify only one row remains in `push_subscriptions` for `(user_id, platform='web', user_agent=<my UA>)`
- [ ] Multi-device check: confirm a row from a different user_agent (e.g. desktop Safari) is NOT pruned when phone PWA resubscribes

## Notes
- Doesn't backfill — existing NULL-UA orphans need a one-time wipe per user (we just did this for my account manually). Could add a follow-up sweep if other users hit the same issue, but for now most active users either have real UAs already or will get clean state on their next resubscribe.
- Independent from the iOS-native dedup at lines 41–48; that path deletes web subs by UA-pattern when native registers. This PR adds the symmetric web→web case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)