### PR TITLE
fix(nav): stop double-counting squad_invite as both bell + squads dot

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1122,7 +1122,7 @@ export default function Home() {
             if (t === "feed" && userId) loadRealData();
             if (t !== "feed") checksHook.dispatch({ type: CheckActionType.SET_NEWLY_ADDED, checkId: null });
           }}
-          hasSquadsUnread={squadsHook.squads.some((s) => s.hasUnread) || notificationsHook.notifications.some((n) => n.type === "squad_invite" && !n.is_read)}
+          hasSquadsUnread={squadsHook.squads.some((s) => s.hasUnread)}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- A single `squad_invite` notification was lighting up two indicators: the bell badge **and** the red dot on the Squads tab. Opening the bell would only show one item, so the second badge looked like a phantom.
- Root cause in `src/app/page.tsx:1125` — `hasSquadsUnread` was OR-ing `notifications.some((n) => n.type === "squad_invite" && !n.is_read)` on top of actual squad-unread state. But `squad_invite` already flows through the bell: `NotificationsPanel.tsx:260` renders it, and `getUnreadCount()` includes it (only `squad_message`/`squad_mention` are excluded).
- Fix: drop the `squad_invite` term. The Squads dot is now just for unread activity in squads you've already joined; invites stay in the bell where they're already counted and listed.

## Test plan
- [ ] Send a `squad_invite` to a test user → only the bell shows a badge; Squads tab has no red dot
- [ ] Receive a chat message in an existing squad → Squads tab dot lights up (unchanged behavior)
- [ ] Have both a pending invite and an unread squad message → bell shows count, Squads tab shows dot (one indicator each, no overlap)
- [ ] Accept/decline a `squad_invite` → bell unread count decrements; Squads dot reflects only real squad activity

https://claude.ai/code/session_01Y2qp7Ko3ceYTL2A1m4G47D

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2qp7Ko3ceYTL2A1m4G47D)_