### PR TITLE
feat(squad): recalc squad chat expiry when check date is edited

### DIFF
--- a/supabase/migrations/20260505000001_recalc_squad_expiry_on_check_date_update.sql
+++ b/supabase/migrations/20260505000001_recalc_squad_expiry_on_check_date_update.sql
@@ -1,0 +1,30 @@
+-- When an interest check's event_date changes, recalculate the linked squad's
+-- expires_at to match. Uses the same formula as set_squad_expiry() and
+-- reactivate_squad(): (event_date + 1 day) + 24h grace, or NOW() + 24h when
+-- the date is cleared. Only touches active (non-archived) squads — reviving
+-- an archived squad stays a separate, explicit action.
+
+CREATE OR REPLACE FUNCTION public.recalc_squad_expiry_on_check_date_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.event_date IS NOT DISTINCT FROM OLD.event_date THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.squads
+  SET expires_at = CASE
+    WHEN NEW.event_date IS NOT NULL
+      THEN (NEW.event_date + INTERVAL '1 day') + INTERVAL '24 hours'
+    ELSE NOW() + INTERVAL '24 hours'
+  END
+  WHERE check_id = NEW.id
+    AND archived_at IS NULL;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS on_check_date_recalc_squad_expiry ON public.interest_checks;
+CREATE TRIGGER on_check_date_recalc_squad_expiry
+  AFTER UPDATE ON public.interest_checks
+  FOR EACH ROW EXECUTE FUNCTION public.recalc_squad_expiry_on_check_date_change();


### PR DESCRIPTION
## Summary
- AFTER UPDATE trigger on `interest_checks` keeps the linked squad's `expires_at` in sync when the author edits the check's `event_date`.
- Reuses the existing formula from `set_squad_expiry()` / `reactivate_squad()`: `(event_date + 1 day) + 24h grace`, or `NOW() + 24h` when the date is cleared.
- Only touches active (non-archived) squads — reviving an archived squad stays a separate, explicit action.
- Trigger no-ops when `event_date` is unchanged, so text/location/etc. edits don't churn the squad expiry.

## Why a DB trigger over app code
Lives next to `set_squad_expiry()` and the date-change notification trigger so the rules can't drift. Covers every write path (UI, RPCs, service-role) atomically with the check update.

## Test plan
Verified locally via `psql` against `npx supabase db reset`:
- [x] event_date today+7 → squad expires `today+9 00:00 UTC` (initial insert path, unchanged)
- [x] update event_date to today+14 → squad expiry shifts to `today+16 00:00 UTC`
- [x] event_date set to NULL → squad expiry falls back to `NOW + 24h`
- [x] text-only update → squad expiry untouched
- [x] archived squad → expiry untouched even when event_date changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)