### PR TITLE
fix(calendar): include down checks + authored checks, clarify auto-sync

### DIFF
--- a/src/app/api/calendar/[token]/route.ts
+++ b/src/app/api/calendar/[token]/route.ts
@@ -23,22 +23,28 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  // Fetch saved events
+  // Saved events
   const { data: savedEvents } = await supabase
     .from("saved_events")
     .select("*, event:events(*)")
     .eq("user_id", profile.id);
 
-  // Fetch interest check responses with event dates
-  const { data: checkResponses } = await supabase
+  // Checks the user is "down" on
+  const { data: downResponses } = await supabase
     .from("check_responses")
-    .select("*, check:interest_checks(*)")
+    .select("check:interest_checks(*)")
     .eq("user_id", profile.id)
-    .in("status", ["down", "waitlist"]);
+    .eq("response", "down");
+
+  // Checks the user authored (authors have no check_responses row)
+  const { data: authoredChecks } = await supabase
+    .from("interest_checks")
+    .select("*")
+    .eq("author_id", profile.id)
+    .not("event_date", "is", null);
 
   const icsEvents: ICSEventParams[] = [];
 
-  // Add saved events
   for (const se of savedEvents ?? []) {
     const ev = se.event;
     if (!ev?.date) continue;
@@ -51,10 +57,19 @@ export async function GET(
     });
   }
 
-  // Add interest checks with dates
-  for (const cr of checkResponses ?? []) {
-    const check = cr.check;
-    if (!check?.event_date) continue;
+  type CheckRow = {
+    id: string;
+    text: string | null;
+    event_date: string | null;
+    event_time: string | null;
+    location: string | null;
+  };
+
+  const seenCheckIds = new Set<string>();
+  const pushCheck = (check: CheckRow | null | undefined) => {
+    if (!check?.event_date) return;
+    if (seenCheckIds.has(check.id)) return;
+    seenCheckIds.add(check.id);
     icsEvents.push({
       uid: check.id,
       title: check.text ?? "Interest Check",
@@ -62,6 +77,13 @@ export async function GET(
       time: check.event_time ?? undefined,
       venue: check.location ?? undefined,
     });
+  };
+
+  for (const row of downResponses ?? []) {
+    pushCheck(row.check as unknown as CheckRow | null);
+  }
+  for (const check of authoredChecks ?? []) {
+    pushCheck(check as unknown as CheckRow);
   }
 
   const icsContent = generateICSCalendar(icsEvents, timezone);

--- a/src/app/components/SyncCalendarModal.tsx
+++ b/src/app/components/SyncCalendarModal.tsx
@@ -231,7 +231,7 @@ const SyncCalendarModal = ({
         ) : (
           <div style={{ padding: "0 20px calc(20px + env(safe-area-inset-bottom, 0px))" }}>
             <p className="font-mono text-xs text-muted mb-4" style={{ fontSize: 11, lineHeight: 1.6 }}>
-              Subscribe once and your calendar app will automatically stay in sync. New events you save will appear automatically — no duplicates.
+              Subscribe once. Anything you save or are down for shows up here, and date / time / location edits flow through automatically — no need to re-add or re-save.
             </p>
 
             {tokenLoading ? (


### PR DESCRIPTION
## Summary
- Existing `webcal://` subscription already auto-updates everything in the feed when source events/checks change date/time/location, but two gaps made it useless for interest checks:
  1. The route filtered `check_responses` by `status` (column doesn't exist) on values `down`/`waitlist` (values don't exist). Real column is `response`, real values are `down`/`maybe`/`nah`. PostgREST 400'd silently → checks never appeared.
  2. Authors don't get a `check_responses` row of their own (a slot is reserved for them in the cap-down logic), so even if you created a check with a date you'd never see it in your own calendar.
- Added an explicit query for authored checks with `event_date IS NOT NULL`, deduped against down responses.
- Updated subscribe-tab copy in `SyncCalendarModal` to spell out that date/time/location edits flow through automatically — that's the value prop of the subscription, and it wasn't called out.

## Why this is "option A" for per-event auto-sync
With the trigger from #508 already keeping squad expiry in sync on date edits, the master ICS feed + stable VEVENT UIDs already give us the requested feature: any change the author makes to date/time/location/title flows to subscribed calendars on the next poll, in place, without the user touching anything.
- **Apple Calendar**: configurable poll, default ~1 hour — best experience.
- **Google Calendar**: external webcal feeds historically poll slowly (8–24h), eventually consistent.

## Test plan
Verified locally against `127.0.0.1:54321`:
- [x] Seeded an authored dated check + a `down` response on someone else's dated check, hit `/api/calendar/[token]` → both VEVENTs present (this would have been zero before the fix)
- [x] Edited the authored check (`event_date`, `event_time`, `location` all changed) → re-fetched feed → same UID, new DTSTART / DTEND / LOCATION reflected immediately
- [x] `tsc --noEmit` clean
- [x] No new RLS surface (route uses service-role client, lookup is via opaque per-user `calendar_token`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)