### PR TITLE
fix(squad): backfill stale expires_at, clear warned_at on recalc

### DIFF
--- a/supabase/migrations/20260511000001_backfill_stale_squad_expiry_from_check_date.sql
+++ b/supabase/migrations/20260511000001_backfill_stale_squad_expiry_from_check_date.sql
@@ -1,0 +1,51 @@
+-- Two fixes for the squad-expiry-from-check-date flow:
+--
+-- 1. Backfill squads whose linked check.event_date was edited BEFORE the
+--    20260505000001 trigger existed. Their expires_at is still anchored to
+--    the original date, so the cron eventually archives them even though the
+--    check itself moved to a future date. (See: "5k bakery roulette" — date
+--    moved to May 31 on May 4, trigger added May 5, squad archived May 12
+--    against the stale May-12 expiry.)
+--
+-- 2. Update recalc_squad_expiry_on_check_date_change() to also clear
+--    warned_at when expires_at moves forward. Otherwise the 1h "expires
+--    soon" warning is suppressed forever after a date extension, since
+--    warned_at IS NULL is a precondition for the cron to re-warn.
+--
+-- The new expires_at uses the same formula as set_squad_expiry() and the
+-- existing trigger: (event_date + 1 day) + 24h grace.
+
+CREATE OR REPLACE FUNCTION public.recalc_squad_expiry_on_check_date_change()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.event_date IS NOT DISTINCT FROM OLD.event_date THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.squads
+  SET expires_at = CASE
+    WHEN NEW.event_date IS NOT NULL
+      THEN (NEW.event_date + INTERVAL '1 day') + INTERVAL '24 hours'
+    ELSE NOW() + INTERVAL '24 hours'
+  END,
+  warned_at = NULL
+  WHERE check_id = NEW.id
+    AND archived_at IS NULL;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Backfill: align expires_at with check.event_date for any check-linked squad
+-- where the two are out of sync. Resurrects squads that were wrongly archived
+-- (archived_at set, but the check's event_date is still in the future).
+UPDATE public.squads s
+SET
+  expires_at = (ic.event_date + INTERVAL '1 day') + INTERVAL '24 hours',
+  archived_at = NULL,
+  warned_at = NULL
+FROM public.interest_checks ic
+WHERE s.check_id = ic.id
+  AND ic.event_date IS NOT NULL
+  AND (ic.event_date + INTERVAL '1 day') + INTERVAL '24 hours' > NOW()
+  AND s.expires_at IS DISTINCT FROM (ic.event_date + INTERVAL '1 day') + INTERVAL '24 hours';


### PR DESCRIPTION
## Summary
- The trigger from #508 only catches *future* check-date edits. Squads whose date was changed before #508 deployed (May 5) kept their stale `expires_at` and eventually got archived by the cron — e.g. "5k bakery roulette" (date moved to May 31 on May 4, archived May 12 against the stale May-12 expiry).
- Backfill aligns `expires_at` with `check.event_date` for any out-of-sync squad and resurrects ones that were wrongly archived (clears `archived_at`).
- Also extends `recalc_squad_expiry_on_check_date_change()` to clear `warned_at`, so a date extension re-arms the 1h "expires soon" cron warning.

## Test plan
- [x] Local: stale archived squad with future event_date → migration unarchives, recalcs `expires_at`, clears `warned_at`
- [x] Local: trigger fire after `warned_at` is set → trigger clears `warned_at` along with the new `expires_at`
- [x] Prod audit: only the bakery squad matches the stale-state criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)